### PR TITLE
backoffice ui: fix validation error on loan action

### DIFF
--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/LoanDetails/components/LoanActions/LoanActions.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/LoanDetails/components/LoanActions/LoanActions.js
@@ -15,14 +15,16 @@ export default class LoanActions extends Component {
       actions = omit(actions, 'checkout');
     }
     return Object.keys(actions).map(action => {
-      const loanAction = (cancelReason = null) =>
+      const cancelAction = (cancelReason = null) =>
         this.performLoanAction(pid, loan, actions[action], cancelReason);
+      const loanAction = () =>
+        this.performLoanAction(pid, loan, actions[action]);
       return (
         <List.Item key={action}>
           {action === 'cancel' ? (
             <CancelLoanModal
               loan={this.props.loanDetails}
-              action={loanAction}
+              action={cancelAction}
             />
           ) : (
             <Button primary onClick={loanAction}>


### PR DESCRIPTION
Fixes issue where loan actions (except cancelling) were failing because the click event was passed as the cancel reason.

Closes #409 