### PR TITLE
add selector component and modify keywords

### DIFF
--- a/invenio_app_ils/ui/src/invenio_app_ils/common/api/index.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/api/index.js
@@ -1,18 +1,9 @@
-import { document } from './documents/document';
-import { http } from './base';
-import { item } from './items/item';
-import { eitem } from './eitems/eitem';
-import { loan } from './loans/loan';
-import { patron } from './patrons/patron';
-import { location } from './locations/location';
-import { internalLocation } from './locations/internalLocation';
-export {
-  document,
-  http,
-  item,
-  eitem,
-  loan,
-  patron,
-  location,
-  internalLocation,
-};
+export { document } from './documents/document';
+export { http } from './base';
+export { item } from './items/item';
+export { eitem } from './eitems/eitem';
+export { loan } from './loans/loan';
+export { patron } from './patrons/patron';
+export { location } from './locations/location';
+export { internalLocation } from './locations/internalLocation';
+export { keyword } from './keywords/keyword';

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/api/keywords/keyword.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/api/keywords/keyword.js
@@ -1,0 +1,20 @@
+import { http } from '../base';
+import { serializer } from './serializer';
+
+const keywordURL = '/keywords/';
+
+const list = query => {
+  return http.get(`${keywordURL}?q=${query}`).then(response => {
+    response.data.total = response.data.hits.total;
+    response.data.hits = response.data.hits.hits.map(hit =>
+      serializer.fromJSON(hit)
+    );
+    return response;
+  });
+};
+
+export const keyword = {
+  list: list,
+  serializer: serializer,
+  url: keywordURL,
+};

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/api/keywords/serializer.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/api/keywords/serializer.js
@@ -1,0 +1,20 @@
+import _isEmpty from 'lodash/isEmpty';
+import { fromISO } from '../date';
+
+function serializeResponse(hit) {
+  let result = {};
+  if (!_isEmpty(hit)) {
+    result['id'] = hit.id;
+    result['created'] = fromISO(hit.created);
+    result['updated'] = fromISO(hit.updated);
+    if (!_isEmpty(hit.metadata)) {
+      result['metadata'] = hit.metadata;
+      result['keyword_pid'] = hit.metadata.keyword_pid;
+    }
+  }
+  return result;
+}
+
+export const serializer = {
+  fromJSON: serializeResponse,
+};

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/ESSelector.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/ESSelector.js
@@ -1,0 +1,78 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { List, Container, Icon } from 'semantic-ui-react';
+import isEmpty from 'lodash/isEmpty';
+import { HitsSearch } from './HitsSearch';
+import './ESSelector.scss';
+
+export default class ESSelector extends Component {
+  constructor(props) {
+    super(props);
+
+    this.searchRef = null;
+    this.props.updateSelections(props.initialSelections);
+  }
+
+  removeSelection = selection => {
+    if (this.searchRef) {
+      this.searchRef.searchInputRef.focus();
+    }
+    this.props.removeSelection(selection);
+  };
+
+  renderSelections = () => (
+    <Container className="result-selections">
+      <List divided relaxed>
+        {this.props.selections.map(selection => (
+          <List.Item key={selection.id}>
+            <List.Icon name="angle right" size="small" verticalAlign="middle" />
+            <List.Content onClick={() => this.removeSelection(selection)}>
+              <List.Header as="a">
+                <span className="extra">{selection.extra}</span>
+                {selection.title}
+                <Icon name="delete" />
+              </List.Header>
+              <List.Description as="a">
+                {selection.description}
+              </List.Description>
+            </List.Content>
+          </List.Item>
+        ))}
+      </List>
+    </Container>
+  );
+
+  render() {
+    return (
+      <div id="es-selector">
+        <HitsSearch
+          query={this.props.query}
+          delay={this.props.delay}
+          alwaysWildcard={this.props.alwaysWildcard}
+          minCharacters={this.props.minCharacters}
+          onSelect={result =>
+            this.props.multiple
+              ? this.props.addMultiSelection(result)
+              : this.props.addSingleSelection(result)
+          }
+          ref={element => (this.searchRef = element)}
+        />
+        {!isEmpty(this.props.selections) && this.renderSelections()}
+      </div>
+    );
+  }
+}
+
+ESSelector.propTypes = {
+  alwaysWildcard: PropTypes.bool,
+  delay: PropTypes.number,
+  initialSelections: PropTypes.array,
+  minCharacters: PropTypes.number,
+  multiple: PropTypes.bool,
+  query: PropTypes.func.isRequired,
+};
+
+ESSelector.defaultProps = {
+  delay: 250,
+  minCharacters: 3,
+};

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/ESSelector.scss
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/ESSelector.scss
@@ -1,0 +1,30 @@
+$es_red: #d41414;
+
+#es-selector {
+  .input {
+    width: 100% !important;
+  }
+
+  .error {
+    .input {
+      color: $es_red;
+    }
+
+    input {
+      border-color: $es_red;
+    }
+
+    .results .title {
+      color: $es_red;
+    }
+  }
+
+  .result-selections {
+    .extra {
+      color: #21ba45;
+      float: right;
+      font-size: 0.85rem;
+      font-weight: 500;
+    }
+  }
+}

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/ESSelectorModal.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/ESSelectorModal.js
@@ -1,0 +1,67 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Button, Modal } from 'semantic-ui-react';
+import { ESSelector } from './';
+import './ESSelector.scss';
+
+export default class ESSelectorModal extends Component {
+  state = { visible: false };
+
+  constructor(props) {
+    super(props);
+    this.selectorRef = null;
+  }
+
+  toggle = () => this.setState({ visible: !this.state.visible });
+
+  save = () => {
+    const { onSave } = this.props;
+    if (onSave) {
+      onSave(this.props.selections);
+    }
+    this.toggle();
+  };
+
+  render() {
+    const { title } = this.props;
+    const trigger = React.cloneElement(this.props.trigger, {
+      onClick: this.toggle,
+    });
+
+    return (
+      <Modal
+        id="es-selector-modal"
+        open={this.state.visible}
+        trigger={trigger}
+        size="tiny"
+        centered={false}
+        onClose={this.toggle}
+      >
+        <Modal.Header>{title}</Modal.Header>
+        <Modal.Content>
+          <ESSelector {...this.props} />
+        </Modal.Content>
+        <Modal.Actions>
+          <Button color="black" onClick={this.toggle}>
+            Close
+          </Button>
+          <Button
+            positive
+            icon="checkmark"
+            labelPosition="right"
+            content="Save"
+            onClick={this.save}
+          />
+        </Modal.Actions>
+      </Modal>
+    );
+  }
+}
+
+ESSelectorModal.propTypes = {
+  alwaysWildcard: PropTypes.bool,
+  multiple: PropTypes.bool,
+  trigger: PropTypes.node.isRequired,
+  title: PropTypes.string,
+  initialSelections: PropTypes.array,
+};

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/HitsSearch.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/HitsSearch.js
@@ -1,0 +1,114 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import debounce from 'lodash/debounce';
+import { Search } from 'semantic-ui-react';
+import { serializeError, serializeHit } from './serializer';
+
+const initialState = {
+  isLoading: false,
+  hasError: false,
+  results: [],
+  query: null,
+  value: '',
+};
+
+const ResultRenderer = ({ id, title, description, extra }) => (
+  <div key={id} className="content">
+    {extra && <div className="price">{extra}</div>}
+    {title && <div className="title">{title}</div>}
+    {description && <div className="description">{description}</div>}
+  </div>
+);
+
+export class HitsSearch extends Component {
+  state = initialState;
+
+  constructor(props) {
+    super(props);
+    this.searchInputRef = null;
+  }
+
+  clear = () => this.setState(initialState);
+
+  onSelectResult = (event, { result }) => {
+    if (this.state.hasError) return;
+
+    if (this.props.onSelect) {
+      this.props.onSelect(result);
+    }
+    this.setState(initialState);
+    this.searchInputRef.focus();
+  };
+
+  search = debounce(async searchQuery => {
+    try {
+      const queryString = this.props.alwaysWildcard
+        ? searchQuery + '*'
+        : searchQuery;
+      const response = await this.props.query(queryString);
+      const results = [];
+      for (let hit of response.data.hits) {
+        results.push(serializeHit(hit));
+      }
+      if (this.props.onResults) {
+        this.props.onResults(results);
+      }
+
+      const { value, query } = this.state;
+      if (value !== query) {
+        this.onSearchChange(null, { value: value });
+      }
+
+      this.setState({
+        isLoading: false,
+        hasError: false,
+        nextQuery: null,
+        results: results,
+      });
+    } catch (error) {
+      this.setState({
+        isLoading: false,
+        hasError: true,
+        results: [serializeError(error)],
+      });
+    }
+  }, this.props.delay);
+
+  onSearchChange = (event, { value }) => {
+    if (value.length < this.props.minCharacters) {
+      this.setState({ value });
+      return;
+    }
+
+    this.setState({ isLoading: true, value: value, query: value });
+    this.search(value);
+  };
+
+  componentDidMount() {
+    if (this.searchInputRef) {
+      this.searchInputRef.focus();
+    }
+  }
+
+  render() {
+    const { hasError, isLoading, results, value } = this.state;
+    return (
+      <Search
+        fluid
+        className={hasError ? 'error' : null}
+        loading={isLoading}
+        minCharacters={this.props.minCharacters}
+        onResultSelect={this.onSelectResult}
+        onSearchChange={this.onSearchChange}
+        results={results}
+        value={value}
+        resultRenderer={ResultRenderer}
+        input={{ ref: element => (this.searchInputRef = element) }}
+      />
+    );
+  }
+}
+
+HitsSearch.propTypes = {
+  delay: PropTypes.number.isRequired,
+};

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/__tests__/HitsSearch.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/__tests__/HitsSearch.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import { HitsSearch } from '../HitsSearch';
+
+describe('HitsSearch tests', () => {
+  let component;
+  afterEach(() => {
+    if (component) {
+      component.unmount();
+    }
+  });
+
+  it('should load the selector component', () => {
+    const component = shallow(<HitsSearch delay={0} query={() => {}} />);
+    expect(component).toMatchSnapshot();
+  });
+
+  it('should search when text input changes', done => {
+    const mockedApi = query => {
+      expect(query).toBe('test');
+      done();
+    };
+
+    component = mount(<HitsSearch delay={0} query={mockedApi} />);
+    component.find('input').simulate('change', {
+      target: { value: 'test' },
+    });
+  });
+
+  it('should return one result', done => {
+    const api = async query => {
+      const response = {
+        data: {
+          hits: [],
+        },
+      };
+      return await response;
+    };
+
+    const onResults = results => {
+      expect(results.length).toBe(0);
+      done();
+    };
+
+    component = mount(
+      <HitsSearch query={api} delay={0} onResults={onResults} />
+    );
+    component.find('input').simulate('change', {
+      target: { value: 'test' },
+    });
+  });
+
+  it('should return one result', done => {
+    const api = async query => {
+      const response = {
+        data: {
+          hits: [
+            {
+              id: 1,
+              keyword_pid: '1',
+              metadata: {
+                $schema:
+                  'https://127.0.0.1:5000/schemas/keywords/keyword-v1.0.0.json',
+                keyword_pid: '1',
+                name: 'Dolorem',
+                provenance: 'Quaerat',
+              },
+            },
+          ],
+        },
+      };
+      return await response;
+    };
+
+    const onResults = results => {
+      expect(results.length).toBe(1);
+      expect(results[0].title).toBe('Dolorem');
+      done();
+    };
+
+    component = mount(
+      <HitsSearch query={api} delay={0} onResults={onResults} />
+    );
+    component.find('input').simulate('change', {
+      target: { value: 'test' },
+    });
+  });
+});

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/__tests__/__snapshots__/HitsSearch.js.snap
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/__tests__/__snapshots__/HitsSearch.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HitsSearch tests should load the selector component 1`] = `
+<Search
+  className={null}
+  fluid={true}
+  icon="search"
+  input={
+    Object {
+      "ref": [Function],
+    }
+  }
+  loading={false}
+  minCharacters={1}
+  noResultsMessage="No results found."
+  onResultSelect={[Function]}
+  onSearchChange={[Function]}
+  resultRenderer={[Function]}
+  results={Array []}
+  showNoResults={true}
+  value=""
+/>
+`;

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/index.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/index.js
@@ -1,0 +1,28 @@
+import { connect } from 'react-redux';
+import ESSelectorComponent from './ESSelector';
+import ESSelectorModalComponent from './ESSelectorModal';
+import {
+  addMultiSelection,
+  addSingleSelection,
+  removeSelection,
+  updateSelections,
+} from './state/actions';
+
+const mapStateToProps = state => ({
+  selections: state.esSelector.selections,
+});
+const mapDispatchToProps = dispatch => ({
+  updateSelections: selections => dispatch(updateSelections(selections)),
+  addMultiSelection: selection => dispatch(addMultiSelection(selection)),
+  addSingleSelection: selection => dispatch(addSingleSelection(selection)),
+  removeSelection: selection => dispatch(removeSelection(selection)),
+});
+
+export const ESSelector = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ESSelectorComponent);
+export const ESSelectorModal = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ESSelectorModalComponent);

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/reducer.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/reducer.js
@@ -1,0 +1,1 @@
+export { default as esSelectorReducer } from './state/reducer';

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/serializer.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/serializer.js
@@ -1,0 +1,139 @@
+const formatPid = pid => `PID: ${pid}`;
+
+export const serializeError = error => ({
+  id: 'error',
+  key: 'error',
+  title: error.toString(),
+  description: 'Failed to retrieve search results.',
+  extra: '',
+});
+
+export const serializeDocument = metadata => ({
+  id: metadata.document_pid,
+  key: metadata.document_pid,
+  title: metadata.title,
+  description: metadata.authors
+    ? `Authors: ${metadata.authors.join(', ')}`
+    : 'Document',
+  extra: formatPid(metadata.document_pid),
+  metadata: metadata,
+});
+
+export const serializeEItem = metadata => ({
+  id: metadata.eitem_pid,
+  key: metadata.eitem_pid,
+  title: metadata.document.title,
+  description: `Open access: ${metadata.open_access ? 'Yes' : 'No'}`,
+  extra: formatPid(metadata.eitem_pid),
+  metadata: metadata,
+});
+
+export const serializeInternalLocation = metadata => ({
+  id: metadata.internal_location_pid,
+  key: metadata.internal_location_pid,
+  title: metadata.name,
+  description: metadata.location ? `Location: ${metadata.location.name}` : null,
+  extra: formatPid(metadata.internal_location_pid),
+  metadata: metadata,
+});
+
+export const serializeItem = metadata => ({
+  id: metadata.item_pid,
+  key: metadata.item_pid,
+  title: metadata.medium,
+  description: metadata.shelf ? `Shelf: ${metadata.shelf}` : null,
+  extra: formatPid(metadata.item_pid),
+  metadata: metadata,
+});
+
+export const serializeKeyword = metadata => ({
+  id: metadata.keyword_pid,
+  key: metadata.keyword_pid,
+  title: metadata.name,
+  description: metadata.provenance
+    ? `Provenance: ${metadata.provenance}`
+    : null,
+  extra: formatPid(metadata.keyword_pid),
+  metadata: metadata,
+});
+
+export const serializeLoan = metadata => ({
+  id: metadata.loan_pid,
+  key: metadata.loan_pid,
+  title: metadata.state,
+  description: metadata.document_pid
+    ? `Document PID: ${metadata.document_pid}`
+    : null,
+  extra: formatPid(metadata.loan_pid),
+  metadata: metadata,
+});
+
+export const serializeLocation = metadata => ({
+  id: metadata.location_pid,
+  key: metadata.location_pid,
+  title: metadata.name,
+  description: metadata.address ? `Address: ${metadata.address}` : null,
+  extra: formatPid(metadata.location_pid),
+  metadata: metadata,
+});
+
+export const serializePatron = metadata => ({
+  id: metadata.id,
+  key: metadata.id,
+  title: metadata.email,
+  description: metadata.name ? `Name: ${metadata.name}` : null,
+  extra: `ID: ${metadata.id}`,
+  metadata: metadata,
+});
+
+export const serializeSeries = metadata => ({
+  id: metadata.series_pid,
+  key: metadata.series_pid,
+  title: metadata.title,
+  description: metadata.mode_of_issuance
+    ? `Mode of Issuance: ${metadata.mode_of_issuance}`
+    : null,
+  extra: `ID: ${metadata.series_pid}`,
+  metadata: metadata,
+});
+
+export const serializeHit = hit => {
+  const { metadata } = hit;
+  const schema = metadata['$schema'];
+
+  const hasSchema = text => schema.includes(text);
+
+  let result = {};
+  if (schema) {
+    if (hasSchema('/schemas/loans/loan-v1')) {
+      result = serializeLoan(metadata);
+    } else if (hasSchema('/schemas/items/item-v1')) {
+      result = serializeItem(metadata);
+    } else if (hasSchema('/schemas/documents/document-v1')) {
+      result = serializeDocument(metadata);
+    } else if (hasSchema('/schemas/eitems/eitem-v1')) {
+      result = serializeEItem(metadata);
+    } else if (hasSchema('/schemas/internal_locations/internal_location-v1')) {
+      result = serializeInternalLocation(metadata);
+    } else if (hasSchema('/schemas/locations/location-v1')) {
+      result = serializeLocation(metadata);
+    } else if (hasSchema('/schemas/keywords/keyword-v1')) {
+      result = serializeKeyword(metadata);
+    } else if (hasSchema('/schemas/series/series-v1')) {
+      result = serializeSeries(metadata);
+    } else {
+      console.warn('failed to serialize hit: unknown schema ', schema);
+    }
+  } else {
+    // TODO: add a "fake" schema to patrons so we can check the type more easily
+    if (metadata.email) {
+      result = serializePatron(metadata);
+    } else {
+      console.warn('failed to serialize hit:', hit);
+    }
+  }
+
+  return {
+    ...result,
+  };
+};

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/state/__tests__/reducer.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/state/__tests__/reducer.js
@@ -1,0 +1,79 @@
+import reducer, { initialState } from '../reducer';
+import * as types from '../types';
+
+describe('Add selection tests', () => {
+  it('should have initial state', () => {
+    expect(reducer(undefined, {})).toEqual(initialState);
+  });
+
+  it('should update selections', () => {
+    const action = {
+      type: types.UPDATE_SELECTIONS,
+      payload: [{ id: 1, title: 'test' }],
+    };
+    expect(reducer(initialState, action)).toEqual({
+      ...initialState,
+      selections: [{ id: 1, title: 'test' }],
+    });
+  });
+
+  it('should add a single selection', () => {
+    const action1 = {
+      type: types.ADD_SINGLE_SELECTION,
+      payload: { id: 1, title: 'test' },
+    };
+    const action2 = {
+      type: types.ADD_SINGLE_SELECTION,
+      payload: { id: 2, title: 'hello' },
+    };
+    const step1 = reducer(initialState, action1);
+    expect(step1).toEqual({
+      ...initialState,
+      selections: [{ id: 1, title: 'test' }],
+    });
+    expect(reducer(step1, action2)).toEqual({
+      ...step1,
+      selections: [{ id: 2, title: 'hello' }],
+    });
+  });
+
+  it('should add multi-selection', () => {
+    const action1 = {
+      type: types.ADD_MULTI_SELECTION,
+      payload: { id: 1, title: 'test' },
+    };
+    const action2 = {
+      type: types.ADD_MULTI_SELECTION,
+      payload: { id: 2, title: 'hello' },
+    };
+    const step1 = reducer(initialState, action1);
+    expect(step1).toEqual({
+      ...initialState,
+      selections: [{ id: 1, title: 'test' }],
+    });
+    expect(reducer(step1, action2)).toEqual({
+      ...step1,
+      selections: [{ id: 1, title: 'test' }, { id: 2, title: 'hello' }],
+    });
+  });
+
+  it('should remove selection', () => {
+    const action1 = {
+      type: types.ADD_SINGLE_SELECTION,
+      payload: { id: 1, title: 'test' },
+    };
+    const action2 = {
+      type: types.REMOVE_SELECTION,
+      payload: { id: 1, title: 'hello' },
+    };
+    const step1 = reducer(initialState, action1);
+    expect(step1).toEqual({
+      ...initialState,
+      selections: [{ id: 1, title: 'test' }],
+    });
+    expect(reducer(step1, action2)).toEqual({
+      ...initialState,
+      selections: [],
+    });
+  });
+});

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/state/actions.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/state/actions.js
@@ -1,0 +1,26 @@
+import {
+  ADD_SINGLE_SELECTION,
+  ADD_MULTI_SELECTION,
+  REMOVE_SELECTION,
+  UPDATE_SELECTIONS,
+} from './types';
+
+export const updateSelections = selections => ({
+  type: UPDATE_SELECTIONS,
+  payload: selections,
+});
+
+export const addMultiSelection = selection => ({
+  type: ADD_MULTI_SELECTION,
+  payload: selection,
+});
+
+export const addSingleSelection = selection => ({
+  type: ADD_SINGLE_SELECTION,
+  payload: selection,
+});
+
+export const removeSelection = selection => ({
+  type: REMOVE_SELECTION,
+  payload: selection,
+});

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/state/reducer.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/state/reducer.js
@@ -1,0 +1,56 @@
+import cloneDeep from 'lodash/cloneDeep';
+import find from 'lodash/find';
+import {
+  ADD_SINGLE_SELECTION,
+  ADD_MULTI_SELECTION,
+  REMOVE_SELECTION,
+  UPDATE_SELECTIONS,
+} from './types';
+
+export const initialState = {
+  selections: [],
+};
+
+export default (state = initialState, action) => {
+  let selection;
+  let hasMatch;
+
+  switch (action.type) {
+    case UPDATE_SELECTIONS:
+      return {
+        ...state,
+        selections: cloneDeep(action.payload),
+      };
+    case ADD_SINGLE_SELECTION:
+      selection = action.payload;
+      hasMatch = find(state.selections, sel => sel.id === selection.id);
+      if (hasMatch) {
+        return state;
+      }
+
+      return {
+        ...state,
+        selections: [selection],
+      };
+    case ADD_MULTI_SELECTION:
+      selection = action.payload;
+      hasMatch = find(state.selections, sel => sel.id === selection.id);
+      if (hasMatch) {
+        return state;
+      }
+
+      return {
+        ...state,
+        selections: [...state.selections, selection],
+      };
+    case REMOVE_SELECTION:
+      return {
+        ...state,
+        selections: state.selections.filter(
+          selection => selection.id !== action.payload.id
+        ),
+      };
+    default:
+      return state;
+  }
+};

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/state/types.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/state/types.js
@@ -1,0 +1,4 @@
+export const UPDATE_SELECTIONS = 'esSelector/UPDATE_SELECTIONS';
+export const ADD_MULTI_SELECTION = 'esSelector/ADD_MULTI_SELECTION';
+export const ADD_SINGLE_SELECTION = 'esSelector/ADD_SINGLE_SELECTION';
+export const REMOVE_SELECTION = 'esSelector/REMOVE_SELECTION';

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/DocumentDetails/components/DocumentMetadata/DocumentMetadata.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/DocumentDetails/components/DocumentMetadata/DocumentMetadata.js
@@ -8,6 +8,7 @@ import {
   List,
   Label,
   Icon,
+  Button,
 } from 'semantic-ui-react';
 import PropTypes from 'prop-types';
 import isEmpty from 'lodash/isEmpty';
@@ -18,9 +19,12 @@ import {
   document as documentApi,
   loan as loanApi,
   item as itemApi,
+  keyword as keywordApi,
 } from '../../../../../common/api';
 import { BackOfficeRoutes, openRecordEditor } from '../../../../../routes/urls';
 import { DeleteRecordModal } from '../../../components/DeleteRecordModal';
+import { ESSelectorModal } from '../../../../../common/components/ESSelector';
+import { serializeKeyword } from '../../../../../common/components/ESSelector/serializer';
 import { DocumentAccessRestrictions } from '../DocumentAccessRestrictions';
 
 const getReadAccessSet = document => {
@@ -35,7 +39,14 @@ export default class DocumentMetadata extends Component {
     this.deleteDocument = props.deleteDocument;
   }
 
+  updateKeywords = results => {
+    const documentPid = this.props.documentDetails.metadata.document_pid;
+    const keywordPids = results.map(result => result.metadata.keyword_pid);
+    this.props.updateDocument(documentPid, '/keyword_pids', keywordPids);
+  };
+
   renderKeywords(keywords) {
+    const keywordSelection = keywords.map(serializeKeyword);
     return (
       <List horizontal>
         {keywords.map(keyword => (
@@ -52,6 +63,16 @@ export default class DocumentMetadata extends Component {
             </Link>
           </List.Item>
         ))}
+        <List.Item>
+          <ESSelectorModal
+            multiple
+            initialSelections={keywordSelection}
+            trigger={<Button basic color="blue" size="small" content="edit" />}
+            query={keywordApi.list}
+            title="Select Keywords"
+            onSave={this.updateKeywords}
+          />
+        </List.Item>
       </List>
     );
   }
@@ -121,13 +142,11 @@ export default class DocumentMetadata extends Component {
     const rows = [
       { name: 'Title', value: document.metadata.title },
       { name: 'Authors', value: document.metadata.authors },
-    ];
-    if (!isEmpty(document.metadata.keywords)) {
-      rows.push({
+      {
         name: 'Keywords',
         value: this.renderKeywords(document.metadata.keywords),
-      });
-    }
+      },
+    ];
     return rows;
   }
 

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/DocumentDetails/components/DocumentMetadata/index.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/DocumentDetails/components/DocumentMetadata/index.js
@@ -2,7 +2,11 @@ import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import DocumentMetadataComponent from './DocumentMetadata';
-import { deleteDocument, fetchDocumentDetails } from '../../state/actions';
+import {
+  deleteDocument,
+  fetchDocumentDetails,
+  updateDocument,
+} from '../../state/actions';
 
 const mapStateToProps = state => ({
   documentDetails: state.documentDetails.data,
@@ -13,6 +17,8 @@ const mapDispatchToProps = dispatch => ({
   fetchDocumentDetails: documentPid =>
     dispatch(fetchDocumentDetails(documentPid)),
   deleteDocument: documentPid => dispatch(deleteDocument(documentPid)),
+  updateDocument: (documentPid, path, value) =>
+    dispatch(updateDocument(documentPid, path, value)),
 });
 
 export const DocumentMetadata = compose(

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/DocumentDetails/state/actions.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/DocumentDetails/state/actions.js
@@ -69,3 +69,33 @@ export const deleteDocument = documentPid => {
     }
   };
 };
+
+export const updateDocument = (documentPid, path, value) => {
+  return async dispatch => {
+    dispatch({
+      type: IS_LOADING,
+    });
+
+    await documentApi
+      .patch(documentPid, [
+        {
+          op: 'replace',
+          path: path,
+          value: value,
+        },
+      ])
+      .then(response => {
+        dispatch({
+          type: SUCCESS,
+          payload: response.data,
+        });
+      })
+      .catch(error => {
+        dispatch({
+          type: HAS_ERROR,
+          payload: error,
+        });
+        dispatch(sendErrorNotification(error));
+      });
+  };
+};

--- a/invenio_app_ils/ui/src/invenio_app_ils/store.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/store.js
@@ -36,6 +36,7 @@ import {
   renewedLoansReducer,
 } from './pages/backoffice/Home/reducer';
 import { notificationsReducer } from './common/components/Notifications/reducer';
+import { esSelectorReducer } from './common/components/ESSelector/reducer';
 
 import {
   mostLoanedDocumentsReducer,
@@ -71,6 +72,7 @@ const rootReducer = combineReducers({
   notifications: notificationsReducer,
   mostLoanedDocuments: mostLoanedDocumentsReducer,
   mostRecentDocuments: mostRecentDocumentsReducer,
+  esSelector: esSelectorReducer,
 });
 
 const composeEnhancers = composeWithDevTools({


### PR DESCRIPTION
* Add/remove keywords from `Document`
* Component: Search and select hits from ElasticSearch
  * Single and multiple selection
  * Configurable search delay
  * Wildcard search
  * Supports search/select for:
    - `Document`
    - `EItem`
    - `InternalLocation`
    - `Items`
    - `Loans`
    - `Locations`
    - `Keyword`
    - `Patron`
    - `Series`

Multi-selection + update document keywords:
![keywords_new_480](https://user-images.githubusercontent.com/9783490/57536791-34f63880-7345-11e9-9f89-f13153d50019.gif)

Single selection + search by author:
![select-document_480](https://user-images.githubusercontent.com/9783490/57536797-37f12900-7345-11e9-962a-6a8d66290c68.gif)
