### PR TITLE
backoffice: add cancel loan modal with cancel reason

### DIFF
--- a/invenio_app_ils/ui/src/invenio_app_ils/common/api/loans/loan.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/api/loans/loan.js
@@ -25,7 +25,7 @@ const postAction = (
   loan,
   transactionUserPid,
   transactionLocationPid,
-  shouldForceCheckout
+  params = {}
 ) => {
   const now = DateTime.local();
   const payload = {
@@ -33,7 +33,7 @@ const postAction = (
     patron_pid: loan.metadata.patron_pid,
     transaction_location_pid: transactionLocationPid,
     transaction_date: toISO(now),
-    force_checkout: shouldForceCheckout,
+    ...params,
   };
 
   if ('item_pid' in loan.metadata) {

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/LoanDetails/components/CancelLoanModal/CancelLoanModal.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/LoanDetails/components/CancelLoanModal/CancelLoanModal.js
@@ -1,0 +1,93 @@
+import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
+import { Button, Header, Icon, Input, Modal, Popup } from 'semantic-ui-react';
+import PropTypes from 'prop-types';
+import isEmpty from 'lodash/isEmpty';
+
+export default class CancelLoanModal extends Component {
+  state = {
+    open: false,
+    showPopup: false,
+    value: this.props.value,
+  };
+
+  hide = () => this.setState({ open: false, showPopup: false, value: '' });
+  show = () => this.setState({ open: true, showPopup: false, value: '' });
+
+  updateInputRef = element => {
+    this.inputRef = element
+      ? ReactDOM.findDOMNode(element).querySelector('input')
+      : null;
+  };
+
+  cancel = () => {
+    const { value } = this.state;
+    if (isEmpty(value)) {
+      this.setState({ showPopup: true });
+    } else {
+      this.props.action(value);
+      this.hide();
+    }
+  };
+
+  handleOnChange = (event, { value }) => {
+    const newState = { value };
+    if (this.state.showPopup && !isEmpty(value)) {
+      newState.showPopup = false;
+    }
+    this.setState(newState);
+  };
+
+  render() {
+    const { loan } = this.props;
+    return (
+      <Modal
+        basic
+        size="small"
+        trigger={<Button primary content="cancel" onClick={this.show} />}
+        open={this.state.open}
+        onClose={this.hide}
+      >
+        <Header content={`Cancel Loan #${loan.loan_pid}`} />
+        <Modal.Content>
+          <p>
+            You are about to cancel loan #{loan.loan_pid}. Please enter a reason
+            for cancelling this loan.
+          </p>
+          <Input
+            focus
+            fluid
+            placeholder="Enter a cancel reason..."
+            onChange={this.handleOnChange}
+            ref={this.updateInputRef}
+            value={this.state.value}
+          />
+          <Popup
+            context={this.inputRef}
+            content="Please specify a reason."
+            position="bottom left"
+            open={this.state.showPopup}
+          />
+        </Modal.Content>
+        <Modal.Actions>
+          <Button basic color="black" inverted onClick={this.hide}>
+            Back
+          </Button>
+          <Button color="red" inverted onClick={this.cancel}>
+            <Icon name="remove" /> Cancel Loan
+          </Button>
+        </Modal.Actions>
+      </Modal>
+    );
+  }
+}
+
+CancelLoanModal.propTypes = {
+  action: PropTypes.func.isRequired,
+  loan: PropTypes.object.isRequired,
+  value: PropTypes.string,
+};
+
+CancelLoanModal.defaultProps = {
+  value: '',
+};

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/LoanDetails/components/CancelLoanModal/__tests__/CancelLoanModal.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/LoanDetails/components/CancelLoanModal/__tests__/CancelLoanModal.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import CancelLoanModal from '../CancelLoanModal';
+import { item } from '../../../../../../common/api';
+import { doesNotReject } from 'assert';
+
+jest.mock('../../../../../../common/config');
+
+const loan = {
+  loan_pid: '1',
+};
+
+describe('CancelLoanModal tests', () => {
+  let component;
+  afterEach(() => {
+    if (component) {
+      component.unmount();
+    }
+  });
+
+  it('should load the cancel loan modal component', () => {
+    component = shallow(<CancelLoanModal action={() => {}} loan={loan} />);
+    expect(component).toMatchSnapshot();
+  });
+
+  it('should not perform loan action with an empty reason', () => {
+    const mockAction = jest.fn();
+    component = mount(<CancelLoanModal action={mockAction} loan={loan} />);
+    expect(component.state('open')).toEqual(false);
+    component.find('button').simulate('click');
+    expect(component.state('open')).toEqual(true);
+    const cancelButton = component.find('button.red');
+    expect(cancelButton).toHaveLength(1);
+
+    cancelButton.simulate('click');
+    expect(mockAction).not.toHaveBeenCalled();
+  });
+
+  it('should show a popup if trying to cancel without a reason', () => {
+    component = mount(<CancelLoanModal action={() => {}} loan={loan} />);
+    component.find('button').simulate('click');
+    expect(component.state('showPopup')).toEqual(false);
+    let popup = component.find('Popup');
+    const cancelButton = component.find('button.red');
+    expect(cancelButton).toHaveLength(1);
+    expect(popup.prop('open')).toEqual(false);
+
+    cancelButton.simulate('click');
+    popup = component.find('Popup');
+    expect(component.state('showPopup')).toEqual(true);
+    expect(popup).toHaveLength(1);
+    expect(popup.prop('open')).toEqual(true);
+  });
+
+  it('should perform the loan action given a reason', () => {
+    const value = 'test';
+    const mockAction = jest.fn();
+    component = mount(<CancelLoanModal action={mockAction} loan={loan} />);
+    component.find('button').simulate('click');
+    component.setState({ value: value });
+    expect(component.state('showPopup')).toEqual(false);
+
+    const cancelButton = component.find('button.red');
+    cancelButton.simulate('click');
+    expect(component.state('showPopup')).toEqual(false);
+    expect(mockAction).toHaveBeenCalledWith(value);
+  });
+});

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/LoanDetails/components/CancelLoanModal/__tests__/__snapshots__/CancelLoanModal.js.snap
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/LoanDetails/components/CancelLoanModal/__tests__/__snapshots__/CancelLoanModal.js.snap
@@ -1,0 +1,72 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CancelLoanModal tests should load the cancel loan modal component 1`] = `
+<Modal
+  basic={true}
+  centered={true}
+  closeOnDimmerClick={true}
+  closeOnDocumentClick={false}
+  dimmer={true}
+  eventPool="Modal"
+  onClose={[Function]}
+  open={false}
+  size="small"
+  trigger={
+    <Button
+      as="button"
+      content="cancel"
+      onClick={[Function]}
+      primary={true}
+    />
+  }
+>
+  <Header
+    content="Cancel Loan #1"
+  />
+  <ModalContent>
+    <p>
+      You are about to cancel loan #
+      1
+      . Please enter a reason for cancelling this loan.
+    </p>
+    <Input
+      fluid={true}
+      focus={true}
+      onChange={[Function]}
+      placeholder="Enter a cancel reason..."
+      type="text"
+      value=""
+    />
+    <Popup
+      content="Please specify a reason."
+      keepInViewPort={true}
+      on="hover"
+      open={false}
+      position="bottom left"
+    />
+  </ModalContent>
+  <ModalActions>
+    <Button
+      as="button"
+      basic={true}
+      color="black"
+      inverted={true}
+      onClick={[Function]}
+    >
+      Back
+    </Button>
+    <Button
+      as="button"
+      color="red"
+      inverted={true}
+      onClick={[Function]}
+    >
+      <Icon
+        as="i"
+        name="remove"
+      />
+       Cancel Loan
+    </Button>
+  </ModalActions>
+</Modal>
+`;

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/LoanDetails/components/CancelLoanModal/index.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/LoanDetails/components/CancelLoanModal/index.js
@@ -1,0 +1,1 @@
+export { default as CancelLoanModal } from './CancelLoanModal';

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/LoanDetails/components/LoanActions/LoanActions.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/LoanDetails/components/LoanActions/LoanActions.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { List, Button } from 'semantic-ui-react';
 import { omit } from 'lodash/object';
+import { CancelLoanModal } from '../CancelLoanModal';
 
 export default class LoanActions extends Component {
   constructor(props) {
@@ -14,16 +15,20 @@ export default class LoanActions extends Component {
       actions = omit(actions, 'checkout');
     }
     return Object.keys(actions).map(action => {
+      const loanAction = (cancelReason = null) =>
+        this.performLoanAction(pid, loan, actions[action], cancelReason);
       return (
         <List.Item key={action}>
-          <Button
-            primary
-            onClick={() => {
-              this.performLoanAction(pid, loan, actions[action]);
-            }}
-          >
-            {action}
-          </Button>
+          {action === 'cancel' ? (
+            <CancelLoanModal
+              loan={this.props.loanDetails}
+              action={loanAction}
+            />
+          ) : (
+            <Button primary onClick={loanAction}>
+              {action}
+            </Button>
+          )}
         </List.Item>
       );
     });

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/LoanDetails/components/LoanActions/index.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/LoanDetails/components/LoanActions/index.js
@@ -8,8 +8,8 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  performLoanAction: (pid, loan, url) =>
-    dispatch(performLoanAction(pid, loan, url)),
+  performLoanAction: (pid, loan, url, cancelReason = null) =>
+    dispatch(performLoanAction(pid, loan, url, cancelReason)),
 });
 
 export const LoanActions = connect(

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/LoanDetails/components/LoanMetadata/LoanMetadata.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/LoanDetails/components/LoanMetadata/LoanMetadata.js
@@ -89,6 +89,7 @@ export default class LoanMetadata extends Component {
   }
 
   prepareRightData(data) {
+    const { cancel_reason: reason, state } = data.metadata;
     const rows = [
       {
         name: 'Transaction date',
@@ -99,6 +100,12 @@ export default class LoanMetadata extends Component {
         value: toShortDateTime(data.metadata.request_expire_date),
       },
     ];
+    if (state === 'CANCELLED' && !isEmpty(reason)) {
+      rows.push({
+        name: 'Cancel Reason',
+        value: reason,
+      });
+    }
     return rows;
   }
 

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/LoanDetails/state/__tests__/actions.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/LoanDetails/state/__tests__/actions.js
@@ -114,7 +114,8 @@ describe('Loan details tests', () => {
             '123',
             loan,
             sessionManager.user.id,
-            sessionManager.user.locationPid
+            sessionManager.user.locationPid,
+            {}
           );
           const actions = store.getActions();
           expect(actions[0]).toEqual(expectedActions[0]);
@@ -140,7 +141,8 @@ describe('Loan details tests', () => {
             '123',
             loan,
             sessionManager.user.id,
-            sessionManager.user.locationPid
+            sessionManager.user.locationPid,
+            {}
           );
           const actions = store.getActions();
           expect(actions[1]).toEqual(expectedActions[0]);
@@ -166,7 +168,8 @@ describe('Loan details tests', () => {
             '123',
             loan,
             sessionManager.user.id,
-            sessionManager.user.locationPid
+            sessionManager.user.locationPid,
+            {}
           );
           const actions = store.getActions();
           expect(actions[1]).toEqual(expectedActions[0]);

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/LoanDetails/state/actions.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/LoanDetails/state/actions.js
@@ -29,14 +29,22 @@ export const fetchLoanDetails = loanPid => {
   };
 };
 
-export const performLoanAction = (pid, loan, url) => {
+export const performLoanAction = (pid, loan, url, cancelReason = null) => {
   return async dispatch => {
     dispatch({
       type: IS_LOADING,
     });
     const currentUser = sessionManager.user;
+    const params = cancelReason ? { cancel_reason: cancelReason } : {};
     await loanApi
-      .postAction(url, pid, loan, currentUser.id, currentUser.locationPid)
+      .postAction(
+        url,
+        pid,
+        loan,
+        currentUser.id,
+        currentUser.locationPid,
+        params
+      )
       .then(details => {
         dispatch({
           type: SUCCESS,

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/PatronDetails/components/ItemsCheckout/state/__tests__/actions.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/PatronDetails/components/ItemsCheckout/state/__tests__/actions.js
@@ -51,7 +51,9 @@ describe('ItemsCheckout actions tests', () => {
           loan,
           sessionManager.user.id,
           sessionManager.user.locationPid,
-          shouldForceCheckout
+          {
+            force_checkout: shouldForceCheckout,
+          }
         );
 
         const actions = store.getActions();
@@ -78,7 +80,9 @@ describe('ItemsCheckout actions tests', () => {
             loan,
             sessionManager.user.id,
             sessionManager.user.locationPid,
-            doForceCheckout
+            {
+              force_checkout: doForceCheckout,
+            }
           );
 
           const actions = store.getActions();
@@ -104,7 +108,9 @@ describe('ItemsCheckout actions tests', () => {
           loan,
           sessionManager.user.id,
           sessionManager.user.locationPid,
-          shouldForceCheckout
+          {
+            force_checkout: shouldForceCheckout,
+          }
         );
         const actions = store.getActions();
         expect(actions[1]).toEqual(expectedActions[0]);
@@ -129,7 +135,9 @@ describe('ItemsCheckout actions tests', () => {
           loan,
           sessionManager.user.id,
           sessionManager.user.locationPid,
-          shouldForceCheckout
+          {
+            force_checkout: shouldForceCheckout,
+          }
         );
         const actions = store.getActions();
         expect(actions[1]).toEqual(expectedActions[0]);

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/PatronDetails/components/ItemsCheckout/state/actions.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/PatronDetails/components/ItemsCheckout/state/actions.js
@@ -22,7 +22,9 @@ export const checkoutItem = (item, patronPid, shouldForceCheckout = false) => {
         },
         currentUser.id,
         currentUser.locationPid,
-        shouldForceCheckout
+        {
+          force_checkout: shouldForceCheckout,
+        }
       )
       .then(response => {
         dispatch({


### PR DESCRIPTION
Modal to give a reason when cancelling a loan.

Requires inveniosoftware/invenio-circulation#112
Closes #301 

![cancel-reason](https://user-images.githubusercontent.com/9783490/58970761-574f6a80-87ba-11e9-9af2-afd67a220874.png)
