### PR TITLE
circulation: fix create new loan request

### DIFF
--- a/invenio_app_ils/circulation/api.py
+++ b/invenio_app_ils/circulation/api.py
@@ -14,6 +14,8 @@ from invenio_circulation.errors import CirculationException
 from invenio_circulation.pidstore.minters import loan_pid_minter
 from invenio_circulation.proxies import current_circulation
 
+from invenio_app_ils.circulation.utils import circulation_document_retriever
+
 
 def request_loan(params):
     """Create a loan and trigger the first transition to create a request."""
@@ -51,6 +53,10 @@ def create_loan(params):
         raise CirculationException(
             "Patron has already a request or active loan on this item.")
 
+    if "document_pid" not in params:
+        document_pid = circulation_document_retriever(params["item_pid"])
+        if document_pid:
+            params["document_pid"] = document_pid
     # create a new loan
     record_uuid = uuid.uuid4()
     new_loan = {}

--- a/invenio_app_ils/circulation/utils.py
+++ b/invenio_app_ils/circulation/utils.py
@@ -35,10 +35,12 @@ def circulation_items_retriever(document_pid):
 
 
 def circulation_document_retriever(item_pid):
-    """Retrieve items given a document."""
+    """Retrieves document given an item."""
     item = Item.get_record_by_pid(item_pid)
     item = item.replace_refs()
-    return item["document"]["document_pid"]
+    if item.get("document") and item["document"].get("document_pid"):
+        return item["document"]["document_pid"]
+    return ""
 
 
 def circulation_item_location_retriever(item_pid):

--- a/invenio_app_ils/indexer.py
+++ b/invenio_app_ils/indexer.py
@@ -110,12 +110,12 @@ class LoanIndexer(RecordIndexer):
         """Index a loan."""
         super(LoanIndexer, self).index(loan)
         index_item_after_loan_indexed.apply_async(
-            (loan.get(Item.pid_field),),
+            (loan.get(Item.pid_field, ""),),
             eta=datetime.utcnow()
             + current_app.config["ILS_INDEXER_TASK_DELAY"],
         )
         index_document_after_loan_indexed.apply_async(
-            (loan[Document.pid_field],),
+            (loan.get(Document.pid_field, ""),),
             eta=datetime.utcnow()
             + current_app.config["ILS_INDEXER_TASK_DELAY"],
         )


### PR DESCRIPTION
The ui wasn't sending the `document_pid` when it was requesting a new loan for an item and thus the indexer was assuming that was there. I made it optional when the indexer tries to index the document after the loan is changed and also tried to extract the document from the item when the `create_loan` api was being called.