### PR TITLE
backoffice: fix for missing payload params in item checkout

### DIFF
--- a/invenio_app_ils/ui/src/invenio_app_ils/common/api/loans/loan.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/api/loans/loan.js
@@ -39,6 +39,8 @@ const postAction = (
   const payload = {
     transaction_user_pid: transactionUserPid,
     patron_pid: loan.metadata.patron_pid,
+    document_pid: loan.metadata.document_pid,
+    item_pid: loan.metadata.item_pid,
     transaction_location_pid: transactionLocationPid,
     transaction_date: toISO(now),
     ...params,


### PR DESCRIPTION
Fix for missing payload params (item_pid and document_pid) in checkout items.