### PR TITLE
fix: state queries and document_pid

### DIFF
--- a/invenio_app_ils/circulation/receivers.py
+++ b/invenio_app_ils/circulation/receivers.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import, print_function
 from invenio_circulation.signals import loan_replace_item, loan_state_changed
 
 from ..proxies import current_app_ils_extension
-from ..records.api import Document, Item
+from ..records.api import Item
 
 
 def register_circulation_signals(app):

--- a/invenio_app_ils/cli.py
+++ b/invenio_app_ils/cli.py
@@ -12,7 +12,6 @@ from random import randint
 
 import click
 import lorem
-from flask import current_app
 from flask.cli import with_appcontext
 from invenio_circulation.api import Loan
 from invenio_circulation.pidstore.pids import CIRCULATION_LOAN_PID_TYPE
@@ -21,7 +20,6 @@ from invenio_indexer.api import RecordIndexer
 from invenio_pidstore.models import PersistentIdentifier, PIDStatus, \
     RecordIdentifier
 
-from .circulation.receivers import index_record_after_loan_change
 from .records.api import Document, InternalLocation, Item, Location
 
 from .pidstore.pids import (  # isort:skip

--- a/invenio_app_ils/indexer.py
+++ b/invenio_app_ils/indexer.py
@@ -16,9 +16,6 @@ from flask import current_app
 from invenio_circulation.api import Loan
 from invenio_circulation.search.api import search_by_pid
 from invenio_indexer.api import RecordIndexer
-from invenio_jsonschemas import current_jsonschemas
-from invenio_pidstore.resolver import Resolver
-from invenio_records.api import Record
 
 from invenio_app_ils.circulation.utils import circulation_document_retriever, \
     circulation_items_retriever

--- a/invenio_app_ils/permissions.py
+++ b/invenio_app_ils/permissions.py
@@ -9,7 +9,7 @@
 
 from __future__ import absolute_import, print_function
 
-from flask import abort, g
+from flask import abort
 from flask_login import current_user
 from flask_principal import UserNeed
 from invenio_access import action_factory

--- a/invenio_app_ils/records/jsonresolver/circulation.py
+++ b/invenio_app_ils/records/jsonresolver/circulation.py
@@ -8,13 +8,12 @@
 """Ils Records Documents record circulation resolver."""
 
 import jsonresolver
-from invenio_circulation.api import get_loan_for_item, is_item_available
+from invenio_circulation.api import is_item_available
 from invenio_circulation.search.api import search_by_pid
 from werkzeug.routing import Rule
 
 from invenio_app_ils.circulation.utils import circulation_is_item_available, \
     circulation_items_retriever
-from invenio_app_ils.records.api import Document
 
 
 @jsonresolver.hookimpl

--- a/invenio_app_ils/records/jsonresolver/location.py
+++ b/invenio_app_ils/records/jsonresolver/location.py
@@ -19,7 +19,6 @@ def jsonresolver_loader(url_map):
     """Resolve the location for internal location record."""
     from flask import current_app
 
-
     def _location_resolver(loc_pid):
         """Return the location record for the given pid or raise exception."""
         location = {}

--- a/invenio_app_ils/records/loaders/schemas/json/item.py
+++ b/invenio_app_ils/records/loaders/schemas/json/item.py
@@ -8,8 +8,7 @@
 """Item schema for marshmallow loader."""
 
 from invenio_records_rest.schemas import RecordMetadataSchemaJSONV1
-from invenio_records_rest.schemas.fields import PersistentIdentifier
-from marshmallow import Schema, fields, post_load
+from marshmallow import fields
 
 
 class ItemSchemaV1(RecordMetadataSchemaJSONV1):

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/api/item.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/api/item.js
@@ -8,9 +8,9 @@ const get = itemPid => {
 
 const buildItemsQuery = (documentPid, state, extraQuery) => {
   const qsDoc = documentPid ? `document.document_pid:${documentPid}` : '';
-  const qsState = state ? `AND state:${state}` : '';
+  const qsState = state ? ` AND state:${state}` : '';
   const qsExtra = extraQuery ? `${extraQuery}` : '';
-  return `${qsDoc}${qsState} ${qsExtra}`;
+  return `${qsDoc}${qsState}${qsExtra}`;
 };
 
 const fetchItems = (documentPid, state, extraQuery) => {
@@ -19,9 +19,9 @@ const fetchItems = (documentPid, state, extraQuery) => {
 };
 
 const fetchItemsByDocPid = (documentPid, config) => {
-  const qs = `(document_pid:${documentPid} AND status:${
+  const qs = `document.document_pid:${documentPid} AND status:${
     config.items.available.status
-  })`;
+  }`;
   return http.get(`${itemURL}?q=${qs}`);
 };
 

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/api/loan.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/api/loan.js
@@ -4,7 +4,7 @@ import { DateTime } from 'luxon';
 
 const loanURL = '/circulation/loans/';
 const get = loanPid => http.get(`${loanURL}${loanPid}`);
-const getLoanReplaceItemUrl = loanPid => `${loanURL}/${loanPid}/replace-item`;
+const getLoanReplaceItemUrl = loanPid => `${loanURL}${loanPid}/replace-item`;
 
 const postAction = (
   url,
@@ -42,7 +42,7 @@ const assignItemToLoan = (itemPid, loanPid) => {
 const buildLoansQuery = (
   documentPid,
   itemPid,
-  state,
+  stateQuery,
   patronPid,
   extraQuery
 ) => {
@@ -55,9 +55,9 @@ const buildLoansQuery = (
     qsDocItem && qsUser
       ? `(${qsDocItem} AND ${qsUser})`
       : `${qsDocItem}${qsUser}`;
-  const qsState = state ? `AND state:${state}` : '';
+  const qsState = stateQuery ? ` AND ${stateQuery}` : '';
   const qsExtra = extraQuery ? `${extraQuery}` : '';
-  return `${qsDocItemUser}${qsState} ${qsExtra}`;
+  return `${qsDocItemUser}${qsState}${qsExtra}`;
 };
 
 const fetchLoans = (
@@ -66,13 +66,13 @@ const fetchLoans = (
   sortBy,
   sortOrder,
   patronPid,
-  state,
+  stateQuery,
   extraQuery
 ) => {
   const qs = buildLoansQuery(
     documentPid,
     itemPid,
-    state,
+    stateQuery,
     patronPid,
     extraQuery
   );

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/DocumentDetails/components/DocumentPendingLoans/DocumentPendingLoans.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/DocumentDetails/components/DocumentPendingLoans/DocumentPendingLoans.js
@@ -30,7 +30,7 @@ export default class DocumentPendingLoans extends Component {
   _showAllHandler = () => {
     const { document_pid } = this.props.document.id;
     this.props.history.push(
-      this.showAllUrl(document_pid, null, 'PENDING', null)
+      this.showAllUrl(document_pid, null, 'state:PENDING', null)
     );
   };
 

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/DocumentDetails/components/DocumentPendingLoans/state/__tests__/actions.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/DocumentDetails/components/DocumentPendingLoans/state/__tests__/actions.js
@@ -46,7 +46,8 @@ describe('Pending loans tests', () => {
           null,
           null,
           null,
-          'PENDING'
+          'state:PENDING',
+          null
         );
         const actions = store.getActions();
         expect(actions[0]).toEqual(expectedAction);
@@ -69,7 +70,8 @@ describe('Pending loans tests', () => {
           null,
           null,
           null,
-          'PENDING'
+          'state:PENDING',
+          null
         );
         const actions = store.getActions();
         expect(actions[1]).toEqual(expectedAction);
@@ -92,7 +94,8 @@ describe('Pending loans tests', () => {
           null,
           null,
           null,
-          'PENDING'
+          'state:PENDING',
+          null
         );
         const actions = store.getActions();
         expect(actions[1]).toEqual(expectedAction);

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/DocumentDetails/components/DocumentPendingLoans/state/actions.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/DocumentDetails/components/DocumentPendingLoans/state/actions.js
@@ -8,7 +8,7 @@ export const fetchPendingLoans = documentPid => {
     });
 
     await loanApi
-      .fetchLoans(documentPid, null, null, null, null, 'PENDING')
+      .fetchLoans(documentPid, null, null, null, null, 'state:PENDING', null)
       .then(response => {
         dispatch({
           type: SUCCESS,

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/ItemDetails/components/ItemDetails/ItemDetails.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/ItemDetails/components/ItemDetails/ItemDetails.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Loader, Error } from '../../../../../common/components';
-import { ItemMetadata, ItemPastLoans, ItemPendingLoans  } from '../';
+import { ItemMetadata, ItemPastLoans, ItemPendingLoans } from '../';
 
 export default class ItemDetails extends Component {
   render() {

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/ItemDetails/components/ItemPastLoans/ItemPastLoans.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/ItemDetails/components/ItemPastLoans/ItemPastLoans.js
@@ -33,9 +33,9 @@ export default class ItemPastLoans extends Component {
       this.showAllUrl(
         document_pid,
         item_pid,
-        'ITEM_RETURNED',
+        'state:ITEM_RETURNED OR state:CANCELLED',
         null,
-        'OR state:CANCELLED'
+        null
       )
     );
   };

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/ItemDetails/components/ItemPastLoans/state/__tests__/actions.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/ItemDetails/components/ItemPastLoans/state/__tests__/actions.js
@@ -48,8 +48,8 @@ describe('Past loans tests', () => {
           null,
           null,
           null,
-          'ITEM_RETURNED',
-          'OR state:CANCELLED'
+          'state:ITEM_RETURNED OR state:CANCELLED',
+          null
         );
         const actions = store.getActions();
         expect(actions[0]).toEqual(expectedAction);
@@ -72,8 +72,8 @@ describe('Past loans tests', () => {
           null,
           null,
           null,
-          'ITEM_RETURNED',
-          'OR state:CANCELLED'
+          'state:ITEM_RETURNED OR state:CANCELLED',
+          null
         );
         const actions = store.getActions();
         expect(actions[1]).toEqual(expectedAction);
@@ -96,8 +96,8 @@ describe('Past loans tests', () => {
           null,
           null,
           null,
-          'ITEM_RETURNED',
-          'OR state:CANCELLED'
+          'state:ITEM_RETURNED OR state:CANCELLED',
+          null
         );
         const actions = store.getActions();
         expect(actions[1]).toEqual(expectedAction);

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/ItemDetails/components/ItemPastLoans/state/actions.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/ItemDetails/components/ItemPastLoans/state/actions.js
@@ -14,8 +14,8 @@ export const fetchPastLoans = (documentPid, itemPid) => {
         null,
         null,
         null,
-        'ITEM_RETURNED',
-        'OR state:CANCELLED'
+        'state:ITEM_RETURNED OR state:CANCELLED',
+        null
       )
       .then(response => {
         dispatch({

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/ItemDetails/components/ItemPendingLoans/ItemPendingLoans.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/ItemDetails/components/ItemPendingLoans/ItemPendingLoans.js
@@ -31,7 +31,7 @@ export default class ItemPendingLoans extends Component {
   _showAllHandler = () => {
     const { document_pid, item_pid } = this.props.item.metadata;
     this.props.history.push(
-      this.showAllUrl(document_pid, item_pid, 'PENDING', null)
+      this.showAllUrl(document_pid, item_pid, 'state:PENDING', null)
     );
   };
 

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/ItemDetails/components/ItemPendingLoans/state/__tests__/actions.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/ItemDetails/components/ItemPendingLoans/state/__tests__/actions.js
@@ -44,7 +44,8 @@ describe('Pending loans tests', () => {
           initialState.sortBy,
           initialState.sortOrder,
           null,
-          'PENDING'
+          'state:PENDING',
+          null
         );
         const actions = store.getActions();
         expect(actions[0]).toEqual(expectedAction);
@@ -69,7 +70,8 @@ describe('Pending loans tests', () => {
           initialState.sortBy,
           initialState.sortOrder,
           null,
-          'PENDING'
+          'state:PENDING',
+          null
         );
         const actions = store.getActions();
         expect(actions[1]).toEqual(expectedAction);
@@ -92,7 +94,8 @@ describe('Pending loans tests', () => {
           initialState.sortBy,
           initialState.sortOrder,
           null,
-          'PENDING'
+          'state:PENDING',
+          null
         );
         const actions = store.getActions();
         expect(actions[1]).toEqual(expectedAction);

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/ItemDetails/components/ItemPendingLoans/state/actions.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/ItemDetails/components/ItemPendingLoans/state/actions.js
@@ -18,7 +18,15 @@ export const fetchPendingLoans = (documentPid, itemPid) => {
     const sortOrder = getState().itemPendingLoans.sortOrder;
 
     await loanApi
-      .fetchLoans(documentPid, itemPid, sortBy, sortOrder, null, 'PENDING')
+      .fetchLoans(
+        documentPid,
+        itemPid,
+        sortBy,
+        sortOrder,
+        null,
+        'state:PENDING',
+        null
+      )
       .then(response => {
         dispatch({
           type: SUCCESS,

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/UserDetails/components/PatronLoans/state/__tests__/actions.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/UserDetails/components/PatronLoans/state/__tests__/actions.js
@@ -46,7 +46,8 @@ describe('Patron loans tests', () => {
           initialState.sortBy,
           initialState.sortOrder,
           2,
-          'P'
+          'state:P',
+          null
         );
         const actions = store.getActions();
         expect(actions[0]).toEqual(expectedAction);
@@ -69,7 +70,8 @@ describe('Patron loans tests', () => {
           initialState.sortBy,
           initialState.sortOrder,
           2,
-          'P'
+          'state:P',
+          null
         );
         const actions = store.getActions();
         expect(actions[1]).toEqual(expectedAction);
@@ -92,7 +94,8 @@ describe('Patron loans tests', () => {
           initialState.sortBy,
           initialState.sortOrder,
           2,
-          'P'
+          'state:P',
+          null
         );
         const actions = store.getActions();
         expect(actions[1]).toEqual(expectedAction);

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/UserDetails/components/PatronLoans/state/actions.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/UserDetails/components/PatronLoans/state/actions.js
@@ -23,7 +23,15 @@ export const fetchPatronLoans = (
     const sortOrder = getState().patronLoans.sortOrder;
 
     await loanApi
-      .fetchLoans(documentPid, itemPid, sortBy, sortOrder, patronPid, loanState)
+      .fetchLoans(
+        documentPid,
+        itemPid,
+        sortBy,
+        sortOrder,
+        patronPid,
+        `state:${loanState}`,
+        null
+      )
       .then(response => {
         dispatch({
           type: SUCCESS,

--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,7 @@ setup(
             "invenio_app_ils.records.jsonresolver.internal_location",
             "circulation = invenio_app_ils.records.jsonresolver.circulation"
         ],
-        'invenio_celery.tasks' : [
+        'invenio_celery.tasks': [
             'indexer = invenio_app_ils.indexer'
         ]
     },

--- a/tests/api/test_loan_item_permissions.py
+++ b/tests/api/test_loan_item_permissions.py
@@ -144,7 +144,7 @@ def test_anonymous_cannot_update_loans(client, json_headers,
     """Test that anonymous cannot update loans."""
     loanid = 'loanid-1'
     _test_post_new_loan(client, json_headers, 401)
-    _test_patch_existing_loan(client,  json_patch_headers, loanid, 401)
+    _test_patch_existing_loan(client, json_patch_headers, loanid, 401)
     _test_replace_existing_loan(client, json_headers, loanid, 401)
     _test_delete_existing_loan(client, json_headers, loanid, 401)
 

--- a/tests/api/test_loan_item_resolver.py
+++ b/tests/api/test_loan_item_resolver.py
@@ -6,14 +6,8 @@
 # it under the terms of the MIT License; see LICENSE file for more details.
 
 """Tests for loan item resolver."""
-from copy import deepcopy
-from json import loads
 
 from invenio_circulation.api import Loan
-from invenio_circulation.proxies import current_circulation
-from pkg_resources import resource_string
-
-from invenio_app_ils.records.api import Item
 
 
 def test_loan_item_resolver(app, testdata):


### PR DESCRIPTION
* fixed queries for state and multiple states for loanApi fetchLoans method
* fixed queries document_pid which was missing from the metadata of the record but exists in the resolved property of document
* fixed missing document_pid from items search