### PR TITLE
Refactored API module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
   global:
     - ES6_DOWNLOAD_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.0.tar.gz"
     - ES_HOST=127.0.0.1
+    - NODE_PATH=src
   matrix:
     - REQUIREMENTS=lowest EXTRAS=all ES_URL=$ES6_DOWNLOAD_URL
     - REQUIREMENTS=release EXTRAS=all ES_URL=$ES6_DOWNLOAD_URL DEPLOY=true

--- a/invenio_app_ils/ui/backoffice/src/App.js
+++ b/invenio_app_ils/ui/backoffice/src/App.js
@@ -1,26 +1,24 @@
 import React, { Component } from 'react';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import { Grid } from 'semantic-ui-react';
-import { Backoffice } from './pages/Backoffice';
-import { Sidebar } from './common/components';
-import { NotFound } from './common/components';
-import { ItemLayout } from './layouts';
-import { LoanLayout } from './layouts';
-import { URLS } from './common/urls';
+import { Sidebar, NotFound } from 'common/components';
+import { URLS } from 'common/urls';
+import { ItemLayout, LoanLayout } from 'layouts';
+import { Backoffice } from './pages';
 
 export default class App extends Component {
   render() {
     return (
-      <BrowserRouter basename={URLS.BASENAME}>
+      <BrowserRouter basename={URLS.basename}>
         <Grid columns={2} relaxed>
           <Grid.Column width={3}>
             <Sidebar />
           </Grid.Column>
           <Grid.Column width={12}>
             <Switch>
-              <Route path={URLS.ITEM_LIST} component={ItemLayout} />
-              <Route path={URLS.LOAN_LIST} component={LoanLayout} />
-              <Route path={URLS.ROOT} exact component={Backoffice} />
+              <Route path={URLS.itemList} component={ItemLayout} />
+              <Route path={URLS.loanList} component={LoanLayout} />
+              <Route path={URLS.root} exact component={Backoffice} />
               <Route component={NotFound} />
             </Switch>
           </Grid.Column>

--- a/invenio_app_ils/ui/backoffice/src/common/api/base.js
+++ b/invenio_app_ils/ui/backoffice/src/common/api/base.js
@@ -2,7 +2,6 @@ import axios from 'axios';
 
 // In development create a personal token to be able to perform requests and
 // and put it in a .env file under the name `REACT_APP_JWT_TOKEN`
-
 const getProductionToken = () => {
   const res = document.getElementsByName('authorized_token');
   if (res.length > 0 && res[0].hasOwnProperty('value')) {
@@ -16,7 +15,7 @@ const token =
     ? getProductionToken()
     : process.env.REACT_APP_JWT_TOKEN;
 
-export const $axios = axios.create({
+export const http = axios.create({
   baseURL:
     process.env.NODE_ENV === 'production'
       ? '/api'
@@ -26,15 +25,3 @@ export const $axios = axios.create({
   },
   withCredentials: true,
 });
-
-export const fetchList = url => {
-  return $axios.get(url);
-};
-
-export const fetchRecord = (url, recid) => {
-  return $axios.get(`${url}/${recid}`);
-};
-
-export const postRecord = (url, data) => {
-  return $axios.post(url, data);
-};

--- a/invenio_app_ils/ui/backoffice/src/common/api/index.js
+++ b/invenio_app_ils/ui/backoffice/src/common/api/index.js
@@ -1,0 +1,5 @@
+import { http } from './base';
+import { item } from './item';
+import { loan } from './loan';
+
+export { http, item, loan };

--- a/invenio_app_ils/ui/backoffice/src/common/api/item.js
+++ b/invenio_app_ils/ui/backoffice/src/common/api/item.js
@@ -1,0 +1,16 @@
+import { http } from './base';
+
+const itemURL = '/items/';
+
+const getList = () => {
+  return http.get(itemURL);
+};
+
+const getRecord = itemId => {
+  return http.get(`${itemURL}${itemId}`);
+};
+
+export const item = {
+  getList: getList,
+  getRecord: getRecord,
+};

--- a/invenio_app_ils/ui/backoffice/src/common/api/loan.js
+++ b/invenio_app_ils/ui/backoffice/src/common/api/loan.js
@@ -1,0 +1,21 @@
+import { http } from './base';
+
+const loanURL = '/circulation/loans/';
+
+const getList = () => {
+  return http.get(loanURL);
+};
+
+const getRecord = loanId => {
+  return http.get(`${loanURL}${loanId}`);
+};
+
+const postRecord = (loanId, data) => {
+  return http.post(`${loanURL}${loanId}`, data);
+};
+
+export const loan = {
+  getList: getList,
+  getRecord: getRecord,
+  postRecord: postRecord,
+};

--- a/invenio_app_ils/ui/backoffice/src/common/api/loan.js
+++ b/invenio_app_ils/ui/backoffice/src/common/api/loan.js
@@ -14,8 +14,13 @@ const postRecord = (loanId, data) => {
   return http.post(`${loanURL}${loanId}`, data);
 };
 
+const postAction = (loanId, data) => {
+  return http.post(`${loanURL}${loanId}/next`, data);
+};
+
 export const loan = {
   getList: getList,
   getRecord: getRecord,
   postRecord: postRecord,
+  postAction: postAction,
 };

--- a/invenio_app_ils/ui/backoffice/src/common/components/NotFound/NotFound.js
+++ b/invenio_app_ils/ui/backoffice/src/common/components/NotFound/NotFound.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { Grid, Button, Icon } from 'semantic-ui-react';
-import { URLS } from '../../../common/urls';
+import { URLS } from 'common/urls';
 
 import './NotFound.scss';
 
@@ -18,7 +18,7 @@ export class NotFound extends Component {
           <Icon name="compass outline" size="massive" />
           <h1>404</h1>
           <h2>Not all who wander are lost..</h2>
-          <Link to={URLS.ROOT}>
+          <Link to={URLS.root}>
             <Button className="teal">back to office</Button>
           </Link>
         </Grid.Column>

--- a/invenio_app_ils/ui/backoffice/src/common/components/Sidebar/Sidebar.js
+++ b/invenio_app_ils/ui/backoffice/src/common/components/Sidebar/Sidebar.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
 import { Menu } from 'semantic-ui-react';
-import { URLS } from '../../../common/urls';
+import { URLS } from 'common/urls';
 
 import './Sidebar.scss';
 
@@ -22,14 +22,14 @@ class Sidebar extends Component {
         </Menu.Header>
         <Menu.Item
           name="loans"
-          location={URLS.LOAN_LIST}
+          location={URLS.loanList}
           active={activeItem === 'loans'}
           onClick={this.handleItemClick}
         >
           Loans
         </Menu.Item>
         <Menu.Item
-          location={URLS.ITEM_LIST}
+          location={URLS.itemList}
           name="items"
           active={activeItem === 'items'}
           onClick={this.handleItemClick}

--- a/invenio_app_ils/ui/backoffice/src/common/urls.js
+++ b/invenio_app_ils/ui/backoffice/src/common/urls.js
@@ -1,8 +1,9 @@
+//NOTE: These are route urls used for navigation from the application
 export const URLS = {
-  ROOT: '/',
-  BASENAME: '/backoffice',
-  ITEM_LIST: '/items',
-  ITEM_DETAILS: id => `/items/${id}`,
-  LOAN_LIST: '/loans',
-  LOAN_DETAILS: id => `/loans/${id}`,
+  root: '/',
+  basename: '/backoffice',
+  itemList: '/items',
+  itemDetails: id => `/items/${id}`,
+  loanList: '/loans',
+  loanDetails: id => `/loans/${id}`,
 };

--- a/invenio_app_ils/ui/backoffice/src/layouts/ItemLayout/ItemLayout.js
+++ b/invenio_app_ils/ui/backoffice/src/layouts/ItemLayout/ItemLayout.js
@@ -1,8 +1,7 @@
 import React, { Component } from 'react';
 import { Route, Switch } from 'react-router-dom';
 
-import { ItemDetails } from '../../pages/ItemDetails';
-import { ItemList } from '../../pages/ItemList';
+import { ItemList, ItemDetails } from 'pages';
 
 export class ItemLayout extends Component {
   render() {

--- a/invenio_app_ils/ui/backoffice/src/layouts/LoanLayout/LoanLayout.js
+++ b/invenio_app_ils/ui/backoffice/src/layouts/LoanLayout/LoanLayout.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { Route, Switch } from 'react-router-dom';
-import { LoanList } from '../../pages/LoanList';
-import { LoanDetails } from '../../pages/LoanDetails';
+import { LoanList, LoanDetails } from 'pages';
 
 export class LoanLayout extends Component {
   render() {

--- a/invenio_app_ils/ui/backoffice/src/pages/Backoffice/index.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/Backoffice/index.js
@@ -1,1 +1,0 @@
-export { Backoffice } from './Backoffice';

--- a/invenio_app_ils/ui/backoffice/src/pages/ItemDetails/components/ItemLoans/ItemLoans.js~backoffice: fixes from review
+++ b/invenio_app_ils/ui/backoffice/src/pages/ItemDetails/components/ItemLoans/ItemLoans.js~backoffice: fixes from review
@@ -1,0 +1,14 @@
+import React, { Component } from 'react';
+import { Segment, Message } from 'semantic-ui-react';
+
+export class ItemLoans extends Component {
+  render() {
+    return (
+      <Segment raised>
+        <Message info>
+          <Message.Header>There are no loans for this item!</Message.Header>
+        </Message>
+      </Segment>
+    );
+  }
+}

--- a/invenio_app_ils/ui/backoffice/src/pages/ItemDetails/components/ItemLoans/ItemLoans.js~refs/remotes/inveniosoftware/master
+++ b/invenio_app_ils/ui/backoffice/src/pages/ItemDetails/components/ItemLoans/ItemLoans.js~refs/remotes/inveniosoftware/master
@@ -1,0 +1,14 @@
+import React, { Component } from 'react';
+import { Segment, Message } from 'semantic-ui-react';
+
+export class ItemLoans extends Component {
+  render() {
+    return (
+      <Segment raised>
+        <Message info>
+          <Message.Header>There are no loans for this item!</Message.Header>
+        </Message>
+      </Segment>
+    );
+  }
+}

--- a/invenio_app_ils/ui/backoffice/src/pages/ItemDetails/index.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/ItemDetails/index.js
@@ -4,7 +4,7 @@ import { fetchItemDetails } from './state/actions';
 import ItemDetailsComponent from './ItemDetails';
 
 const mapDispatchToProps = dispatch => ({
-  fetchItemDetails: itemid => dispatch(fetchItemDetails(itemid)),
+  fetchItemDetails: itemId => dispatch(fetchItemDetails(itemId)),
 });
 
 export const ItemDetails = connect(

--- a/invenio_app_ils/ui/backoffice/src/pages/ItemDetails/state/actions.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/ItemDetails/state/actions.js
@@ -1,23 +1,24 @@
-import { ITEM_LOADING, ITEM_DETAILS, ITEM_ERROR } from './types';
-import { fetchRecord } from '../../../common/api';
+import { IS_LOADING, ITEM_DETAILS, HAS_ERROR } from './types';
+import { item } from 'common/api';
 
-export const fetchItemDetails = itemid => {
+export const fetchItemDetails = itemId => {
   return async dispatch => {
     dispatch({
-      type: ITEM_LOADING,
+      type: IS_LOADING,
       payload: {},
     });
 
-    let details = await fetchRecord('/items', itemid).catch(reason => {
+    let response = await item.getRecord(itemId).catch(reason => {
       dispatch({
-        type: ITEM_ERROR,
+        type: HAS_ERROR,
         payload: reason,
       });
     });
-    if (details) {
+
+    if (response) {
       dispatch({
         type: ITEM_DETAILS,
-        payload: details.data,
+        payload: response.data,
       });
     }
   };

--- a/invenio_app_ils/ui/backoffice/src/pages/ItemDetails/state/reducer.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/ItemDetails/state/reducer.js
@@ -1,4 +1,4 @@
-import { ITEM_LOADING, ITEM_DETAILS, ITEM_ERROR } from './types';
+import { IS_LOADING, ITEM_DETAILS, HAS_ERROR } from './types';
 
 const initialState = {
   fetchLoading: true,
@@ -7,11 +7,11 @@ const initialState = {
 
 export default (state = initialState, action) => {
   switch (action.type) {
-    case ITEM_LOADING:
+    case IS_LOADING:
       return { ...state, fetchLoading: true };
     case ITEM_DETAILS:
       return { ...state, fetchLoading: false, data: action.payload };
-    case ITEM_ERROR:
+    case HAS_ERROR:
       return { ...state, fetchLoading: false, error: action.payload };
     default:
       return state;

--- a/invenio_app_ils/ui/backoffice/src/pages/ItemDetails/state/types.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/ItemDetails/state/types.js
@@ -1,3 +1,3 @@
 export const ITEM_DETAILS = 'ITEM_DETAILS';
-export const ITEM_ERROR = 'ITEM_ERROR';
-export const ITEM_LOADING = 'ITEM_LOADING';
+export const HAS_ERROR = 'HAS_ERROR';
+export const IS_LOADING = 'IS_LOADING';

--- a/invenio_app_ils/ui/backoffice/src/pages/ItemList/ItemTable/ItemTable.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/ItemList/ItemTable/ItemTable.js
@@ -1,11 +1,11 @@
 import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
 import { Table } from 'semantic-ui-react';
-import { URLS } from '../../../common/urls';
+import { URLS } from 'common/urls';
 
 class ItemTable extends Component {
   navigateToDetails(itemId) {
-    this.props.history.push(URLS.ITEM_DETAILS(itemId));
+    this.props.history.push(URLS.itemDetails(itemId));
   }
 
   renderData(items) {

--- a/invenio_app_ils/ui/backoffice/src/pages/ItemList/state/actions.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/ItemList/state/actions.js
@@ -1,23 +1,24 @@
-import { ITEM_LIST, ITEM_LIST_LOADING, ITEM_LIST_ERROR } from './types';
-import { fetchList } from '../../../common/api';
+import { ITEM_LIST, IS_LOADING, HAS_ERROR } from './types';
+import { item } from 'common/api';
 
 export const fetchItemList = () => {
   return async dispatch => {
     dispatch({
-      type: ITEM_LIST_LOADING,
+      type: IS_LOADING,
       payload: {},
     });
 
-    let itemList = await fetchList('/items/').catch(reason => {
+    let response = await item.getList().catch(reason => {
       dispatch({
-        type: ITEM_LIST_ERROR,
+        type: HAS_ERROR,
         payload: reason,
       });
     });
-    if (itemList) {
+
+    if (response) {
       dispatch({
         type: ITEM_LIST,
-        payload: itemList.data,
+        payload: response.data,
       });
     }
   };

--- a/invenio_app_ils/ui/backoffice/src/pages/ItemList/state/reducer.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/ItemList/state/reducer.js
@@ -1,4 +1,4 @@
-import { ITEM_LIST, ITEM_LIST_LOADING, ITEM_LIST_ERROR } from './types';
+import { ITEM_LIST, IS_LOADING, HAS_ERROR } from './types';
 
 const initialState = {
   isLoading: true,
@@ -7,11 +7,11 @@ const initialState = {
 
 export default (state = initialState, action) => {
   switch (action.type) {
-    case ITEM_LIST_LOADING:
+    case IS_LOADING:
       return { ...state, isLoading: true };
     case ITEM_LIST:
       return { ...state, isLoading: false, data: action.payload };
-    case ITEM_LIST_ERROR:
+    case HAS_ERROR:
       return { ...state, isLoading: false, error: action.payload };
     default:
       return state;

--- a/invenio_app_ils/ui/backoffice/src/pages/ItemList/state/types.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/ItemList/state/types.js
@@ -1,3 +1,3 @@
 export const ITEM_LIST = 'ITEM_LIST';
-export const ITEM_LIST_ERROR = 'ITEM_LIST';
-export const ITEM_LIST_LOADING = 'ITEM_LOADING';
+export const HAS_ERROR = 'HAS_ERROR';
+export const IS_LOADING = 'IS_LOADING';

--- a/invenio_app_ils/ui/backoffice/src/pages/LoanDetails/index.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/LoanDetails/index.js
@@ -4,7 +4,7 @@ import { fetchLoanDetails, postLoanAction } from './state/actions';
 import LoanDetailsComponent from './LoanDetails';
 
 const mapDispatchToProps = dispatch => ({
-  fetchLoanDetails: loanid => dispatch(fetchLoanDetails(loanid)),
+  fetchLoanDetails: loanId => dispatch(fetchLoanDetails(loanId)),
   postLoanAction: (url, data) => dispatch(postLoanAction(url, data)),
 });
 

--- a/invenio_app_ils/ui/backoffice/src/pages/LoanDetails/index.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/LoanDetails/index.js
@@ -5,7 +5,7 @@ import LoanDetailsComponent from './LoanDetails';
 
 const mapDispatchToProps = dispatch => ({
   fetchLoanDetails: loanId => dispatch(fetchLoanDetails(loanId)),
-  postLoanAction: (url, data) => dispatch(postLoanAction(url, data)),
+  postLoanAction: (loanId, data) => dispatch(postLoanAction(loanId, data)),
 });
 
 export const LoanDetails = connect(

--- a/invenio_app_ils/ui/backoffice/src/pages/LoanDetails/state/actions.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/LoanDetails/state/actions.js
@@ -5,16 +5,17 @@ import {
   LOAN_ACTION_SUCCESS,
   SET_LOAN_ACTION_ERROR,
 } from './types';
-import { fetchRecord, postRecord } from '../../../common/api';
+import { loan } from 'common/api';
 import { serializeLoanDetails } from './selectors';
 
-export const fetchLoanDetails = loanid => {
+export const fetchLoanDetails = loanId => {
   return dispatch => {
     dispatch({
       type: SET_LOAN_FETCH_LOADING,
     });
 
-    return fetchRecord('/circulation/loans', loanid)
+    return loan
+      .getRecord('/circulation/loans', loanId)
       .then(details =>
         dispatch({
           type: LOAN_FETCH_DETAILS_SUCCESS,
@@ -24,7 +25,7 @@ export const fetchLoanDetails = loanid => {
       .catch(reason => {
         dispatch({
           type: SET_LOAN_ACTION_ERROR,
-          payload: loanid,
+          payload: loanId,
         });
       });
   };
@@ -36,7 +37,8 @@ export const postLoanAction = (url, data) => {
       type: SET_LOAN_ACTION_LOADING,
     });
 
-    return postRecord(url, data)
+    return loan
+      .postRecord(url, data)
       .then(details =>
         dispatch({
           type: LOAN_ACTION_SUCCESS,

--- a/invenio_app_ils/ui/backoffice/src/pages/LoanDetails/state/actions.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/LoanDetails/state/actions.js
@@ -15,7 +15,7 @@ export const fetchLoanDetails = loanId => {
     });
 
     return loan
-      .getRecord('/circulation/loans', loanId)
+      .getRecord(loanId)
       .then(details =>
         dispatch({
           type: LOAN_FETCH_DETAILS_SUCCESS,
@@ -31,14 +31,14 @@ export const fetchLoanDetails = loanId => {
   };
 };
 
-export const postLoanAction = (url, data) => {
+export const postLoanAction = (loanId, data) => {
   return async dispatch => {
     dispatch({
       type: SET_LOAN_ACTION_LOADING,
     });
 
     return loan
-      .postRecord(url, data)
+      .postAction(loanId, data)
       .then(details =>
         dispatch({
           type: LOAN_ACTION_SUCCESS,

--- a/invenio_app_ils/ui/backoffice/src/pages/LoanDetails/state/tests/actions.test.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/LoanDetails/state/tests/actions.test.js
@@ -1,7 +1,7 @@
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import MockAdapter from 'axios-mock-adapter';
-import { $axios } from '../../../../common/api';
+import { http } from 'common/api';
 // Actions to be tested
 import * as actions from '../actions';
 import { initialState } from '../reducer';
@@ -23,7 +23,7 @@ describe('loan actions', () => {
     let mock;
     let response = {};
     beforeEach(() => {
-      mock = new MockAdapter($axios);
+      mock = new MockAdapter(http);
       mock.onGet(`${loansBaseUrl}/1`).reply(() => {
         return new Promise((resolve, reject) =>
           setTimeout(() => {
@@ -89,7 +89,7 @@ describe('loan actions', () => {
     let mock;
     let response = {};
     beforeEach(() => {
-      mock = new MockAdapter($axios);
+      mock = new MockAdapter(http);
       mock.onPost(`${loansBaseUrl}/1/next`).reply(() => {
         return new Promise((resolve, reject) =>
           setTimeout(() => {

--- a/invenio_app_ils/ui/backoffice/src/pages/LoanDetails/state/tests/actions.test.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/LoanDetails/state/tests/actions.test.js
@@ -113,13 +113,11 @@ describe('loan actions', () => {
         },
       ];
 
-      store
-        .dispatch(actions.postLoanAction(`${loansBaseUrl}/1/next`, {}))
-        .then(() => {
-          let actions = store.getActions();
-          expect(actions[0]).toEqual(expectedActions[0]);
-          done();
-        });
+      store.dispatch(actions.postLoanAction(1, {})).then(() => {
+        let actions = store.getActions();
+        expect(actions[0]).toEqual(expectedActions[0]);
+        done();
+      });
     });
 
     it('fires an event when the loan transition action succeeds', done => {
@@ -130,13 +128,11 @@ describe('loan actions', () => {
         },
       ];
 
-      return store
-        .dispatch(actions.postLoanAction(`${loansBaseUrl}/1/next`, {}))
-        .then(() => {
-          let actions = store.getActions();
-          expect(actions[1]).toEqual(expectedActions[0]);
-          done();
-        });
+      return store.dispatch(actions.postLoanAction(1, {})).then(() => {
+        let actions = store.getActions();
+        expect(actions[1]).toEqual(expectedActions[0]);
+        done();
+      });
     });
 
     it('fires an event when the loan transition action fails', done => {
@@ -147,13 +143,11 @@ describe('loan actions', () => {
         },
       ];
 
-      return store
-        .dispatch(actions.postLoanAction(`${loansBaseUrl}/2/next`, {}))
-        .then(() => {
-          let actions = store.getActions();
-          expect(actions[1]).toEqual(expectedActions[0]);
-          done();
-        });
+      return store.dispatch(actions.postLoanAction(2, {})).then(() => {
+        let actions = store.getActions();
+        expect(actions[1]).toEqual(expectedActions[0]);
+        done();
+      });
     });
   });
 });

--- a/invenio_app_ils/ui/backoffice/src/pages/index.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/index.js
@@ -1,0 +1,5 @@
+export { Backoffice } from './Backoffice/Backoffice';
+export { ItemList } from './ItemList';
+export { ItemDetails } from './ItemDetails';
+export { LoanList } from './LoanList';
+export { LoanDetails } from './LoanDetails';


### PR DESCRIPTION
Api has been split in different modules. We support now `import { item } from 'common/api'` and then `item.getList()`, same for loans. They all share the same axios instance.

Closes #49