### PR TITLE
records: permissions implementation for basic roles

### DIFF
--- a/invenio_app_ils/config.py
+++ b/invenio_app_ils/config.py
@@ -18,9 +18,9 @@ from __future__ import absolute_import, print_function
 from datetime import timedelta
 
 from invenio_app.config import APP_DEFAULT_SECURE_HEADERS
-from invenio_records_rest.utils import allow_all
 
 from .records.api import Document, InternalLocation, Item, Location
+from .records.permissions import RecordPermission
 from .search.api import DocumentSearch, InternalLocationSearch, ItemSearch, \
     LocationSearch
 
@@ -231,8 +231,10 @@ RECORDS_REST_ENDPOINTS = dict(
         default_media_type="application/json",
         max_result_window=10000,
         error_handlers=dict(),
-        create_permission_factory_imp=allow_all,
-        update_permission_factory_imp=allow_all,
+        read_permission_factory_imp=RecordPermission,
+        create_permission_factory_imp=RecordPermission,
+        update_permission_factory_imp=RecordPermission,
+        delete_permission_factory_imp=RecordPermission,
     ),
     itemid=dict(
         pid_type=ITEM_PID_TYPE,
@@ -255,8 +257,10 @@ RECORDS_REST_ENDPOINTS = dict(
         default_media_type="application/json",
         max_result_window=10000,
         error_handlers=dict(),
-        create_permission_factory_imp=allow_all,
-        delete_permission_factory_imp=allow_all,
+        read_permission_factory_imp=RecordPermission,
+        create_permission_factory_imp=RecordPermission,
+        update_permission_factory_imp=RecordPermission,
+        delete_permission_factory_imp=RecordPermission,
     ),
     locid=dict(
         pid_type=LOCATION_PID_TYPE,
@@ -279,7 +283,7 @@ RECORDS_REST_ENDPOINTS = dict(
         default_media_type="application/json",
         max_result_window=10000,
         error_handlers=dict(),
-        create_permission_factory_imp=allow_all,
+        create_permission_factory_imp=RecordPermission,
     ),
     ilocid=dict(
         pid_type=INTERNAL_LOCATION_PID_TYPE,
@@ -302,12 +306,12 @@ RECORDS_REST_ENDPOINTS = dict(
         default_media_type="application/json",
         max_result_window=10000,
         error_handlers=dict(),
-        create_permission_factory_imp=allow_all,
+        read_permission_factory_imp=RecordPermission,
+        create_permission_factory_imp=RecordPermission,
+        update_permission_factory_imp=RecordPermission,
+        delete_permission_factory_imp=RecordPermission,
     ),
 )
-
-# Allow all GET requests
-RECORDS_REST_DEFAULT_READ_PERMISSION_FACTORY = allow_all
 
 # RECORDS UI
 # ==========

--- a/invenio_app_ils/records/permissions.py
+++ b/invenio_app_ils/records/permissions.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2018 CERN.
+#
+# invenio-app-ils is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Ils records' permissions."""
+from flask_principal import ActionNeed, RoleNeed, UserNeed
+from invenio_access import Permission, superuser_access
+
+librarian_role = RoleNeed('librarian')
+create_records_action = ActionNeed('create-records')
+
+
+class RecordPermission(Permission):
+    """Record permission.
+
+    - Create action given to librarian, admin and specified users.
+    - Read access given to everyone with possibility to hide.
+    - Delete access to admin and specified users.
+    """
+
+    create_actions = ['create']
+    read_actions = ['read']
+    update_actions = ['update']
+    delete_actions = ['delete']
+
+    def __init__(self, record, action):
+        """Constructor."""
+        self.record = record
+        self.action = action
+        self._permissions = None
+        record_needs = self._dispatch()
+        super(RecordPermission, self).__init__(*record_needs)
+
+        # removes need of superuser for reading access
+        if self.allow_by_default:
+            self.explicit_needs.remove(superuser_access)
+
+    def _dispatch(self):
+        """Dispatch permission policy per action."""
+        if self.action in self.read_actions:
+            return self.read_permissions()
+        elif self.action in self.create_actions:
+            return [create_records_action] + self.librarian_permissions()
+        elif self.action in self.update_actions:
+            return self.record_needs() + self.librarian_permissions()
+        else:
+            return self.record_needs()
+
+    def read_permissions(self):
+        """Define read permission policy per record."""
+        if self.is_public():
+            # allow by default per everyone when read is empty
+            self.allow_by_default = True
+            return []
+        else:
+            return self.record_needs() + self.librarian_permissions()
+
+    def librarian_permissions(self):
+        """Define librarian role permission."""
+        return [librarian_role]
+
+    def record_allows(self):
+        """Read what record allows per action."""
+        return self.record.get('_access', {}).get(self.action, [])
+
+    def record_needs(self):
+        """Create needs of the record."""
+        needs = []
+        for access_entity in self.record_allows():
+            try:
+                needs.append(RoleNeed(access_entity.lower()))
+            except AttributeError:
+                needs.append(UserNeed(access_entity))
+        return needs
+
+    def is_public(self):
+        """Check if the record is fully public.
+
+        In practice this means that the record doesn't have the ``access``
+        key or the action is not inside access or is empty.
+        """
+        return '_access' not in self.record or \
+               not self.record.get('_access', {}).get(self.action)

--- a/tests/api/test_record_permissions.py
+++ b/tests/api/test_record_permissions.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2018 CERN.
+#
+# invenio-app-ils is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Test record permissions."""
+import uuid
+
+import pytest
+from flask import g
+from flask_principal import ActionNeed, RoleNeed, identity_loaded
+from flask_security import login_user
+from invenio_accounts.models import User
+from invenio_records.api import Record
+
+# from invenio_app_ils.records.permissions import has_admin_permission, \
+#     has_librarian_permission, record_permission_factory
+from invenio_app_ils.records.permissions import RecordPermission
+
+
+@pytest.mark.parametrize('access,action,is_allowed', [
+    ({'foo': 'bar'}, 'read', True),     # default cases
+    ({'foo': 'bar'}, 'update', False),
+    ({'_access': {'read': [1, 'no-access@invenio',
+                           'no-access-either@invenio']}}, 'read', True),
+    ({'_access': {'read': [2, 'no-access@invenio']}}, 'read', False),
+    ({'_access': {'read': ['test@invenio']}}, 'read', True),
+    # permission for specific user to create
+    ({'_access': {'update': [1]}}, 'update', True),
+    # checks if the access works for different actions
+    ({'_access': {'update': [1]}}, 'create', False),
+    ({'_access': {'delete': [1]}}, 'update', False),
+
+    # delete access for user and librarian
+    ({'_access': {'delete': [1, 'librarian']}}, 'delete', True),
+
+])
+def test_record_generic_access(db, users, access, action, is_allowed):
+    """Test access control for records."""
+
+    @identity_loaded.connect
+    def mock_identity_provides(sender, identity):
+        """Provide additional role to the user."""
+        roles = [RoleNeed('test@invenio')]
+        # Gives the user additional roles, f.e. based on his groups
+        identity.provides |= set(roles)
+
+    def login_and_test(user_id):
+        login_user(User.query.get(user_id))
+        # Create record
+        user = User.query.get(user_id)
+        id = uuid.uuid4()
+        record = Record.create(access, id_=id)
+        factory = RecordPermission(record, action)
+        # print dir(factory)
+        if user.has_role('admin'):
+            # super user can do EVERYTHING
+            assert factory.can()
+        elif user.has_role('librarian') and action != 'delete':
+            # librarian should be able to update, create, and read everything
+            assert factory.can()
+        else:
+            assert factory.can() if is_allowed else not factory.can()
+
+    # Test standard user
+    login_and_test(1)
+    # Test librarian access
+    login_and_test(3)
+    # Test superuser access
+    login_and_test(4)
+
+
+@pytest.mark.parametrize('access,action,is_allowed', [
+    ({'foo': 'bar'}, 'update', True),
+    ({'foo': 'bar'}, 'delete', False),
+    ({'_access': {'delete': ['librarian']}}, 'delete', True),
+])
+def test_record_librarian_access(db, users, access, action, is_allowed):
+    """Test Librarian access."""
+    login_user(User.query.get(3))
+    id = uuid.uuid4()
+    record = Record.create(access, id_=id)
+    factory = RecordPermission(record, action)
+    assert factory.can() if is_allowed else not factory.can()
+
+
+@pytest.mark.parametrize('access,action,is_allowed', [
+    ({'foo': 'bar'}, 'update', False),
+    ({'foo': 'bar'}, 'delete', False),
+    ({'_access': {'delete': [1]}}, 'delete', True),
+    ({'_access': {'update': [1]}}, 'update', True),
+])
+def test_record_patron_access(db, users, access, action, is_allowed):
+    """Test patron access."""
+    login_user(User.query.get(1))
+    id = uuid.uuid4()
+    record = Record.create(access, id_=id)
+    factory = RecordPermission(record, action)
+    assert factory.can() if is_allowed else not factory.can()
+
+
+@pytest.mark.parametrize('access,action,is_allowed', [
+    ({'foo': 'bar'}, 'create', True),
+    ({'foo': 'bar'}, 'update', False),
+    ({'foo': 'bar'}, 'delete', False),
+])
+def test_record_patron_create(db, users, access, action, is_allowed):
+    """Test patron create."""
+    @identity_loaded.connect
+    def mock_identity_provides(sender, identity):
+        """Provide additional role to the user."""
+        roles = [ActionNeed('create-records')]
+        # Gives the user additional roles, f.e. based on his groups
+        identity.provides |= set(roles)
+
+    login_user(User.query.get(1))
+    id = uuid.uuid4()
+    record = Record.create(access, id_=id)
+    factory = RecordPermission(record, action)
+
+    assert factory.can() if is_allowed else not factory.can()

--- a/tests/api/test_record_permissions.py
+++ b/tests/api/test_record_permissions.py
@@ -76,6 +76,8 @@ def test_record_generic_access(db, users, access, action, is_allowed):
     ({'foo': 'bar'}, 'update', True),
     ({'foo': 'bar'}, 'delete', False),
     ({'_access': {'delete': ['librarian']}}, 'delete', True),
+    ({'_access': {'delete': ['1']}}, 'delete', False),
+    ({'_access': {'update': ['1']}}, 'update', True),
 ])
 def test_record_librarian_access(db, users, access, action, is_allowed):
     """Test Librarian access."""
@@ -91,6 +93,8 @@ def test_record_librarian_access(db, users, access, action, is_allowed):
     ({'foo': 'bar'}, 'delete', False),
     ({'_access': {'delete': [1]}}, 'delete', True),
     ({'_access': {'update': [1]}}, 'update', True),
+    ({'_access': {'update': ['1']}}, 'update', True),
+    ({'_access': {'update': ['1']}}, 'delete', False),
 ])
 def test_record_patron_access(db, users, access, action, is_allowed):
     """Test patron access."""


### PR DESCRIPTION
* NEW Implements librarian, superuser and patron access policy
  to a record by using _access field of a record

* CHANGES config for RECORDS_REST_ENDPOINTS

My idea was to take 3 basic roles `Librarian`, `Patron`, `Admin` and implement the policy for actions:

- `read`: allowed by default for everyone, might be restricted by adding role or user to 
```
    {'_access': 'read': {}}
``` 
- `create`: allowed for `Librarian` and `Admin`, might be also allowed for specific users or roles by adding them in a field `create` in `_access`
- `update`: same policy as `create`
- `delete`: by default allowed only for `Admin`,  might be also allowed for specific users or roles by adding them in a field `delete` in `_access`

this seems for me to be the most flexible, and it might be overwritten depending on the needs. Also it's now implemented generally for record.
Feedback for this logic much appreciated.
(closes #18)