### PR TITLE
home-page: adding most recent/loaned document views

### DIFF
--- a/invenio_app_ils/circulation/views.py
+++ b/invenio_app_ils/circulation/views.py
@@ -112,7 +112,8 @@ class LoanCreateResource(IlsResource):
     def post(self, **kwargs):
         """Loan create post method."""
         params = request.get_json()
-        should_force_checkout = params.pop("force_checkout")
+        should_force_checkout = params.pop("force_checkout")\
+            if "force_checkout" in params else False
         pid, loan = create_loan(params, should_force_checkout)
 
         return self.make_response(

--- a/invenio_app_ils/ui/src/invenio_app_ils/__tests__/App.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/__tests__/App.js
@@ -4,7 +4,9 @@ import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import App from '../App';
 import configureMockStore from 'redux-mock-store';
-import { initialState } from '../common/components/Notifications/state/reducer';
+import { initialState as notificationsInitialState } from '../common/components/Notifications/state/reducer';
+import { initialState as mostRecentDocumentsInitialState } from '../pages/frontsite/Home/components/MostLoanedDocuments/state/reducer';
+import { initialState as mostLoanedDocumentsInitialState } from '../pages/frontsite/Home/components/MostLoanedDocuments/state/reducer';
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
@@ -16,7 +18,13 @@ beforeEach(() => {
   window.history.pushState({}, 'Backoffice page title', '/backoffice');
   store = mockStore({
     notifications: {
-      ...initialState,
+      ...notificationsInitialState,
+    },
+    mostLoanedDocuments: {
+      ...mostLoanedDocumentsInitialState,
+    },
+    mostRecentDocuments: {
+      ...mostRecentDocumentsInitialState,
     },
   });
   store.clearActions();

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/api/documents/document.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/api/documents/document.js
@@ -13,13 +13,20 @@ const get = documentPid => {
 class QueryBuilder {
   constructor() {
     this.overbookedQuery = [];
+    this.currentlyOnLoanQuery = [];
     this.availableItemsQuery = [];
     this.withPendingLoansQuery = [];
     this.withKeywordQuery = [];
+    this.withSortQuery = [];
   }
 
   overbooked() {
     this.overbookedQuery.push(`circulation.overbooked:true`);
+    return this;
+  }
+
+  currentlyOnLoan() {
+    this.currentlyOnLoanQuery.push('circulation.active_loans:>0&');
     return this;
   }
 
@@ -41,12 +48,19 @@ class QueryBuilder {
     return this;
   }
 
+  withSort(order = 'bestmatch') {
+    this.withSortQuery.push(`&sort=${order}`);
+    return this;
+  }
+
   qs() {
     return this.overbookedQuery
       .concat(
+        this.currentlyOnLoanQuery,
         this.availableItemsQuery,
         this.withPendingLoansQuery,
-        this.withKeywordQuery
+        this.withKeywordQuery,
+        this.withSortQuery
       )
       .join(' AND ');
   }

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/components/SearchBar/SearchBar.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/components/SearchBar/SearchBar.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Input } from 'semantic-ui-react';
+import { Input, Icon } from 'semantic-ui-react';
 import { QueryBuildHelper } from './components/QueryBuildHelper/';
 
 export class SearchBar extends Component {
@@ -25,12 +25,17 @@ export class SearchBar extends Component {
     return (
       <>
         <Input
-          action={{
-            content: 'Search',
-            onClick: () => {
-              executeSearch();
-            },
-          }}
+          icon={
+            <Icon
+              onClick={executeSearch}
+              name="search"
+              inverted
+              circular
+              link
+            />
+          }
+          iconPosition="left"
+          size="massive"
           fluid
           placeholder={placeholder}
           onChange={(e, { value }) =>

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/components/SearchBar/__tests__/SearchBar.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/components/SearchBar/__tests__/SearchBar.js
@@ -70,8 +70,10 @@ describe('LoansSearch SearchBar tests', () => {
         placeholder={'Search'}
       />
     );
-
-    const input = component.find('Input').find('button');
+    const input = component
+      .find('Input')
+      .find('Icon')
+      .find('i');
     input.simulate('click');
     expect(mockedExecuteSearch).toHaveBeenCalled();
   });

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/components/SearchBar/__tests__/__snapshots__/SearchBar.js.snap
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/components/SearchBar/__tests__/__snapshots__/SearchBar.js.snap
@@ -21,21 +21,27 @@ exports[`LoansSearch SearchBar tests should render search bar with query helper 
   }
 >
   <Input
-    action={
-      Object {
-        "content": "Search",
-        "onClick": [Function],
-      }
-    }
     fluid={true}
+    icon={
+      <Icon
+        as="i"
+        circular={true}
+        inverted={true}
+        link={true}
+        name="search"
+        onClick={[MockFunction]}
+      />
+    }
+    iconPosition="left"
     onChange={[Function]}
     onKeyPress={[Function]}
     placeholder="Search"
+    size="massive"
     type="text"
     value=""
   >
     <div
-      className="ui fluid action input"
+      className="ui massive fluid left icon input"
     >
       <input
         onChange={[Function]}
@@ -44,18 +50,20 @@ exports[`LoansSearch SearchBar tests should render search bar with query helper 
         type="text"
         value=""
       />
-      <Button
-        as="button"
-        content="Search"
-        onClick={[Function]}
+      <Icon
+        as="i"
+        circular={true}
+        inverted={true}
+        link={true}
+        name="search"
+        onClick={[MockFunction]}
       >
-        <button
-          className="ui button"
-          onClick={[Function]}
-        >
-          Search
-        </button>
-      </Button>
+        <i
+          aria-hidden="true"
+          className="search circular inverted link icon"
+          onClick={[MockFunction]}
+        />
+      </Icon>
     </div>
   </Input>
   <QueryBuildHelper
@@ -146,21 +154,27 @@ exports[`LoansSearch SearchBar tests should render the current query string 1`] 
   placeholder="Search"
 >
   <Input
-    action={
-      Object {
-        "content": "Search",
-        "onClick": [Function],
-      }
-    }
     fluid={true}
+    icon={
+      <Icon
+        as="i"
+        circular={true}
+        inverted={true}
+        link={true}
+        name="search"
+        onClick={[Function]}
+      />
+    }
+    iconPosition="left"
     onChange={[Function]}
     onKeyPress={[Function]}
     placeholder="Search"
+    size="massive"
     type="text"
     value="The Gulf: The Making of An American Sea"
   >
     <div
-      className="ui fluid action input"
+      className="ui massive fluid left icon input"
     >
       <input
         onChange={[Function]}
@@ -169,18 +183,20 @@ exports[`LoansSearch SearchBar tests should render the current query string 1`] 
         type="text"
         value="The Gulf: The Making of An American Sea"
       />
-      <Button
-        as="button"
-        content="Search"
+      <Icon
+        as="i"
+        circular={true}
+        inverted={true}
+        link={true}
+        name="search"
         onClick={[Function]}
       >
-        <button
-          className="ui button"
+        <i
+          aria-hidden="true"
+          className="search circular inverted link icon"
           onClick={[Function]}
-        >
-          Search
-        </button>
-      </Button>
+        />
+      </Icon>
     </div>
   </Input>
 </SearchBar>

--- a/invenio_app_ils/ui/src/invenio_app_ils/history.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/history.js
@@ -1,3 +1,10 @@
 import { createBrowserHistory } from 'history';
 
-export default createBrowserHistory();
+const history = createBrowserHistory();
+
+export const goTo = path => e => {
+  history.push(path);
+  history.go();
+};
+
+export default history;

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/Home.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/Home.js
@@ -1,29 +1,75 @@
 import React, { Component } from 'react';
-import { Grid } from 'semantic-ui-react';
-import MenuSidebar from './components/MenuSidebar';
+import { Container, Grid } from 'semantic-ui-react';
 import Statistics from './components/Statistics';
-import { SIDEBAR_MENU_ITEMS } from '../constants';
 
 import './Home.scss';
+import { apiConfig } from '../../../common/api/base';
+import { document as documentApi } from '../../../common/api/documents/document';
+import { ReactSearchKit, SearchBar } from 'react-searchkit';
+import { SearchBar as DocumentsSearchBar } from '../../../common/components/SearchBar';
+import { FrontSiteRoutes } from '../../../routes/urls';
+import Header from 'semantic-ui-react/dist/commonjs/elements/Header';
+import { MostLoanedDocuments } from './components/MostLoanedDocuments';
+import { MostRecentDocuments } from './components/MostRecentDocuments';
+import { default as config } from './config';
+import { goTo } from '../../../history';
 
 export default class Home extends Component {
+  _renderSearchBar = (_, queryString, onInputChange, executeSearch) => {
+    const onBtnSearchClick = (event, input) => {
+      executeSearch();
+      goTo(FrontSiteRoutes.documentsListWithQuery(queryString));
+    };
+
+    return (
+      <DocumentsSearchBar
+        currentQueryString={queryString}
+        onInputChange={onInputChange}
+        executeSearch={onBtnSearchClick}
+        placeholder={'Search for books, articles, proceedings...'}
+        queryHelperFields={config.HELPER_FIELDS}
+      />
+    );
+  };
   render() {
     return (
       <div className="home-container">
-        <Grid columns="equal">
-          <Grid.Column width={2} className="sidebar-container">
-            <MenuSidebar menuItems={SIDEBAR_MENU_ITEMS} />
-          </Grid.Column>
-          <Grid.Column className="document-list-container">
-            <div className="home-banner">
-              <div className="home-title">CERN Library</div>
-              <div className="home-description">
-                Find books, e-books, articles, proceedings to loan at CERN.
-              </div>
-            </div>
-          </Grid.Column>
+        <Grid centered columns={2}>
+          <Header size="huge">What would you like to find?</Header>
+
+          <Grid.Row centered columns={2}>
+            <ReactSearchKit
+              searchConfig={{
+                ...apiConfig,
+                url: documentApi.url,
+              }}
+            >
+              <Container className="books-search-searchbar">
+                <SearchBar renderElement={this._renderSearchBar} />
+              </Container>
+            </ReactSearchKit>
+          </Grid.Row>
+
+          <Grid.Row centered columns={2}>
+            <Header size="medium">Most Loaned Documents</Header>
+            <MostLoanedDocuments
+              maxDisplayedItems={config.MAX_ITEMS_TO_DISPLAY}
+              filter={config.DOCUMENT_TYPE}
+            />
+          </Grid.Row>
+
+          <Grid.Row centered columns={2}>
+            <Header size="medium">Most Recent Documents</Header>
+            <MostRecentDocuments
+              maxDisplayedItems={config.MAX_ITEMS_TO_DISPLAY}
+              filter={config.DOCUMENT_TYPE}
+            />
+          </Grid.Row>
+
+          <Grid.Row centered columns={2}>
+            <Statistics />
+          </Grid.Row>
         </Grid>
-        <Statistics />
       </div>
     );
   }

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/Home.scss
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/Home.scss
@@ -31,7 +31,6 @@ $margin-20: 20px;
 
     margin: 0 $margin-10;
 
-    background-image: url('../../../static/images/home.jpg');
     background-position: center;
 
     justify-content: center;
@@ -45,5 +44,9 @@ $margin-20: 20px;
     .home-description {
       font-size: 1.5em;
     }
+  }
+
+  .ui.cards {
+    padding-left: 100px;
   }
 }

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/DocumentCard/DocumentCard.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/DocumentCard/DocumentCard.js
@@ -1,0 +1,23 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import { Card, Image } from 'semantic-ui-react';
+
+export default class DocumentCard extends Component {
+  render() {
+    const documentData = this.props.documentData;
+    return (
+      <Card onClick={documentData.onClick}>
+        <Image size={documentData.imageSize} src={documentData.imageCover} />
+        <Card.Content>
+          <Card.Header>{documentData.title}</Card.Header>
+          <Card.Meta>{documentData.authors}</Card.Meta>
+        </Card.Content>
+      </Card>
+    );
+  }
+}
+
+DocumentCard.propTypes = {
+  documentData: PropTypes.object.isRequired,
+};

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/DocumentCard/index.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/DocumentCard/index.js
@@ -1,0 +1,1 @@
+export { default as DocumentCard } from './DocumentCard';

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/MostLoanedDocuments/MostLoanedDocuments.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/MostLoanedDocuments/MostLoanedDocuments.js
@@ -1,0 +1,76 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Loader, Error } from '../../../../../common/components';
+import { FrontSiteRoutes } from '../../../../../routes/urls';
+import { Button, Card, Divider } from 'semantic-ui-react';
+import { DocumentCard } from '../DocumentCard';
+import { truncate } from 'lodash/string';
+import { goTo } from '../../../../../history';
+
+export default class MostLoanedDocuments extends Component {
+  constructor(props) {
+    super(props);
+    this.fetchMostLoanedDocuments = props.fetchMostLoanedDocuments;
+    this.maxItemsToDisplay = props.maxDisplayedItems;
+  }
+
+  componentDidMount() {
+    this.fetchMostLoanedDocuments();
+  }
+
+  prepareData(data) {
+    return data.hits
+      .slice(0, this.maxItemsToDisplay)
+      .filter(document =>
+        document.metadata.document_types.includes(this.props.filter)
+      )
+      .map(document => {
+        return {
+          pid: document.metadata.document_pid,
+          title: document.metadata.title,
+          authors: truncate(document.metadata.authors.join('\n')),
+          imageSize: 'small',
+          imageCover: 'https://assets.thalia.media/img/46276899-00-00.jpg',
+          onClick: goTo(
+            FrontSiteRoutes.documentDetailsFor(document.metadata.document_pid)
+          ),
+        };
+      });
+  }
+
+  renderCards(items) {
+    const cards = items.map(document => {
+      return <DocumentCard key={document.pid} documentData={document} />;
+    });
+
+    return <Card.Group>{cards}</Card.Group>;
+  }
+
+  render() {
+    const { data, isLoading, error } = this.props;
+    const items = this.prepareData(data);
+    return (
+      <Loader isLoading={isLoading}>
+        <Error error={error}>
+          <div>
+            <Button
+              onClick={goTo(
+                FrontSiteRoutes.documentsListWithQuery('&sort=-mostloaned')
+              )}
+            >
+              See All
+            </Button>
+            <Divider hidden />
+            {this.renderCards(items)}
+          </div>
+        </Error>
+      </Loader>
+    );
+  }
+}
+
+MostLoanedDocuments.propTypes = {
+  fetchMostLoanedDocuments: PropTypes.func.isRequired,
+  data: PropTypes.object.isRequired,
+  filter: PropTypes.string.isRequired,
+};

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/MostLoanedDocuments/index.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/MostLoanedDocuments/index.js
@@ -1,0 +1,19 @@
+import { connect } from 'react-redux';
+import { fetchMostLoanedDocuments } from './state/actions';
+import MostLoanedDocumentsComponent from './MostLoanedDocuments';
+
+const mapStateToProps = state => ({
+  data: state.mostLoanedDocuments.data,
+  error: state.mostLoanedDocuments.error,
+  isLoading: state.mostLoanedDocuments.isLoading,
+  hasError: state.mostLoanedDocuments.hasError,
+});
+
+const mapDispatchToProps = dispatch => ({
+  fetchMostLoanedDocuments: () => dispatch(fetchMostLoanedDocuments()),
+});
+
+export const MostLoanedDocuments = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(MostLoanedDocumentsComponent);

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/MostLoanedDocuments/state/__tests__/actions.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/MostLoanedDocuments/state/__tests__/actions.js
@@ -1,0 +1,86 @@
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import * as actions from '../actions';
+import { initialState } from '../reducer';
+import * as types from '../types';
+import { document as documentApi } from '../../../../../../../common/api';
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+
+const mockFetchMostLoanedDocs = jest.fn();
+documentApi.list = mockFetchMostLoanedDocs;
+
+const response = { data: {} };
+const expectedPayload = {};
+
+let store;
+beforeEach(() => {
+  mockFetchMostLoanedDocs.mockClear();
+
+  store = mockStore(initialState);
+  store.clearActions();
+});
+
+describe('Most loaned documents actions', () => {
+  describe('Fetch most loaned documents tests', () => {
+    it('should dispatch an action when fetching most loaned documents', done => {
+      mockFetchMostLoanedDocs.mockResolvedValue(response);
+
+      const expectedActions = [
+        {
+          type: types.IS_LOADING,
+        },
+      ];
+
+      store.dispatch(actions.fetchMostLoanedDocuments()).then(() => {
+        expect(mockFetchMostLoanedDocs).toHaveBeenCalledWith(
+          'circulation.active_loans:>0& AND &sort=mostloaned'
+        );
+        const actions = store.getActions();
+        expect(actions[0]).toEqual(expectedActions[0]);
+        done();
+      });
+    });
+
+    it('should dispatch an action when most loaned documents fetch succeeds', done => {
+      mockFetchMostLoanedDocs.mockResolvedValue(response);
+
+      const expectedActions = [
+        {
+          type: types.SUCCESS,
+          payload: expectedPayload,
+        },
+      ];
+
+      store.dispatch(actions.fetchMostLoanedDocuments()).then(() => {
+        expect(mockFetchMostLoanedDocs).toHaveBeenCalledWith(
+          'circulation.active_loans:>0& AND &sort=mostloaned'
+        );
+        const actions = store.getActions();
+        expect(actions[1]).toEqual(expectedActions[0]);
+        done();
+      });
+    });
+
+    it('should dispatch an action when most loaned documents fetch fails', done => {
+      mockFetchMostLoanedDocs.mockRejectedValue([500, 'Error']);
+
+      const expectedActions = [
+        {
+          type: types.HAS_ERROR,
+          payload: [500, 'Error'],
+        },
+      ];
+
+      store.dispatch(actions.fetchMostLoanedDocuments()).then(() => {
+        expect(mockFetchMostLoanedDocs).toHaveBeenCalledWith(
+          'circulation.active_loans:>0& AND &sort=mostloaned'
+        );
+        const actions = store.getActions();
+        expect(actions[1]).toEqual(expectedActions[0]);
+        done();
+      });
+    });
+  });
+});

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/MostLoanedDocuments/state/__tests__/reducer.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/MostLoanedDocuments/state/__tests__/reducer.js
@@ -1,0 +1,45 @@
+import reducer, { initialState } from '../reducer';
+import * as types from '../types';
+
+describe('Fetch most loaned documents reducer', () => {
+  it('should have initial state', () => {
+    expect(reducer(undefined, {})).toEqual(initialState);
+  });
+
+  it('should change loading state on loading action', () => {
+    const action = {
+      type: types.IS_LOADING,
+    };
+    expect(reducer(initialState, action)).toEqual({
+      ...initialState,
+      isLoading: true,
+    });
+  });
+
+  it('should change data state on success action', () => {
+    const document = { document_pid: '123456' };
+    const action = {
+      type: types.SUCCESS,
+      payload: document,
+    };
+    expect(reducer(initialState, action)).toEqual({
+      ...initialState,
+      isLoading: false,
+      data: document,
+      hasError: false,
+    });
+  });
+
+  it('should change error state on error action', () => {
+    const action = {
+      type: types.HAS_ERROR,
+      payload: 'Error',
+    };
+    expect(reducer(initialState, action)).toEqual({
+      ...initialState,
+      isLoading: false,
+      error: 'Error',
+      hasError: true,
+    });
+  });
+});

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/MostLoanedDocuments/state/actions.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/MostLoanedDocuments/state/actions.js
@@ -1,0 +1,30 @@
+import { IS_LOADING, SUCCESS, HAS_ERROR } from './types';
+import { document as documentApi } from '../../../../../../common/api';
+import { sendErrorNotification } from '../../../../../../common/components/Notifications';
+
+export const fetchMostLoanedDocuments = () => {
+  return async dispatch => {
+    try {
+      dispatch({
+        type: IS_LOADING,
+      });
+      const response = await documentApi.list(
+        documentApi
+          .query()
+          .currentlyOnLoan()
+          .withSort('mostloaned')
+          .qs()
+      );
+      dispatch({
+        type: SUCCESS,
+        payload: response.data,
+      });
+    } catch (error) {
+      dispatch({
+        type: HAS_ERROR,
+        payload: error,
+      });
+      dispatch(sendErrorNotification(error));
+    }
+  };
+};

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/MostLoanedDocuments/state/reducer.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/MostLoanedDocuments/state/reducer.js
@@ -1,0 +1,32 @@
+import { IS_LOADING, SUCCESS, HAS_ERROR } from './types';
+
+export const initialState = {
+  isLoading: true,
+  hasError: false,
+  data: { hits: [], total: 0 },
+  error: {},
+};
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case IS_LOADING:
+      return { ...state, isLoading: true };
+    case SUCCESS:
+      return {
+        ...state,
+        isLoading: false,
+        data: action.payload,
+        error: {},
+        hasError: false,
+      };
+    case HAS_ERROR:
+      return {
+        ...state,
+        isLoading: false,
+        error: action.payload,
+        hasError: true,
+      };
+    default:
+      return state;
+  }
+};

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/MostLoanedDocuments/state/types.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/MostLoanedDocuments/state/types.js
@@ -1,0 +1,3 @@
+export const IS_LOADING = 'fetchMostLoanedDocuments/IS_LOADING';
+export const SUCCESS = 'fetchMostLoanedDocuments/SUCCESS';
+export const HAS_ERROR = 'fetchMostLoanedDocuments/HAS_ERROR';

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/MostRecentDocuments/MostRecentDocuments.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/MostRecentDocuments/MostRecentDocuments.js
@@ -1,0 +1,76 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Loader, Error } from '../../../../../common/components';
+import { FrontSiteRoutes } from '../../../../../routes/urls';
+import { Card, Button, Divider } from 'semantic-ui-react';
+import { DocumentCard } from '../DocumentCard';
+import { truncate } from 'lodash/string';
+import { goTo } from '../../../../../history';
+
+export default class MostRecentDocuments extends Component {
+  constructor(props) {
+    super(props);
+    this.fetchMostRecentDocuments = props.fetchMostRecentDocuments;
+    this.maxItemsToDisplay = props.maxDisplayedItems;
+  }
+
+  componentDidMount() {
+    this.fetchMostRecentDocuments();
+  }
+
+  prepareData(data) {
+    return data.hits
+      .slice(0, this.maxItemsToDisplay)
+      .filter(document =>
+        document.metadata.document_types.includes(this.props.filter)
+      )
+      .map(document => {
+        return {
+          pid: document.metadata.document_pid,
+          title: document.metadata.title,
+          authors: truncate(document.metadata.authors.join('\n')),
+          imageSize: 'small',
+          imageCover: 'https://assets.thalia.media/img/46276899-00-00.jpg',
+          onClick: goTo(
+            FrontSiteRoutes.documentDetailsFor(document.metadata.document_pid)
+          ),
+        };
+      });
+  }
+
+  renderCards(items) {
+    const cards = items.map(document => {
+      return <DocumentCard key={document.pid} documentData={document} />;
+    });
+
+    return <Card.Group>{cards}</Card.Group>;
+  }
+
+  render() {
+    const { data, isLoading, error } = this.props;
+    const items = this.prepareData(data);
+    return (
+      <Loader isLoading={isLoading}>
+        <Error error={error}>
+          <div>
+            <Button
+              onClick={goTo(
+                FrontSiteRoutes.documentsListWithQuery('&sort=-mostrecent')
+              )}
+            >
+              See All
+            </Button>
+            <Divider hidden />
+            {this.renderCards(items)}
+          </div>
+        </Error>
+      </Loader>
+    );
+  }
+}
+
+MostRecentDocuments.propTypes = {
+  fetchMostRecentDocuments: PropTypes.func.isRequired,
+  data: PropTypes.object.isRequired,
+  filter: PropTypes.string.isRequired,
+};

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/MostRecentDocuments/index.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/MostRecentDocuments/index.js
@@ -1,0 +1,19 @@
+import { connect } from 'react-redux';
+import { fetchMostRecentDocuments } from './state/actions';
+import MostRecentDocumentsComponent from './MostRecentDocuments';
+
+const mapStateToProps = state => ({
+  data: state.mostRecentDocuments.data,
+  error: state.mostRecentDocuments.error,
+  isLoading: state.mostRecentDocuments.isLoading,
+  hasError: state.mostRecentDocuments.hasError,
+});
+
+const mapDispatchToProps = dispatch => ({
+  fetchMostRecentDocuments: () => dispatch(fetchMostRecentDocuments()),
+});
+
+export const MostRecentDocuments = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(MostRecentDocumentsComponent);

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/MostRecentDocuments/state/__tests__/actions.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/MostRecentDocuments/state/__tests__/actions.js
@@ -1,0 +1,86 @@
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import * as actions from '../actions';
+import { initialState } from '../reducer';
+import * as types from '../types';
+import { document as documentApi } from '../../../../../../../common/api';
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+
+const mockFetchRecentlyAddedDocs = jest.fn();
+documentApi.list = mockFetchRecentlyAddedDocs;
+
+const response = { data: {} };
+const expectedPayload = {};
+
+let store;
+beforeEach(() => {
+  mockFetchRecentlyAddedDocs.mockClear();
+
+  store = mockStore(initialState);
+  store.clearActions();
+});
+
+describe('Recently added documents actions', () => {
+  describe('Fetch most recently added documents tests', () => {
+    it('should dispatch an action when fetching most recently added documents', done => {
+      mockFetchRecentlyAddedDocs.mockResolvedValue(response);
+
+      const expectedActions = [
+        {
+          type: types.IS_LOADING,
+        },
+      ];
+
+      store.dispatch(actions.fetchMostRecentDocuments()).then(() => {
+        expect(mockFetchRecentlyAddedDocs).toHaveBeenCalledWith(
+          '&sort=-mostrecent'
+        );
+        const actions = store.getActions();
+        expect(actions[0]).toEqual(expectedActions[0]);
+        done();
+      });
+    });
+
+    it('should dispatch an action when most recently added documents fetch succeeds', done => {
+      mockFetchRecentlyAddedDocs.mockResolvedValue(response);
+
+      const expectedActions = [
+        {
+          type: types.SUCCESS,
+          payload: expectedPayload,
+        },
+      ];
+
+      store.dispatch(actions.fetchMostRecentDocuments()).then(() => {
+        expect(mockFetchRecentlyAddedDocs).toHaveBeenCalledWith(
+          '&sort=-mostrecent'
+        );
+        const actions = store.getActions();
+        expect(actions[1]).toEqual(expectedActions[0]);
+        done();
+      });
+    });
+
+    it('should dispatch an action when most recently added documents fetch fails', done => {
+      mockFetchRecentlyAddedDocs.mockRejectedValue([500, 'Error']);
+
+      const expectedActions = [
+        {
+          type: types.HAS_ERROR,
+          payload: [500, 'Error'],
+        },
+      ];
+
+      store.dispatch(actions.fetchMostRecentDocuments()).then(() => {
+        expect(mockFetchRecentlyAddedDocs).toHaveBeenCalledWith(
+          '&sort=-mostrecent'
+        );
+        const actions = store.getActions();
+        expect(actions[1]).toEqual(expectedActions[0]);
+        done();
+      });
+    });
+  });
+});

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/MostRecentDocuments/state/__tests__/reducer.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/MostRecentDocuments/state/__tests__/reducer.js
@@ -1,0 +1,45 @@
+import reducer, { initialState } from '../reducer';
+import * as types from '../types';
+
+describe('Fetch most recently added documents reducer', () => {
+  it('should have initial state', () => {
+    expect(reducer(undefined, {})).toEqual(initialState);
+  });
+
+  it('should change loading state on loading action', () => {
+    const action = {
+      type: types.IS_LOADING,
+    };
+    expect(reducer(initialState, action)).toEqual({
+      ...initialState,
+      isLoading: true,
+    });
+  });
+
+  it('should change data state on success action', () => {
+    const document = { document_id: '123456' };
+    const action = {
+      type: types.SUCCESS,
+      payload: document,
+    };
+    expect(reducer(initialState, action)).toEqual({
+      ...initialState,
+      isLoading: false,
+      data: document,
+      hasError: false,
+    });
+  });
+
+  it('should change error state on error action', () => {
+    const action = {
+      type: types.HAS_ERROR,
+      payload: 'Error',
+    };
+    expect(reducer(initialState, action)).toEqual({
+      ...initialState,
+      isLoading: false,
+      error: 'Error',
+      hasError: true,
+    });
+  });
+});

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/MostRecentDocuments/state/actions.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/MostRecentDocuments/state/actions.js
@@ -1,0 +1,29 @@
+import { IS_LOADING, SUCCESS, HAS_ERROR } from './types';
+import { document as documentApi } from '../../../../../../common/api';
+import { sendErrorNotification } from '../../../../../../common/components/Notifications';
+
+export const fetchMostRecentDocuments = () => {
+  return async dispatch => {
+    try {
+      dispatch({
+        type: IS_LOADING,
+      });
+      const response = await documentApi.list(
+        documentApi
+          .query()
+          .withSort('-mostrecent')
+          .qs()
+      );
+      dispatch({
+        type: SUCCESS,
+        payload: response.data,
+      });
+    } catch (error) {
+      dispatch({
+        type: HAS_ERROR,
+        payload: error,
+      });
+      dispatch(sendErrorNotification(error));
+    }
+  };
+};

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/MostRecentDocuments/state/reducer.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/MostRecentDocuments/state/reducer.js
@@ -1,0 +1,32 @@
+import { IS_LOADING, SUCCESS, HAS_ERROR } from './types';
+
+export const initialState = {
+  isLoading: true,
+  hasError: false,
+  data: { hits: [], total: 0 },
+  error: {},
+};
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case IS_LOADING:
+      return { ...state, isLoading: true };
+    case SUCCESS:
+      return {
+        ...state,
+        isLoading: false,
+        data: action.payload,
+        error: {},
+        hasError: false,
+      };
+    case HAS_ERROR:
+      return {
+        ...state,
+        isLoading: false,
+        error: action.payload,
+        hasError: true,
+      };
+    default:
+      return state;
+  }
+};

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/MostRecentDocuments/state/types.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/MostRecentDocuments/state/types.js
@@ -1,0 +1,3 @@
+export const IS_LOADING = 'fetchMostRecentDocuments/IS_LOADING';
+export const SUCCESS = 'fetchMostRecentDocuments/SUCCESS';
+export const HAS_ERROR = 'fetchMostRecentDocuments/HAS_ERROR';

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/index.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/components/index.js
@@ -1,0 +1,2 @@
+export { MostLoanedDocuments } from './MostLoanedDocuments';
+export { MostRecentDocuments } from './MostRecentDocuments';

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/config.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/config.js
@@ -1,0 +1,20 @@
+const maxItemsToDisplay = 8;
+const document_type = 'BOOK';
+
+const helperFields = [
+  {
+    name: 'author',
+    field: 'authors.full_name',
+    defaultValue: '"Doe, John"',
+  },
+  {
+    name: 'created',
+    field: '_created',
+  },
+];
+
+export default {
+  MAX_ITEMS_TO_DISPLAY: maxItemsToDisplay,
+  DOCUMENT_TYPE: document_type,
+  HELPER_FIELDS: helperFields,
+};

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/reducer.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/Home/reducer.js
@@ -1,0 +1,7 @@
+export {
+  default as mostLoanedDocumentsReducer,
+} from './components/MostLoanedDocuments/state/reducer';
+
+export {
+  default as mostRecentDocumentsReducer,
+} from './components/MostRecentDocuments/state/reducer';

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/components/Header/Header.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/components/Header/Header.js
@@ -68,11 +68,12 @@ export default class Header extends Component {
         fixed="top"
         inverted
         className="header-menu"
+        widths={3}
       >
-        <Menu.Item header className="logo">
-          <Link to="/">Library</Link>
+        <Menu.Item>
+          <Link to="/">ILS</Link>
         </Menu.Item>
-        <Menu.Item position="right">{this.renderRightMenuItem()}</Menu.Item>
+        <Menu.Item>{this.renderRightMenuItem()}</Menu.Item>
       </Menu>
     );
   }

--- a/invenio_app_ils/ui/src/invenio_app_ils/routes/urls.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/routes/urls.js
@@ -10,6 +10,7 @@ const FrontSiteRoutesList = {
 };
 
 const FrontSiteRoutesGenerators = {
+  documentsListWithQuery: qs => `${FrontSiteRoutesList.documentsList}?q=${qs}`,
   documentDetailsFor: documentPid =>
     generatePath(FrontSiteRoutesList.documentDetails, {
       documentPid: documentPid,

--- a/invenio_app_ils/ui/src/invenio_app_ils/store.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/store.js
@@ -35,6 +35,10 @@ import {
 } from './pages/backoffice/Home/reducer';
 import { notificationsReducer } from './common/components/Notifications/reducer';
 
+import {
+  mostLoanedDocumentsReducer,
+  mostRecentDocumentsReducer,
+} from './pages/frontsite/Home/reducer';
 import { documentsDetailsReducer } from './pages/frontsite/DocumentsDetails/reducer';
 
 const rootReducer = combineReducers({
@@ -61,6 +65,8 @@ const rootReducer = combineReducers({
   itemsSearchInput: itemsSearchByBarcodeReducer,
   patronItemsCheckout: patronItemCheckoutReducer,
   notifications: notificationsReducer,
+  mostLoanedDocuments: mostLoanedDocumentsReducer,
+  mostRecentDocuments: mostRecentDocumentsReducer,
 });
 
 const composeEnhancers = composeWithDevTools({


### PR DESCRIPTION
Right now, the recommended items are centered, I could also put them to the left/right side, however this won't be a visible problem once we have more than 8 items or so.
The PR should be merged after the search page, as there are some fixes there, and the search needs to link to the book search, not the backoffice documents search.

![Screenshot from 2019-04-25 13-53-06](https://user-images.githubusercontent.com/47737538/56733956-e2702600-6761-11e9-9cc8-7b891fc7e65a.png)
![Screenshot from 2019-04-25 13-53-30](https://user-images.githubusercontent.com/47737538/56733961-e439e980-6761-11e9-9a51-7fcb742bd893.png)
( closes #218)