### PR TITLE
item: fix date type in schema

### DIFF
--- a/invenio_app_ils/mappings/v6/items/item-v1.0.0.json
+++ b/invenio_app_ils/mappings/v6/items/item-v1.0.0.json
@@ -53,8 +53,7 @@
               "type": "keyword"
             },
             "transaction_date": {
-              "type": "date",
-              "format": "yyyy-MM-dd"
+              "type": "date"
             },
             "patron_pid": {
               "type": "keyword"
@@ -66,19 +65,16 @@
               "type": "keyword"
             },
             "end_date": {
-              "type": "date",
-              "format": "yyyy-MM-dd"
+              "type": "date"
             },
             "state": {
               "type": "keyword"
             },
             "start_date": {
-              "type": "date",
-              "format": "yyyy-MM-dd"
+              "type": "date"
             },
             "request_expire_date": {
-              "type": "date",
-              "format": "yyyy-MM-dd"
+              "type": "date"
             },
             "pickup_location_pid": {
               "type": "keyword"


### PR DESCRIPTION
* previous date type was not aligned with invenio-circulation
* ( closes #282 )
* ( closes #252 )

invenio-circulation produces different date format, and when the output (loan) was inserted to circulation_status it causes mapping error in ES