### PR TITLE
Elastic search delay as constant

### DIFF
--- a/invenio_app_ils/ui/src/invenio_app_ils/common/config.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/config.js
@@ -8,4 +8,4 @@ export const invenioConfig = getInvenioConfig();
 
 // NOTE: the delay that is used when we fire a request with setTimeOut
 // in order to give some time to elastic search to index.
-export const TIMEOUT_DELAY = 3000;
+export const ES_DELAY = 3000;

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/LocationList/state/actions.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/LocationList/state/actions.js
@@ -1,5 +1,5 @@
 import { location as locationApi } from '../../../../common/api';
-import { TIMEOUT_DELAY } from '../../../../common/config';
+import { ES_DELAY } from '../../../../common/config';
 import {
   IS_LOADING,
   SUCCESS,
@@ -58,7 +58,7 @@ export const deleteLocation = locationPid => {
               `The location ${locationPid} has been deleted.`
             )
           );
-        }, TIMEOUT_DELAY);
+        }, ES_DELAY);
       })
       .catch(error => {
         dispatch({

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/PatronDetails/components/ItemsSearch/components/ResultsList/ResultsList.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/PatronDetails/components/ItemsSearch/components/ResultsList/ResultsList.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { ResultsTable } from '../../../../../../../common/components';
 import { Button, Modal, Header, Icon } from 'semantic-ui-react';
 import { ResultsTableFormatter as formatter } from '../../../../../../../common/components';
-import { invenioConfig } from '../../../../../../../common/config';
+import { invenioConfig, ES_DELAY } from '../../../../../../../common/config';
 import _isEmpty from 'lodash/isEmpty';
 import pick from 'lodash/pick';
 
@@ -25,7 +25,7 @@ export class ResultsList extends Component {
       this.clearResults();
       setTimeout(() => {
         this.fetchPatronCurrentLoans(patron);
-      }, 3000);
+      }, ES_DELAY);
     });
 
   actions(item, itemState) {

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/PatronDetails/components/ItemsSearch/state/actions.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/PatronDetails/components/ItemsSearch/state/actions.js
@@ -5,6 +5,7 @@ import {
   QUERY_STRING_UPDATE,
   CLEAR_SEARCH,
 } from './types';
+import { ES_DELAY } from '../../../../../../common/config';
 import { item as itemApi } from '../../../../../../common/api';
 import { fetchPatronCurrentLoans } from '../../PatronCurrentLoans/state/actions';
 import { sendErrorNotification } from '../../../../../../common/components/Notifications';
@@ -55,5 +56,5 @@ export const clearResults = () => {
 };
 
 export const fetchUpdatedCurrentLoans = patronPid => {
-  return fetchPatronCurrentLoans(patronPid, 3000);
+  return fetchPatronCurrentLoans(patronPid, ES_DELAY);
 };

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/PatronDetails/components/PatronCurrentLoans/state/__tests__/actions.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/PatronDetails/components/PatronCurrentLoans/state/__tests__/actions.js
@@ -4,6 +4,7 @@ import * as actions from '../actions';
 import { initialState } from '../reducer';
 import * as types from '../types';
 import { loan as loanApi } from '../../../../../../../common/api';
+import { ES_DELAY } from '../../../../../../../common/config';
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
@@ -96,7 +97,7 @@ describe('Patron current loans tests', () => {
         type: types.IS_LOADING,
       };
 
-      store.dispatch(actions.fetchPatronCurrentLoans(2, 3000)).then(e => {
+      store.dispatch(actions.fetchPatronCurrentLoans(2, ES_DELAY)).then(e => {
         expect(mockFetchPatronCurrentLoans).toHaveBeenCalledWith(
           '(patron_pid:2 AND state:ITEM_ON_LOAN)&sort=-mostrecent'
         );


### PR DESCRIPTION
Suggestion for further refactor.

ResultsTable accepts `showMaxRows`. Across our code this property is mapped to another property in the wrapper component. A few examples, showMaxEntries, showItems, showPendingLoans, showPastLoans etc .. Despite their different name they all refer to the same thing, the amount of rows that will be displayed.