### PR TITLE
resolvers: refactor route implementation

### DIFF
--- a/invenio_app_ils/config.py
+++ b/invenio_app_ils/config.py
@@ -557,6 +557,9 @@ PIDSTORE_RECID_FIELD = Item.pid_field
 ILS_VIEWS_PERMISSIONS_FACTORY = views_permissions_factory
 """Permissions factory for ILS views to handle all ILS actions."""
 
+ILS_INDEXER_TASK_DELAY = timedelta(seconds=5)
+"""Time delay that indexers spawning their asynchronous celery tasks."""
+
 # Records Editor
 # ==============
 RECORDS_EDITOR_URL_PREFIX = "/editor"

--- a/invenio_app_ils/indexer.py
+++ b/invenio_app_ils/indexer.py
@@ -9,7 +9,7 @@
 
 from __future__ import absolute_import, print_function
 
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from celery import shared_task
 from flask import current_app
@@ -55,11 +55,13 @@ class ItemIndexer(RecordIndexer):
         super(ItemIndexer, self).index(item)
         index_loans_after_item_indexed.apply_async(
             (item[Item.pid_field],),
-            eta=datetime.utcnow() + timedelta(seconds=5),
+            eta=datetime.utcnow()
+            + current_app.config["ILS_INDEXER_TASK_DELAY"],
         )
         index_document_after_item_indexed.apply_async(
             (item[Item.pid_field],),
-            eta=datetime.utcnow() + timedelta(seconds=5),
+            eta=datetime.utcnow()
+            + current_app.config["ILS_INDEXER_TASK_DELAY"],
         )
 
 
@@ -83,7 +85,8 @@ class DocumentIndexer(RecordIndexer):
         super(DocumentIndexer, self).index(document)
         index_item_after_document_indexed.apply_async(
             (document[Document.pid_field],),
-            eta=datetime.utcnow() + timedelta(seconds=5),
+            eta=datetime.utcnow()
+            + current_app.config["ILS_INDEXER_TASK_DELAY"],
         )
 
 
@@ -111,9 +114,11 @@ class LoanIndexer(RecordIndexer):
         super(LoanIndexer, self).index(loan)
         index_item_after_loan_indexed.apply_async(
             (loan.get(Item.pid_field),),
-            eta=datetime.utcnow() + timedelta(seconds=5),
+            eta=datetime.utcnow()
+            + current_app.config["ILS_INDEXER_TASK_DELAY"],
         )
         index_document_after_loan_indexed.apply_async(
             (loan[Document.pid_field],),
-            eta=datetime.utcnow() + timedelta(seconds=5),
+            eta=datetime.utcnow()
+            + current_app.config["ILS_INDEXER_TASK_DELAY"],
         )

--- a/invenio_app_ils/records/jsonresolver/document.py
+++ b/invenio_app_ils/records/jsonresolver/document.py
@@ -8,16 +8,27 @@
 """Ils Records Items record document resolver."""
 
 import jsonresolver
+from werkzeug.routing import Rule
 
 from invenio_app_ils.records.api import Document
 
 
-@jsonresolver.route(
-    "/api/resolver/items/document/<pid_value>", host="127.0.0.1:5000"
-)
-def document_for_item_resolver(pid_value):
-    """Return the document for the given item."""
-    document = Document.get_record_by_pid(pid_value)
-    # delete circulation field when document is dereferenced inside item
-    del document["circulation"]
-    return document
+@jsonresolver.hookimpl
+def jsonresolver_loader(url_map):
+    """Resolve the document for item record."""
+    from flask import current_app
+
+    def _document_for_item_resolver(document_pid):
+        """Return the document for the given item."""
+        document = Document.get_record_by_pid(document_pid)
+        # delete circulation field when document is dereferenced inside item
+        del document["circulation"]
+        return document
+
+    url_map.add(
+        Rule(
+            "/api/resolver/items/document/<document_pid>",
+            endpoint=_document_for_item_resolver,
+            host=current_app.config.get("JSONSCHEMAS_HOST"),
+        )
+    )


### PR DESCRIPTION
closes #134 
- Refactors resolvers to use the `jsonresolver.hookimpl` decorator and get rid of the hardcoded localhost in the route
- Make the indexers tasks delay configurable