### PR TITLE
Required document_pid on document create

### DIFF
--- a/invenio_app_ils/records/loaders/schemas/json/document.py
+++ b/invenio_app_ils/records/loaders/schemas/json/document.py
@@ -20,7 +20,7 @@ class DocumentSchemaV1(RecordMetadataSchemaJSONV1):
         """Return pid_field value."""
         return Document.pid_field
 
-    document_pid = fields.Str(required=True)
+    document_pid = fields.Str()
     title = fields.Str()
     authors = fields.Str()
     circulation = fields.Str()


### PR DESCRIPTION
When we are creating a document from the editor, we receive a missing property error for `document_pid`, which obviously doesn't exist before the record gets created. 

I am speculating this is a transferred error.