### PR TITLE
Backoffice: Display minimal user details

### DIFF
--- a/invenio_app_ils/config.py
+++ b/invenio_app_ils/config.py
@@ -560,3 +560,14 @@ ILS_VIEWS_PERMISSIONS_FACTORY = views_permissions_factory
 # ==============
 RECORDS_EDITOR_URL_PREFIX = "/editor"
 """Default URL we want to serve our editor application, i.e /editor."""
+
+# Accounts REST
+# ==============
+ACCOUNTS_REST_READ_USER_PROPERTIES_PERMISSION_FACTORY = backoffice_permission
+"""Default read user properties permission factory: reject any request."""
+
+ACCOUNTS_REST_UPDATE_USER_PROPERTIES_PERMISSION_FACTORY = backoffice_permission
+"""Default modify user properties permission factory: reject any request."""
+
+ACCOUNTS_REST_READ_USERS_LIST_PERMISSION_FACTORY = backoffice_permission
+"""Default list users permission factory: reject any request."""

--- a/invenio_app_ils/ui/backoffice/src/App.js
+++ b/invenio_app_ils/ui/backoffice/src/App.js
@@ -3,7 +3,7 @@ import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import { Header, NotFound } from 'common/components';
 import { URLS } from 'common/urls';
 import { ItemRoutes, LoanRoutes } from 'routes';
-import { Backoffice } from './pages';
+import { Backoffice, UserDetailsContainer } from './pages';
 import './App.scss';
 
 export default class App extends Component {
@@ -16,6 +16,10 @@ export default class App extends Component {
             <Switch>
               <Route path={URLS.itemsSearch} component={ItemRoutes} />
               <Route path={URLS.loansSearch} component={LoanRoutes} />
+              <Route
+                path={URLS.patronDetails}
+                component={UserDetailsContainer}
+              />
               <Route path={URLS.root} exact component={Backoffice} />
               <Route component={NotFound} />
             </Switch>

--- a/invenio_app_ils/ui/backoffice/src/common/api/index.js
+++ b/invenio_app_ils/ui/backoffice/src/common/api/index.js
@@ -1,5 +1,5 @@
 import { http } from './base';
 import { item } from './item';
 import { loan } from './loan';
-
-export { http, item, loan };
+import { user } from './user';
+export { http, item, loan, user };

--- a/invenio_app_ils/ui/backoffice/src/common/api/item.js
+++ b/invenio_app_ils/ui/backoffice/src/common/api/item.js
@@ -2,11 +2,11 @@ import { http } from './base';
 
 const itemURL = '/items/';
 
-const getRecord = itemPid => {
+const get = itemPid => {
   return http.get(`${itemURL}${itemPid}`);
 };
 
 export const item = {
   url: itemURL,
-  getRecord: getRecord,
+  get: get,
 };

--- a/invenio_app_ils/ui/backoffice/src/common/api/loan.js
+++ b/invenio_app_ils/ui/backoffice/src/common/api/loan.js
@@ -4,7 +4,7 @@ import { DateTime } from 'luxon';
 
 const loanURL = '/circulation/loans/';
 
-const getRecord = loanPid => {
+const get = loanPid => {
   return http.get(`${loanURL}${loanPid}`);
 };
 
@@ -59,7 +59,7 @@ const fetchPendingOnDocumentItem = (
 
 export const loan = {
   url: loanURL,
-  getRecord: getRecord,
+  get: get,
   postAction: postAction,
   buildPendingQuery: buildPendingQuery,
   fetchPendingOnDocumentItem: fetchPendingOnDocumentItem,

--- a/invenio_app_ils/ui/backoffice/src/common/api/user.js
+++ b/invenio_app_ils/ui/backoffice/src/common/api/user.js
@@ -1,0 +1,12 @@
+import { http } from './base';
+
+const userURL = '/users/';
+
+const get = userPid => {
+  return http.get(`${userURL}${userPid}`);
+};
+
+export const user = {
+  url: userURL,
+  get: get,
+};

--- a/invenio_app_ils/ui/backoffice/src/common/components/Error/Error.js
+++ b/invenio_app_ils/ui/backoffice/src/common/components/Error/Error.js
@@ -13,6 +13,9 @@ export class Error extends Component {
       case 403:
         message = 'You are not authorized to perform this action.';
         break;
+      case 404:
+        message = 'The requested URL has not been found.';
+        break;
       default:
         message = errorMessage;
     }

--- a/invenio_app_ils/ui/backoffice/src/common/urls.js
+++ b/invenio_app_ils/ui/backoffice/src/common/urls.js
@@ -5,4 +5,5 @@ export const URLS = {
   itemDetails: id => `/items/${id}`,
   loansSearch: '/loans',
   loanDetails: id => `/loans/${id}`,
+  patronDetails: `/users/:userPid`,
 };

--- a/invenio_app_ils/ui/backoffice/src/pages/LoanDetails/state/__tests__/actions.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/LoanDetails/state/__tests__/actions.js
@@ -9,8 +9,8 @@ import { loan as loanApi } from 'common/api';
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 
-const mockGetRecord = jest.fn();
-loanApi.getRecord = mockGetRecord;
+const mockGet = jest.fn();
+loanApi.get = mockGet;
 const mockPostAction = jest.fn();
 loanApi.postAction = mockPostAction;
 
@@ -31,7 +31,7 @@ const _initialState = {
 
 let store;
 beforeEach(() => {
-  mockGetRecord.mockClear();
+  mockGet.mockClear();
   mockPostAction.mockClear();
 
   store = mockStore(_initialState);
@@ -41,7 +41,7 @@ beforeEach(() => {
 describe('Loan details tests', () => {
   describe('Fetch loan details tests', () => {
     it('should dispatch a loading action when fetching a loan', done => {
-      mockGetRecord.mockResolvedValue(response);
+      mockGet.mockResolvedValue(response);
 
       const expectedActions = [
         {
@@ -50,7 +50,7 @@ describe('Loan details tests', () => {
       ];
 
       store.dispatch(actions.fetchLoanDetails('123')).then(() => {
-        expect(mockGetRecord).toHaveBeenCalledWith('123');
+        expect(mockGet).toHaveBeenCalledWith('123');
         const actions = store.getActions();
         expect(actions[0]).toEqual(expectedActions[0]);
         done();
@@ -58,7 +58,7 @@ describe('Loan details tests', () => {
     });
 
     it('should dispatch a success action when loan fetch succeeds', done => {
-      mockGetRecord.mockResolvedValue(response);
+      mockGet.mockResolvedValue(response);
 
       const expectedActions = [
         {
@@ -68,7 +68,7 @@ describe('Loan details tests', () => {
       ];
 
       store.dispatch(actions.fetchLoanDetails('123')).then(() => {
-        expect(mockGetRecord).toHaveBeenCalledWith('123');
+        expect(mockGet).toHaveBeenCalledWith('123');
         const actions = store.getActions();
         expect(actions[1]).toEqual(expectedActions[0]);
         done();
@@ -76,7 +76,7 @@ describe('Loan details tests', () => {
     });
 
     it('should dispatch an error action when loan fetch fails', done => {
-      mockGetRecord.mockRejectedValue([500, 'Error']);
+      mockGet.mockRejectedValue([500, 'Error']);
 
       const expectedActions = [
         {
@@ -86,7 +86,7 @@ describe('Loan details tests', () => {
       ];
 
       store.dispatch(actions.fetchLoanDetails('456')).then(() => {
-        expect(mockGetRecord).toHaveBeenCalledWith('456');
+        expect(mockGet).toHaveBeenCalledWith('456');
         const actions = store.getActions();
         expect(actions[1]).toEqual(expectedActions[0]);
         done();

--- a/invenio_app_ils/ui/backoffice/src/pages/LoanDetails/state/actions.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/LoanDetails/state/actions.js
@@ -16,7 +16,7 @@ export const fetchLoanDetails = loanPid => {
     });
 
     await loanApi
-      .getRecord(loanPid)
+      .get(loanPid)
       .then(response => {
         dispatch({
           type: SUCCESS,

--- a/invenio_app_ils/ui/backoffice/src/pages/UserDetails/UserDetailsContainer.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/UserDetails/UserDetailsContainer.js
@@ -1,0 +1,36 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Container } from 'semantic-ui-react';
+import { UserDetails } from './components';
+
+export default class UserDetailsContainer extends Component {
+  constructor(props) {
+    super(props);
+    this.fetchUserDetails = this.props.fetchUserDetails;
+  }
+
+  componentDidMount() {
+    this.unlisten = this.props.history.listen(location => {
+      if (location.state && location.state.userPid) {
+        this.fetchUserDetails(location.state.userPid);
+      }
+    });
+    this.fetchUserDetails(this.props.match.params.userPid);
+  }
+
+  componentWillUnmount() {
+    this.unlisten();
+  }
+
+  render() {
+    return (
+      <Container>
+        <UserDetails />
+      </Container>
+    );
+  }
+}
+
+UserDetailsContainer.propTypes = {
+  fetchUserDetails: PropTypes.func.isRequired,
+};

--- a/invenio_app_ils/ui/backoffice/src/pages/UserDetails/__tests__/UserDetailsContainer.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/UserDetails/__tests__/UserDetailsContainer.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import UserDetailsContainer from '../UserDetailsContainer';
+jest.mock('../components/UserDetails', () => {
+  return {
+    UserDetails: () => null,
+  };
+});
+
+describe('UserDetailsContainer tests', () => {
+  let component;
+  afterEach(() => {
+    if (component) {
+      component.unmount();
+    }
+  });
+
+  const routerHistory = {
+    listen: () => () => {},
+  };
+  const routerUrlParams = {
+    params: {
+      userPid: 1,
+    },
+  };
+
+  it('should load the details component', () => {
+    const component = shallow(
+      <UserDetailsContainer
+        history={routerHistory}
+        match={routerUrlParams}
+        fetchUserDetails={() => {}}
+      />
+    );
+    expect(component).toMatchSnapshot();
+  });
+
+  it('should fetch user details on mount', () => {
+    const mockedFetchUserDetails = jest.fn();
+    component = mount(
+      <UserDetailsContainer
+        history={routerHistory}
+        match={routerUrlParams}
+        fetchUserDetails={mockedFetchUserDetails}
+      />
+    );
+    expect(mockedFetchUserDetails).toHaveBeenCalledWith(
+      routerUrlParams.params.userPid
+    );
+  });
+});

--- a/invenio_app_ils/ui/backoffice/src/pages/UserDetails/__tests__/__snapshots__/UserDetailsContainer.js.snap
+++ b/invenio_app_ils/ui/backoffice/src/pages/UserDetails/__tests__/__snapshots__/UserDetailsContainer.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UserDetailsContainer tests should load the details component 1`] = `
+<Container>
+  <UserDetails />
+</Container>
+`;

--- a/invenio_app_ils/ui/backoffice/src/pages/UserDetails/components/UserDetails/UserDetails.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/UserDetails/components/UserDetails/UserDetails.js
@@ -1,0 +1,24 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Loader, Error } from 'common/components';
+import { UserMetadata } from '../';
+
+export default class UserDetails extends Component {
+  render() {
+    const { isLoading, hasError, data } = this.props;
+    const errorData = hasError ? data : null;
+    return (
+      <Loader isLoading={isLoading}>
+        <Error error={errorData}>
+          <UserMetadata />
+        </Error>
+      </Loader>
+    );
+  }
+}
+
+UserDetails.propTypes = {
+  isLoading: PropTypes.bool.isRequired,
+  data: PropTypes.object,
+  hasError: PropTypes.bool.isRequired,
+};

--- a/invenio_app_ils/ui/backoffice/src/pages/UserDetails/components/UserDetails/index.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/UserDetails/components/UserDetails/index.js
@@ -1,0 +1,15 @@
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import UserDetailsComponent from './UserDetails';
+
+const mapStateToProps = state => ({
+  isLoading: state.userDetails.isLoading,
+  data: state.userDetails.data,
+  hasError: state.userDetails.hasError,
+});
+
+export const UserDetails = compose(
+  withRouter,
+  connect(mapStateToProps)
+)(UserDetailsComponent);

--- a/invenio_app_ils/ui/backoffice/src/pages/UserDetails/components/UserMetadata/UserMetadata.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/UserDetails/components/UserMetadata/UserMetadata.js
@@ -1,0 +1,55 @@
+import React, { Component } from 'react';
+import { Grid, Segment, List, Header, Label } from 'semantic-ui-react';
+import PropTypes from 'prop-types';
+
+export default class UserMetadata extends Component {
+  render() {
+    const data = this.props.userDetails.data;
+
+    let label;
+    if (data && data.active) {
+      label = (
+        <Label as="a" color="green" ribbon>
+          Active
+        </Label>
+      );
+    } else {
+      label = (
+        <Label as="a" color="red" ribbon>
+          Deactivated
+        </Label>
+      );
+    }
+
+    return (
+      <Segment className="item-metadata">
+        {label}
+        <Grid padded columns={2}>
+          <Grid.Column width={10}>
+            <Header as="h1">Patron - {data.id}</Header>
+          </Grid.Column>
+          <Grid.Column>
+            <List relaxed size="large">
+              <List.Item>
+                <List.Header>Patron PID</List.Header>
+                {data.id}
+              </List.Item>
+              <List.Item>
+                <List.Header>Email</List.Header>
+                {data.email}
+              </List.Item>
+              <List.Item>
+                <List.Header>Active</List.Header>
+                {data.active.toString()}
+              </List.Item>
+            </List>
+          </Grid.Column>
+        </Grid>
+      </Segment>
+    );
+  }
+}
+
+UserMetadata.propTypes = {
+  userDetails: PropTypes.object.isRequired,
+};

--- a/invenio_app_ils/ui/backoffice/src/pages/UserDetails/components/UserMetadata/index.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/UserDetails/components/UserMetadata/index.js
@@ -1,0 +1,13 @@
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import UserMetadataComponent from './UserMetadata';
+
+const mapStateToProps = state => ({
+  userDetails: state.userDetails,
+});
+
+export const UserMetadata = compose(
+  withRouter,
+  connect(mapStateToProps)
+)(UserMetadataComponent);

--- a/invenio_app_ils/ui/backoffice/src/pages/UserDetails/components/index.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/UserDetails/components/index.js
@@ -1,0 +1,2 @@
+export { UserDetails } from './UserDetails';
+export { UserMetadata } from './UserMetadata';

--- a/invenio_app_ils/ui/backoffice/src/pages/UserDetails/index.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/UserDetails/index.js
@@ -1,0 +1,17 @@
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import { fetchUserDetails } from './state/actions';
+import UserDetailsContainerComponent from './UserDetailsContainer';
+
+const mapDispatchToProps = dispatch => ({
+  fetchUserDetails: userPid => dispatch(fetchUserDetails(userPid)),
+});
+
+export const UserDetailsContainer = compose(
+  withRouter,
+  connect(
+    null,
+    mapDispatchToProps
+  )
+)(UserDetailsContainerComponent);

--- a/invenio_app_ils/ui/backoffice/src/pages/UserDetails/reducer.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/UserDetails/reducer.js
@@ -1,0 +1,1 @@
+export { default as userDetailsReducer } from './state/reducer';

--- a/invenio_app_ils/ui/backoffice/src/pages/UserDetails/state/__tests__/actions.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/UserDetails/state/__tests__/actions.js
@@ -3,13 +3,13 @@ import thunk from 'redux-thunk';
 import * as actions from '../actions';
 import { initialState } from '../reducer';
 import * as types from '../types';
-import { item as itemApi } from 'common/api';
+import { user as userApi } from 'common/api';
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 
 const mockGet = jest.fn();
-itemApi.get = mockGet;
+userApi.get = mockGet;
 
 const response = { data: {} };
 const expectedPayload = {};
@@ -22,9 +22,9 @@ beforeEach(() => {
   store.clearActions();
 });
 
-describe('Item details actions', () => {
-  describe('Fetch item details tests', () => {
-    it('should dispatch an action when fetching an item', done => {
+describe('User details actions', () => {
+  describe('Fetch user details tests', () => {
+    it('should dispatch an action when fetching an user', done => {
       mockGet.mockResolvedValue(response);
 
       const expectedActions = [
@@ -33,7 +33,7 @@ describe('Item details actions', () => {
         },
       ];
 
-      store.dispatch(actions.fetchItemDetails('123')).then(() => {
+      store.dispatch(actions.fetchUserDetails('123')).then(() => {
         expect(mockGet).toHaveBeenCalledWith('123');
         const actions = store.getActions();
         expect(actions[0]).toEqual(expectedActions[0]);
@@ -41,7 +41,7 @@ describe('Item details actions', () => {
       });
     });
 
-    it('should dispatch an action when item fetch succeeds', done => {
+    it('should dispatch an action when user fetch succeeds', done => {
       mockGet.mockResolvedValue(response);
 
       const expectedActions = [
@@ -51,7 +51,7 @@ describe('Item details actions', () => {
         },
       ];
 
-      store.dispatch(actions.fetchItemDetails('123')).then(() => {
+      store.dispatch(actions.fetchUserDetails('123')).then(() => {
         expect(mockGet).toHaveBeenCalledWith('123');
         const actions = store.getActions();
         expect(actions[1]).toEqual(expectedActions[0]);
@@ -59,7 +59,7 @@ describe('Item details actions', () => {
       });
     });
 
-    it('should dispatch an action when item fetch fails', done => {
+    it('should dispatch an action when user fetch fails', done => {
       mockGet.mockRejectedValue([500, 'Error']);
 
       const expectedActions = [
@@ -69,7 +69,7 @@ describe('Item details actions', () => {
         },
       ];
 
-      store.dispatch(actions.fetchItemDetails('456')).then(() => {
+      store.dispatch(actions.fetchUserDetails('456')).then(() => {
         expect(mockGet).toHaveBeenCalledWith('456');
         const actions = store.getActions();
         expect(actions[1]).toEqual(expectedActions[0]);

--- a/invenio_app_ils/ui/backoffice/src/pages/UserDetails/state/__tests__/reducer.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/UserDetails/state/__tests__/reducer.js
@@ -1,0 +1,45 @@
+import reducer, { initialState } from '../reducer';
+import * as types from '../types';
+
+describe('Fetch user details reducer', () => {
+  it('should have initial state', () => {
+    expect(reducer(undefined, {})).toEqual(initialState);
+  });
+
+  it('should change loading state on loading action', () => {
+    const action = {
+      type: types.IS_LOADING,
+    };
+    expect(reducer(initialState, action)).toEqual({
+      ...initialState,
+      isLoading: true,
+    });
+  });
+
+  it('should change data state on success action', () => {
+    const user = { id: '1' };
+    const action = {
+      type: types.SUCCESS,
+      payload: user,
+    };
+    expect(reducer(initialState, action)).toEqual({
+      ...initialState,
+      isLoading: false,
+      data: user,
+      hasError: false,
+    });
+  });
+
+  it('should change error state on error action', () => {
+    const action = {
+      type: types.HAS_ERROR,
+      payload: { response: { status: 404 } },
+    };
+    expect(reducer(initialState, action)).toEqual({
+      ...initialState,
+      isLoading: false,
+      hasError: true,
+      data: { response: { status: 404 } },
+    });
+  });
+});

--- a/invenio_app_ils/ui/backoffice/src/pages/UserDetails/state/actions.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/UserDetails/state/actions.js
@@ -1,14 +1,14 @@
 import { IS_LOADING, SUCCESS, HAS_ERROR } from './types';
-import { item } from 'common/api';
+import { user } from 'common/api';
 
-export const fetchItemDetails = itemPid => {
+export const fetchUserDetails = userPid => {
   return async dispatch => {
     dispatch({
       type: IS_LOADING,
     });
 
-    await item
-      .get(itemPid)
+    await user
+      .get(userPid)
       .then(response => {
         dispatch({
           type: SUCCESS,

--- a/invenio_app_ils/ui/backoffice/src/pages/UserDetails/state/reducer.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/UserDetails/state/reducer.js
@@ -1,0 +1,30 @@
+import { IS_LOADING, SUCCESS, HAS_ERROR } from './types';
+
+export const initialState = {
+  isLoading: true,
+  hasError: false,
+  data: {},
+};
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case IS_LOADING:
+      return { ...state, isLoading: true };
+    case SUCCESS:
+      return {
+        ...state,
+        isLoading: false,
+        data: action.payload,
+        hasError: false,
+      };
+    case HAS_ERROR:
+      return {
+        ...state,
+        isLoading: false,
+        data: action.payload,
+        hasError: true,
+      };
+    default:
+      return state;
+  }
+};

--- a/invenio_app_ils/ui/backoffice/src/pages/UserDetails/state/types.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/UserDetails/state/types.js
@@ -1,0 +1,3 @@
+export const IS_LOADING = 'fetchUserDetails/IS_LOADING';
+export const SUCCESS = 'fetchUserDetails/SUCCESS';
+export const HAS_ERROR = 'fetchUserDetails/HAS_ERROR';

--- a/invenio_app_ils/ui/backoffice/src/pages/index.js
+++ b/invenio_app_ils/ui/backoffice/src/pages/index.js
@@ -3,3 +3,4 @@ export { ItemsSearch } from 'pages/ItemsSearch';
 export { ItemDetailsContainer } from 'pages/ItemDetails';
 export { LoansSearch } from 'pages/LoansSearch';
 export { LoanDetailsContainer } from 'pages/LoanDetails';
+export { UserDetailsContainer } from 'pages/UserDetails';

--- a/invenio_app_ils/ui/backoffice/src/store.js
+++ b/invenio_app_ils/ui/backoffice/src/store.js
@@ -8,12 +8,14 @@ import {
   itemPendingLoansReducer,
 } from './pages/ItemDetails/reducer';
 import { loanDetailsReducer } from './pages/LoanDetails/reducer';
+import { userDetailsReducer } from './pages/UserDetails/reducer';
 
 const rootReducer = combineReducers({
   userSession: userSessionReducer,
   itemDetails: itemDetailsReducer,
   itemPendingLoans: itemPendingLoansReducer,
   loanDetails: loanDetailsReducer,
+  userDetails: userDetailsReducer,
 });
 
 const composeEnhancers = composeWithDevTools({

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,8 @@ install_requires = [
     "invenio-circulation==0.1.0.dev20180000",  # TODO: add a version here
     # when released, need for Travis and isort
     "invenio-records-editor==1.0.0a2",
+    "invenio-userprofiles==1.0.1",
+    "invenio-accounts-rest==1.0.0a4",
 ]
 
 packages = find_packages()


### PR DESCRIPTION
How it looks now:
![image](https://user-images.githubusercontent.com/38131488/49027922-851b7d00-f1a1-11e8-9ad1-153e744de084.png)
TODO: 
1. add active loans
2. add the extended metadata from invenio-userprofiles
3. add active loans list of a queried user 