### PR TITLE
fix for cli minter

### DIFF
--- a/invenio_app_ils/cli.py
+++ b/invenio_app_ils/cli.py
@@ -19,7 +19,8 @@ from invenio_circulation.api import Loan
 from invenio_circulation.pidstore.pids import CIRCULATION_LOAN_PID_TYPE
 from invenio_db import db
 from invenio_indexer.api import RecordIndexer
-from invenio_pidstore.models import PersistentIdentifier, PIDStatus
+from invenio_pidstore.models import PersistentIdentifier, PIDStatus, \
+    RecordIdentifier
 from invenio_search import current_search
 
 from .indexer import PatronsIndexer
@@ -47,6 +48,7 @@ def minter(pid_type, pid_field, record):
         object_uuid=record.id,
         status=PIDStatus.REGISTERED,
     )
+    RecordIdentifier.next()
 
 
 class Holder():


### PR DESCRIPTION
Fixes an issue whereby the cli minter was not registering the record PIDs in the RecordIdentifier database, causing a "PIDAlreadyExists" error when trying to insert new records.

* The records were being minted without incrementing the RecordIdentifier database. When trying to add new records, the RecordIdentifier database would be empty, and so the next available record identifier would be "1". However, that pid will already exist since the previously created records have ids starting from 1. Also note the following, from the invenio pidstore docs:

> The feature is primarily provided to support legacy Invenio instances to continue their current record identifier scheme. For new instances we strong encourage to not use auto incrementing record identifiers, but instead use e.g. UUIDs as record identifiers.

(Closes #327)