### PR TITLE
search: fix loans search permissions

### DIFF
--- a/invenio_app_ils/config.py
+++ b/invenio_app_ils/config.py
@@ -19,13 +19,13 @@ from datetime import timedelta
 
 from flask import request
 from invenio_app.config import APP_DEFAULT_SECURE_HEADERS
-from invenio_circulation.search.api import LoansSearch
 from invenio_records_rest.facets import terms_filter
 from invenio_records_rest.utils import deny_all
 
 from .api import can_item_circulate, get_document_pid_by_item_pid, \
     get_item_pids_by_document_pid, get_location_pid_by_item_pid, item_exists, \
     patron_exists
+from .circulation.search import IlsLoansSearch
 from .facets import keyed_range_filter
 from .jwt import ils_jwt_create_token
 from .records.resolver.loan import item_resolver
@@ -656,7 +656,7 @@ CIRCULATION_REST_ENDPOINTS = dict(
         pid_type=CIRCULATION_LOAN_PID_TYPE,
         pid_minter=CIRCULATION_LOAN_MINTER,
         pid_fetcher=CIRCULATION_LOAN_FETCHER,
-        search_class=LoansSearch,
+        search_class=IlsLoansSearch,
         search_factory_imp="invenio_app_ils.circulation.search"
                            ":circulation_search_factory",
         record_class="invenio_circulation.api:Loan",
@@ -732,7 +732,7 @@ RECORDS_REST_SORT_OPTIONS = dict(
             order=1
         )
     ),
-    loans=dict(  # LoansSearch.Meta.index
+    loans=dict(  # IlsLoansSearch.Meta.index
         bestmatch=dict(
             fields=['-_score'],
             title='Best match',
@@ -832,7 +832,7 @@ RECORDS_REST_FACETS = dict(
             circulation_status=terms_filter('circulation_status.state'),
         )
     ),
-    loans=dict(  # LoansSearch.Meta.index
+    loans=dict(  # IlsLoansSearch.Meta.index
         aggs=dict(
             state=dict(
                 terms=dict(field="state"),

--- a/invenio_app_ils/records/resolver/jsonresolver/document_circulation.py
+++ b/invenio_app_ils/records/resolver/jsonresolver/document_circulation.py
@@ -8,10 +8,11 @@
 """Resolve the circulation status referenced in the Document."""
 
 import jsonresolver
+from invenio_circulation.proxies import current_circulation
+from invenio_records_rest.utils import obj_or_import_string
 from werkzeug.routing import Rule
 
-from invenio_app_ils.circulation.search import IlsLoansSearch
-from invenio_app_ils.search.api import ItemSearch
+from invenio_app_ils.pidstore.pids import ITEM_PID_TYPE
 
 # Note: there must be only one resolver per file,
 # otherwise only the last one is registered
@@ -24,8 +25,14 @@ def jsonresolver_loader(url_map):
 
     def circulation_resolver(document_pid):
         """Return circulation info for the given Document."""
+        rest_cfg = current_app.config["CIRCULATION_REST_ENDPOINTS"]
+
+        loan_search = current_circulation.loan_search
+
+        record_cfg = current_app.config["RECORDS_REST_ENDPOINTS"]
+        ItemSearch = obj_or_import_string(
+            record_cfg[ITEM_PID_TYPE]["search_class"])
         item_search = ItemSearch()
-        loan_search = IlsLoansSearch()
 
         all_items_count = item_search.search_by_document_pid(
             document_pid).execute().hits.total

--- a/invenio_app_ils/views.py
+++ b/invenio_app_ils/views.py
@@ -15,7 +15,7 @@ this file.
 from __future__ import absolute_import, print_function
 
 from flask import Blueprint, current_app, render_template
-from invenio_circulation.search.api import LoansSearch
+from invenio_circulation.proxies import current_circulation
 
 from invenio_app_ils.search.api import DocumentSearch, EItemSearch, \
     ItemSearch, PatronsSearch, SeriesSearch
@@ -149,7 +149,7 @@ def _get_loans_ui_config():
         },
         "circulation": {"loanActiveStates": [], "loanCompletedStates": []},
     }
-    loans_index = LoansSearch.Meta.index
+    loans_index = current_circulation.loan_search.Meta.index
 
     loans_sort = current_app.config.get("RECORDS_REST_SORT_OPTIONS", {}).get(
         loans_index, {}


### PR DESCRIPTION
Fix issue where it was possible to bypass permissions if a query was supplied to the loans search.

Closes #47 