### PR TITLE
cli: add ils setup command

### DIFF
--- a/scripts/setup
+++ b/scripts/setup
@@ -6,37 +6,4 @@
 # invenio-app-ils is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-set -e
-
-# Clean redis
-ils shell --no-term-title -c "import redis; redis.StrictRedis.from_url(app.config['CACHE_REDIS_URL']).flushall(); print('Cache cleared')"
-ils db destroy --yes-i-know
-ils db init create
-ils index destroy --force --yes-i-know
-ils index init --force
-ils index queue init purge
-
-# Create roles to restrict access
-ils roles create admin
-ils roles create librarian
-
-# create users
-ils users create patron1@test.ch -a --password=123456 # ID 1
-ils users create patron2@test.ch -a --password=123456 # ID 2
-ils users create admin@test.ch -a --password=123456 # ID 3
-ils users create librarian@test.ch -a --password=123456 # ID 4
-ils users create patron3@test.ch -a --password=123456 # ID 5
-ils users create patron4@test.ch -a --password=123456 # ID 6
-
-
-# assign roles
-ils roles add admin@test.ch admin
-ils roles add librarian@test.ch librarian
-# assign actions
-ils access allow superuser-access role admin
-ils access allow ils-backoffice-access role librarian
-
-#index users
-ils patrons index
-# Create demo data
-ils demo data
+ils setup --verbose

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,8 @@ setup(
         "console_scripts": ["ils = invenio_app.cli:cli"],
         "flask.commands": [
             "demo = invenio_app_ils.cli:demo",
-            "patrons = invenio_app_ils.cli:patrons"
+            "patrons = invenio_app_ils.cli:patrons",
+            "setup = invenio_app_ils.cli:setup",
         ],
         "invenio_base.apps": [
             "invenio_app_ils_ui = invenio_app_ils.ext:InvenioAppIlsUI"


### PR DESCRIPTION
Runs the setup commands using the `CliRunner` instead of through bash to avoid loading Invenio after every CLI call.

```
Usage: ils setup [OPTIONS]

  ILS setup command.

Options:
  --skip-db-destroy  Skip destroying DB.
  --skip-demo-data   Skip creating demo data.
  --skip-patrons     Skip creating patrons.
  --verbose          Verbose output.
```