### PR TITLE
ui: remove status code from error notification

### DIFF
--- a/invenio_app_ils/ui/src/invenio_app_ils/common/components/Notifications/Notifications.scss
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/components/Notifications/Notifications.scss
@@ -1,6 +1,10 @@
 #notifications {
   position: fixed;
-  right: 20px;
-  top: 20px;
+  right: 1em;
+  top: 1em;
   z-index: 1000;
+
+  .message {
+    padding-right: 2.5em;
+  }
 }

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/components/Notifications/messages.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/components/Notifications/messages.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import { Message } from 'semantic-ui-react';
 
+const SUCCESS_AUTO_DISMISS_SECONDS = 60 * 10;
+
 export class IlsMessage extends Component {
   componentDidMount() {
     const { autoDismiss, onDismiss } = this.props;
@@ -42,6 +44,7 @@ export const SuccessMessage = ({ id, header, content, removeNotification }) => (
     icon="check"
     header={header}
     content={content}
+    autoDismiss={SUCCESS_AUTO_DISMISS_SECONDS * 1000}
     onDismiss={() => removeNotification(id)}
   />
 );

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/components/Notifications/state/actions.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/components/Notifications/state/actions.js
@@ -5,8 +5,8 @@ export const sendErrorNotification = error => {
   return dispatch => {
     if (!shouldShowErrorPage(error)) {
       const errorData = error.response.data;
-      const { status, error_class, error_module, message } = errorData;
-      const title = `${error_module}: ${error_class} (${status})`;
+      const { error_class, error_module, message } = errorData;
+      const title = `${error_module}: ${error_class}`;
 
       dispatch(addNotification(title, message, 'error'));
     }


### PR DESCRIPTION
* Remove status code from error notification title
* Auto dismiss success notifications after 10 minutes
* Fixes #233 