### PR TITLE
backoffice ui: pending overdue documents

### DIFF
--- a/invenio_app_ils/circulation/search.py
+++ b/invenio_app_ils/circulation/search.py
@@ -65,6 +65,15 @@ class IlsLoansSearch(LoansSearch):
             ),
         )
 
+    def get_overdue_loans_by_doc_pid(self, document_pid):
+        """Return any overdue loans for the given document."""
+        return search_by_pid(
+            document_pid=document_pid,
+            filter_states=current_app.config.get(
+                "CIRCULATION_STATES_LOAN_ACTIVE", []
+            ),
+        ).filter('range', end_date=dict(lt='now/d'))
+
     class Meta:
         """Define permissions filter."""
 

--- a/invenio_app_ils/records/resolver/jsonresolver/document_circulation.py
+++ b/invenio_app_ils/records/resolver/jsonresolver/document_circulation.py
@@ -33,6 +33,8 @@ def jsonresolver_loader(url_map):
             document_pid).count()
         pending_loans_count = loan_search.get_pending_loans_by_doc_pid(
             document_pid).count()
+        overdue_loans_count = loan_search.get_overdue_loans_by_doc_pid(
+            document_pid).count()
 
         record_cfg = current_app.config["RECORDS_REST_ENDPOINTS"]
         # items
@@ -46,16 +48,12 @@ def jsonresolver_loader(url_map):
         has_items_for_loan = items_count - \
             active_loans_count - unavailable_items_count
 
-        # eitems
-        EItemSearch = obj_or_import_string(
-            record_cfg[EITEM_PID_TYPE]["search_class"])
-        eitem_search = EItemSearch()
-
         circulation = {
             "active_loans": active_loans_count,
             "has_items_for_loan": has_items_for_loan,
             "number_of_past_loans": past_loans_count,
             "overbooked": pending_loans_count > has_items_for_loan,
+            "overdue_loans": overdue_loans_count,
             "pending_loans": pending_loans_count,
         }
 

--- a/invenio_app_ils/records/resolver/jsonresolver/document_item.py
+++ b/invenio_app_ils/records/resolver/jsonresolver/document_item.py
@@ -34,9 +34,10 @@ def jsonresolver_loader(url_map):
                 "description": item.get("description"),
             }
             if circulation:
-                obj["circulation"] = {
-                    "state": circulation.get("state")
-                }
+                include_circulation_keys = ['request_expire_date', 'state']
+                obj["circulation"] = {}
+                for key in include_circulation_keys:
+                    obj["circulation"][key] = circulation.get(key)
             items.append(obj)
         return {
             "total": len(items),

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/api/documents/document.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/api/documents/document.js
@@ -47,6 +47,7 @@ class QueryBuilder {
     this.withKeywordQuery = [];
     this.withDocumentTypeQuery = [];
     this.withEitemsQuery = [];
+    this.pendingOverdueQuery = [];
     this.withSeriesQuery = [];
     this.sortByQuery = '';
   }
@@ -108,6 +109,17 @@ class QueryBuilder {
     return this;
   }
 
+  pendingOverdue() {
+    const query = [
+      'circulation.has_items_for_loan:0',
+      'circulation.pending_loans:>0',
+      'circulation.overdue_loans:>0',
+      'items.total:>0',
+    ];
+    this.pendingOverdueQuery.push(encodeURI(query.join(' AND ')));
+    return this;
+  }
+
   sortBy(order = 'bestmatch') {
     this.sortByQuery = `&sort=${order}`;
     return this;
@@ -122,6 +134,7 @@ class QueryBuilder {
         this.withKeywordQuery,
         this.withDocumentTypeQuery,
         this.withEitemsQuery,
+        this.pendingOverdueQuery,
         this.withSeriesQuery
       )
       .join(' AND ');

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/api/loans/__tests__/loan.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/api/loans/__tests__/loan.js
@@ -64,7 +64,7 @@ describe('Loan query builder tests', () => {
       .query()
       .overdue()
       .qs();
-    expect(decodeURI(query)).toEqual(`(request_expire_date:{* TO ${now}})`);
+    expect(decodeURI(query)).toEqual(`(end_date:{* TO ${now}})`);
   });
 
   it('should build query for update date range', () => {

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/api/loans/loan.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/api/loans/loan.js
@@ -137,7 +137,7 @@ class QueryBuilder {
 
   overdue() {
     let now = toShortDate(DateTime.local());
-    this.overdueQuery.push(encodeURI(`request_expire_date:{* TO ${now}}`));
+    this.overdueQuery.push(encodeURI(`end_date:{* TO ${now}}`));
     return this;
   }
 

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/components/ResultsTable/formatters.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/components/ResultsTable/formatters.js
@@ -37,6 +37,9 @@ function formatDocumentToTableView(document, volume = null) {
       serialized['Requests'] = document.metadata.circulation.pending_loans;
       serialized['Available Items'] =
         document.metadata.circulation.has_items_for_loan;
+      serialized['Overdue Loans'] = document.metadata.circulation.overdue_loans;
+      serialized['Pending Requests'] =
+        document.metadata.circulation.pending_loans;
       serialized['# Loans'] =
         document.metadata.circulation.number_of_past_loans;
     }

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/Home/Home.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/Home/Home.js
@@ -9,6 +9,7 @@ import {
   OverdueLoansList,
   IdleLoansList,
   RenewedLoansList,
+  PendingOverdueDocumentsList,
 } from './components';
 
 export default class Home extends Component {
@@ -38,7 +39,7 @@ export default class Home extends Component {
                   <OverbookedDocumentsList />
                 </Grid.Column>
                 <Grid.Column width={6}>
-                  <OverdueLoansList />
+                  <PendingOverdueDocumentsList />
                 </Grid.Column>
               </Grid.Row>
               <Grid.Row>
@@ -47,6 +48,11 @@ export default class Home extends Component {
                 </Grid.Column>
                 <Grid.Column width={6}>
                   <RenewedLoansList />
+                </Grid.Column>
+              </Grid.Row>
+              <Grid.Row>
+                <Grid.Column width={6}>
+                  <OverdueLoansList />
                 </Grid.Column>
               </Grid.Row>
             </Grid>

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/Home/components/index.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/Home/components/index.js
@@ -4,5 +4,8 @@ export { ACQRequestsCard } from './widgets/ACQRequestsCard';
 export { ILLCard } from './widgets/ILLCard';
 export { OverbookedDocumentsList } from './lists/OverbookedDocumentsList';
 export { OverdueLoansList } from './lists/OverdueLoansList';
+export {
+  PendingOverdueDocumentsList,
+} from './lists/PendingOverdueDocumentsList';
 export { IdleLoansList } from './lists/IdleLoansList';
 export { RenewedLoansList } from './lists/RenewedLoansList';

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/Home/components/lists/PendingOverdueDocumentsList/PendingOverdueDocumentsList.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/Home/components/lists/PendingOverdueDocumentsList/PendingOverdueDocumentsList.js
@@ -2,31 +2,30 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Loader, Error } from '../../../../../../common/components';
 import { ResultsTable } from '../../../../../../common/components';
-import { loan as loanApi } from '../../../../../../common/api';
+import { document as documentApi } from '../../../../../../common/api';
 import { BackOfficeRoutes } from '../../../../../../routes/urls';
 import { formatter } from '../../../../../../common/components/ResultsTable/formatters';
 import { SeeAllButton } from '../../../../components/buttons';
 import { goTo, goToHandler } from '../../../../../../history';
 import pick from 'lodash/pick';
 
-export default class OverdueLoansList extends Component {
+export default class PendingOverdueDocumentsList extends Component {
   constructor(props) {
     super(props);
-    this.fetchOverdueLoans = props.fetchOverdueLoans;
-    this.showDetailsUrl = BackOfficeRoutes.loanDetailsFor;
-    this.seeAllUrl = BackOfficeRoutes.loansListWithQuery;
+    this.fetchPendingOverdueDocuments = props.fetchPendingOverdueDocuments;
+    this.showDetailsUrl = BackOfficeRoutes.documentDetailsFor;
+    this.seeAllUrl = BackOfficeRoutes.documentsListWithQuery;
   }
 
   componentDidMount() {
-    this.fetchOverdueLoans();
+    this.fetchPendingOverdueDocuments();
   }
 
   seeAllButton = () => {
     const path = this.seeAllUrl(
-      loanApi
+      documentApi
         .query()
-        .overdue()
-        .withState('ITEM_ON_LOAN')
+        .pendingOverdue()
         .qs()
     );
     return <SeeAllButton clickHandler={goToHandler(path)} />;
@@ -34,11 +33,12 @@ export default class OverdueLoansList extends Component {
 
   prepareData(data) {
     return data.hits.map(row => {
-      return pick(formatter.loan.toTable(row), [
+      return pick(formatter.document.toTable(row), [
         'ID',
-        'Patron ID',
-        'Item barcode',
-        'End date',
+        'Title',
+        'Overdue Loans',
+        'Pending Requests',
+        'Available Items',
       ]);
     });
   }
@@ -49,9 +49,9 @@ export default class OverdueLoansList extends Component {
     return (
       <ResultsTable
         rows={rows}
-        title={'Overdue loans'}
-        subtitle={'Active loans with past due end date.'}
-        name={'overdue loans'}
+        title={'Pending Overdue Documents'}
+        subtitle={`Documents with pending loan requests, no available items and an active loan that's overdue.`}
+        name={'pending overdue documents'}
         rowActionClickHandler={row => goTo(this.showDetailsUrl(row.ID))}
         seeAllComponent={this.seeAllButton()}
         showMaxRows={this.props.showMaxEntries}
@@ -69,12 +69,12 @@ export default class OverdueLoansList extends Component {
   }
 }
 
-OverdueLoansList.propTypes = {
-  fetchOverdueLoans: PropTypes.func.isRequired,
+PendingOverdueDocumentsList.propTypes = {
+  fetchPendingOverdueDocuments: PropTypes.func.isRequired,
   data: PropTypes.object.isRequired,
   showMaxEntries: PropTypes.number,
 };
 
-OverdueLoansList.defaultProps = {
+PendingOverdueDocumentsList.defaultProps = {
   showMaxEntries: 5,
 };

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/Home/components/lists/PendingOverdueDocumentsList/__tests__/PendingOverdueDocumentsList.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/Home/components/lists/PendingOverdueDocumentsList/__tests__/PendingOverdueDocumentsList.js
@@ -1,0 +1,140 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import { Settings } from 'luxon';
+import { fromISO } from '../../../../../../../common/api/date';
+import { BackOfficeRoutes } from '../../../../../../../routes/urls';
+import PendingOverdueDocumentsList from '../PendingOverdueDocumentsList';
+import history from '../../../../../../../history';
+
+Settings.defaultZoneName = 'utc';
+const stringDate = fromISO('2018-01-01T11:05:00+01:00');
+
+describe('PendingOverdueDocumentsList tests', () => {
+  let component;
+  afterEach(() => {
+    if (component) {
+      component.unmount();
+    }
+  });
+
+  it('should load the details component', () => {
+    const component = shallow(
+      <PendingOverdueDocumentsList
+        data={{ hits: [], total: 0 }}
+        fetchPendingOverdueDocuments={() => {}}
+      />
+    );
+    expect(component).toMatchSnapshot();
+  });
+
+  it('should fetch documents on mount', () => {
+    const mockedFetchDocuments = jest.fn();
+    component = mount(
+      <PendingOverdueDocumentsList
+        data={{ hits: [], total: 0 }}
+        fetchPendingOverdueDocuments={mockedFetchDocuments}
+      />
+    );
+    expect(mockedFetchDocuments).toHaveBeenCalled();
+  });
+
+  it('should render show a message with no documents', () => {
+    component = mount(
+      <PendingOverdueDocumentsList
+        data={{ hits: [], total: 0 }}
+        fetchPendingOverdueDocuments={() => {}}
+      />
+    );
+
+    expect(component).toMatchSnapshot();
+    const message = component
+      .find('Message')
+      .filterWhere(element => element.prop('data-test') === 'no-results');
+    expect(message).toHaveLength(1);
+  });
+
+  it('should render documents', () => {
+    const data = {
+      hits: [
+        {
+          id: 1,
+          updated: stringDate,
+          created: stringDate,
+          pid: 'document1',
+          metadata: {
+            pid: 'document1',
+          },
+        },
+        {
+          id: 2,
+          updated: stringDate,
+          created: stringDate,
+          pid: 'document2',
+          metadata: {
+            pid: 'document2',
+            document_pid: 'doc1',
+          },
+        },
+      ],
+      total: 2,
+    };
+    component = mount(
+      <PendingOverdueDocumentsList
+        data={data}
+        fetchPendingOverdueDocuments={() => {}}
+      />
+    );
+
+    expect(component).toMatchSnapshot();
+    const rows = component
+      .find('TableRow')
+      .filterWhere(
+        element =>
+          element.prop('data-test') === 'document1' ||
+          element.prop('data-test') === 'document2'
+      );
+    expect(rows).toHaveLength(2);
+
+    const footer = component
+      .find('TableRow')
+      .filterWhere(element => element.prop('data-test') === 'footer');
+    expect(footer).toHaveLength(0);
+  });
+
+  it('should go to document details when clicking on a document', () => {
+    const mockedHistoryPush = jest.fn();
+    history.push = mockedHistoryPush;
+    const data = {
+      hits: [
+        {
+          id: 1,
+          updated: stringDate,
+          created: stringDate,
+          pid: 'document1',
+          metadata: {
+            pid: 'document1',
+          },
+        },
+      ],
+      total: 1,
+    };
+
+    component = mount(
+      <PendingOverdueDocumentsList
+        data={data}
+        fetchPendingOverdueDocuments={() => {}}
+        showMaxEntries={1}
+      />
+    );
+
+    const firstId = data.hits[0].pid;
+    const button = component
+      .find('TableRow')
+      .filterWhere(element => element.prop('data-test') === firstId)
+      .find('i');
+    button.simulate('click');
+
+    const expectedParam = BackOfficeRoutes.documentDetailsFor(firstId);
+    expect(mockedHistoryPush).toHaveBeenCalledWith(expectedParam, {});
+  });
+});

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/Home/components/lists/PendingOverdueDocumentsList/__tests__/__snapshots__/PendingOverdueDocumentsList.js.snap
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/Home/components/lists/PendingOverdueDocumentsList/__tests__/__snapshots__/PendingOverdueDocumentsList.js.snap
@@ -1,0 +1,534 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PendingOverdueDocumentsList tests should load the details component 1`] = `
+<Loader>
+  <Error>
+    <ResultsTable
+      currentPage={1}
+      fixed={false}
+      headerActionClickHandler={null}
+      headerActionComponent={null}
+      name="pending overdue documents"
+      paginationComponent={null}
+      renderSegment={true}
+      rowActionClickHandler={[Function]}
+      rows={Array []}
+      seeAllComponent={
+        <SeeAllButton
+          clickHandler={[Function]}
+          disabled={false}
+          fluid={false}
+        />
+      }
+      showMaxRows={5}
+      singleLine={false}
+      subtitle="Documents with pending loan requests, no available items and an active loan that's overdue."
+      title="Pending Overdue Documents"
+    />
+  </Error>
+</Loader>
+`;
+
+exports[`PendingOverdueDocumentsList tests should render documents 1`] = `
+<PendingOverdueDocumentsList
+  data={
+    Object {
+      "hits": Array [
+        Object {
+          "created": "2018-01-01T10:05:00.000Z",
+          "id": 1,
+          "metadata": Object {
+            "pid": "document1",
+          },
+          "pid": "document1",
+          "updated": "2018-01-01T10:05:00.000Z",
+        },
+        Object {
+          "created": "2018-01-01T10:05:00.000Z",
+          "id": 2,
+          "metadata": Object {
+            "document_pid": "doc1",
+            "pid": "document2",
+          },
+          "pid": "document2",
+          "updated": "2018-01-01T10:05:00.000Z",
+        },
+      ],
+      "total": 2,
+    }
+  }
+  fetchPendingOverdueDocuments={[Function]}
+  showMaxEntries={5}
+>
+  <Loader>
+    <Error>
+      <ResultsTable
+        currentPage={1}
+        fixed={false}
+        headerActionClickHandler={null}
+        headerActionComponent={null}
+        name="pending overdue documents"
+        paginationComponent={null}
+        renderSegment={true}
+        rowActionClickHandler={[Function]}
+        rows={
+          Array [
+            Object {
+              "ID": "document1",
+              "Title": undefined,
+            },
+            Object {
+              "ID": "document2",
+              "Title": undefined,
+            },
+          ]
+        }
+        seeAllComponent={
+          <SeeAllButton
+            clickHandler={[Function]}
+            disabled={false}
+            fluid={false}
+          />
+        }
+        showMaxRows={5}
+        singleLine={false}
+        subtitle="Documents with pending loan requests, no available items and an active loan that's overdue."
+        title="Pending Overdue Documents"
+      >
+        <Segment>
+          <div
+            className="ui segment"
+          >
+            <Grid>
+              <div
+                className="ui grid"
+              >
+                <GridRow>
+                  <div
+                    className="row"
+                  >
+                    <GridColumn
+                      verticalAlign="middle"
+                      width={13}
+                    >
+                      <div
+                        className="middle aligned thirteen wide column"
+                      >
+                        <Header
+                          as="h3"
+                          content="Pending Overdue Documents"
+                          subheader="Documents with pending loan requests, no available items and an active loan that's overdue."
+                        >
+                          <h3
+                            className="ui header"
+                          >
+                            Pending Overdue Documents
+                            <HeaderSubheader
+                              content="Documents with pending loan requests, no available items and an active loan that's overdue."
+                            >
+                              <div
+                                className="sub header"
+                              >
+                                Documents with pending loan requests, no available items and an active loan that's overdue.
+                              </div>
+                            </HeaderSubheader>
+                          </h3>
+                        </Header>
+                      </div>
+                    </GridColumn>
+                    <GridColumn
+                      textAlign="right"
+                      width={3}
+                    >
+                      <div
+                        className="right aligned three wide column"
+                      />
+                    </GridColumn>
+                  </div>
+                </GridRow>
+              </div>
+            </Grid>
+            <Table
+              as="table"
+              selectable={true}
+              striped={true}
+            >
+              <table
+                className="ui selectable striped table"
+              >
+                <ResultsTableHeader
+                  columns={
+                    Array [
+                      "ID",
+                      "Title",
+                    ]
+                  }
+                  withRowAction={true}
+                >
+                  <TableHeader
+                    as="thead"
+                  >
+                    <thead
+                      className=""
+                    >
+                      <TableRow
+                        as="tr"
+                        cellAs="td"
+                        data-test="header"
+                      >
+                        <tr
+                          className=""
+                          data-test="header"
+                        >
+                          <TableHeaderCell
+                            as="th"
+                            collapsing={true}
+                            width={2}
+                          >
+                            <TableCell
+                              as="th"
+                              className=""
+                              collapsing={true}
+                              width={2}
+                            >
+                              <th
+                                className="collapsing two wide"
+                              />
+                            </TableCell>
+                          </TableHeaderCell>
+                          <TableHeaderCell
+                            as="th"
+                            key="ID"
+                            width={2}
+                          >
+                            <TableCell
+                              as="th"
+                              className=""
+                              width={2}
+                            >
+                              <th
+                                className="two wide"
+                              >
+                                ID
+                              </th>
+                            </TableCell>
+                          </TableHeaderCell>
+                          <TableHeaderCell
+                            as="th"
+                            key="Title"
+                          >
+                            <TableCell
+                              as="th"
+                              className=""
+                            >
+                              <th
+                                className=""
+                              >
+                                Title
+                              </th>
+                            </TableCell>
+                          </TableHeaderCell>
+                        </tr>
+                      </TableRow>
+                    </thead>
+                  </TableHeader>
+                </ResultsTableHeader>
+                <ResultsTableBody
+                  columns={
+                    Array [
+                      "ID",
+                      "Title",
+                    ]
+                  }
+                  rowActionClickHandler={[Function]}
+                  rows={
+                    Array [
+                      Object {
+                        "ID": "document1",
+                        "Title": undefined,
+                      },
+                      Object {
+                        "ID": "document2",
+                        "Title": undefined,
+                      },
+                    ]
+                  }
+                >
+                  <TableBody
+                    as="tbody"
+                  >
+                    <tbody
+                      className=""
+                    >
+                      <TableRow
+                        as="tr"
+                        cellAs="td"
+                        data-test="document1"
+                        key="document1"
+                      >
+                        <tr
+                          className=""
+                          data-test="document1"
+                        >
+                          <TableCell
+                            as="td"
+                            textAlign="center"
+                          >
+                            <td
+                              className="center aligned"
+                            >
+                              <Button
+                                as="button"
+                                circular={true}
+                                compact={true}
+                                data-test="btn-view-details-document1"
+                                icon="eye"
+                                onClick={[Function]}
+                              >
+                                <button
+                                  className="ui circular compact icon button"
+                                  data-test="btn-view-details-document1"
+                                  onClick={[Function]}
+                                >
+                                  <Icon
+                                    as="i"
+                                    name="eye"
+                                  >
+                                    <i
+                                      aria-hidden="true"
+                                      className="eye icon"
+                                    />
+                                  </Icon>
+                                </button>
+                              </Button>
+                            </td>
+                          </TableCell>
+                          <TableCell
+                            as="td"
+                            data-test="ID-document1"
+                            key="0-document1"
+                          >
+                            <td
+                              className=""
+                              data-test="ID-document1"
+                            >
+                              document1
+                            </td>
+                          </TableCell>
+                          <TableCell
+                            as="td"
+                            data-test="Title-document1"
+                            key="1-document1"
+                          >
+                            <td
+                              className=""
+                              data-test="Title-document1"
+                            >
+                              -
+                            </td>
+                          </TableCell>
+                        </tr>
+                      </TableRow>
+                      <TableRow
+                        as="tr"
+                        cellAs="td"
+                        data-test="document2"
+                        key="document2"
+                      >
+                        <tr
+                          className=""
+                          data-test="document2"
+                        >
+                          <TableCell
+                            as="td"
+                            textAlign="center"
+                          >
+                            <td
+                              className="center aligned"
+                            >
+                              <Button
+                                as="button"
+                                circular={true}
+                                compact={true}
+                                data-test="btn-view-details-document2"
+                                icon="eye"
+                                onClick={[Function]}
+                              >
+                                <button
+                                  className="ui circular compact icon button"
+                                  data-test="btn-view-details-document2"
+                                  onClick={[Function]}
+                                >
+                                  <Icon
+                                    as="i"
+                                    name="eye"
+                                  >
+                                    <i
+                                      aria-hidden="true"
+                                      className="eye icon"
+                                    />
+                                  </Icon>
+                                </button>
+                              </Button>
+                            </td>
+                          </TableCell>
+                          <TableCell
+                            as="td"
+                            data-test="ID-document2"
+                            key="0-document2"
+                          >
+                            <td
+                              className=""
+                              data-test="ID-document2"
+                            >
+                              document2
+                            </td>
+                          </TableCell>
+                          <TableCell
+                            as="td"
+                            data-test="Title-document2"
+                            key="1-document2"
+                          >
+                            <td
+                              className=""
+                              data-test="Title-document2"
+                            >
+                              -
+                            </td>
+                          </TableCell>
+                        </tr>
+                      </TableRow>
+                    </tbody>
+                  </TableBody>
+                </ResultsTableBody>
+                <ResultsTableFooter
+                  allRowsNumber={2}
+                  columnsNumber={2}
+                  currentPage={1}
+                  paginationComponent={null}
+                  seeAllComponent={
+                    <SeeAllButton
+                      clickHandler={[Function]}
+                      disabled={false}
+                      fluid={false}
+                    />
+                  }
+                  showMaxRows={5}
+                />
+              </table>
+            </Table>
+          </div>
+        </Segment>
+      </ResultsTable>
+    </Error>
+  </Loader>
+</PendingOverdueDocumentsList>
+`;
+
+exports[`PendingOverdueDocumentsList tests should render show a message with no documents 1`] = `
+<PendingOverdueDocumentsList
+  data={
+    Object {
+      "hits": Array [],
+      "total": 0,
+    }
+  }
+  fetchPendingOverdueDocuments={[Function]}
+  showMaxEntries={5}
+>
+  <Loader>
+    <Error>
+      <ResultsTable
+        currentPage={1}
+        fixed={false}
+        headerActionClickHandler={null}
+        headerActionComponent={null}
+        name="pending overdue documents"
+        paginationComponent={null}
+        renderSegment={true}
+        rowActionClickHandler={[Function]}
+        rows={Array []}
+        seeAllComponent={
+          <SeeAllButton
+            clickHandler={[Function]}
+            disabled={false}
+            fluid={false}
+          />
+        }
+        showMaxRows={5}
+        singleLine={false}
+        subtitle="Documents with pending loan requests, no available items and an active loan that's overdue."
+        title="Pending Overdue Documents"
+      >
+        <Segment>
+          <div
+            className="ui segment"
+          >
+            <Grid>
+              <div
+                className="ui grid"
+              >
+                <GridRow>
+                  <div
+                    className="row"
+                  >
+                    <GridColumn
+                      verticalAlign="middle"
+                      width={13}
+                    >
+                      <div
+                        className="middle aligned thirteen wide column"
+                      >
+                        <Header
+                          as="h3"
+                          content="Pending Overdue Documents"
+                          subheader="Documents with pending loan requests, no available items and an active loan that's overdue."
+                        >
+                          <h3
+                            className="ui header"
+                          >
+                            Pending Overdue Documents
+                            <HeaderSubheader
+                              content="Documents with pending loan requests, no available items and an active loan that's overdue."
+                            >
+                              <div
+                                className="sub header"
+                              >
+                                Documents with pending loan requests, no available items and an active loan that's overdue.
+                              </div>
+                            </HeaderSubheader>
+                          </h3>
+                        </Header>
+                      </div>
+                    </GridColumn>
+                    <GridColumn
+                      textAlign="right"
+                      width={3}
+                    >
+                      <div
+                        className="right aligned three wide column"
+                      />
+                    </GridColumn>
+                  </div>
+                </GridRow>
+              </div>
+            </Grid>
+            <Message
+              data-test="no-results"
+            >
+              <div
+                className="ui message"
+                data-test="no-results"
+              >
+                There are no 
+                pending overdue documents
+                .
+              </div>
+            </Message>
+          </div>
+        </Segment>
+      </ResultsTable>
+    </Error>
+  </Loader>
+</PendingOverdueDocumentsList>
+`;

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/Home/components/lists/PendingOverdueDocumentsList/index.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/Home/components/lists/PendingOverdueDocumentsList/index.js
@@ -1,0 +1,19 @@
+import { connect } from 'react-redux';
+import { fetchPendingOverdueDocuments } from './state/actions';
+import PendingOverdueDocumentsListComponent from './PendingOverdueDocumentsList';
+
+const mapStateToProps = state => ({
+  data: state.pendingOverdueDocuments.data,
+  error: state.pendingOverdueDocuments.error,
+  isLoading: state.pendingOverdueDocuments.isLoading,
+  hasError: state.pendingOverdueDocuments.hasError,
+});
+
+const mapDispatchToProps = dispatch => ({
+  fetchPendingOverdueDocuments: () => dispatch(fetchPendingOverdueDocuments()),
+});
+
+export const PendingOverdueDocumentsList = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(PendingOverdueDocumentsListComponent);

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/Home/components/lists/PendingOverdueDocumentsList/state/__tests__/actions.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/Home/components/lists/PendingOverdueDocumentsList/state/__tests__/actions.js
@@ -3,9 +3,7 @@ import thunk from 'redux-thunk';
 import * as actions from '../actions';
 import { initialState } from '../reducer';
 import * as types from '../types';
-import { loan as loanApi } from '../../../../../../../../common/api';
-import { toShortDate } from '../../../../../../../../common/api/date';
-import { DateTime } from 'luxon';
+import { document as documentApi } from '../../../../../../../../common/api';
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
@@ -25,38 +23,37 @@ const mockResponse = {
   },
 };
 
+const param =
+  'circulation.has_items_for_loan:0%20AND%20circulation.pending_loans:%3E0%20AND%20circulation.overdue_loans:%3E0%20AND%20items.total:%3E0';
+
 const mockLoanList = jest.fn();
-loanApi.list = mockLoanList;
+documentApi.list = mockLoanList;
 
 let store;
 beforeEach(() => {
   mockLoanList.mockClear();
 
-  store = mockStore({ overdueLoans: initialState });
+  store = mockStore({ pendingOverdueDocuments: initialState });
   store.clearActions();
 });
 
-describe('Loans renewed more then 3 times (last week) fetch tests', () => {
-  let now = toShortDate(DateTime.local());
-
-  it('should dispatch a loading action when fetching loans', done => {
+describe('Fetch pending overdue documents tests', () => {
+  it('should dispatch a loading action when fetching documents', done => {
     mockLoanList.mockResolvedValue(mockResponse);
 
     const expectedAction = {
       type: types.IS_LOADING,
     };
 
-    store.dispatch(actions.fetchOverdueLoans()).then(() => {
-      expect(mockLoanList).toHaveBeenCalledWith(
-        `(state:ITEM_ON_LOAN AND end_date:%7B*%20TO%20${now}%7D)`
-      );
+    store.dispatch(actions.fetchPendingOverdueDocuments()).then(() => {
+      expect(mockLoanList).toHaveBeenCalledWith(param);
       const actions = store.getActions();
       expect(actions[0]).toEqual(expectedAction);
       done();
     });
   });
 
-  it('should dispatch a success action when loans fetch succeeds', done => {
+  it('should dispatch a success action when documents fetch succeeds', done => {
     mockLoanList.mockResolvedValue(mockResponse);
 
     const expectedAction = {
@@ -64,17 +61,15 @@ describe('Loans renewed more then 3 times (last week) fetch tests', () => {
       payload: mockResponse.data,
     };
 
-    store.dispatch(actions.fetchOverdueLoans()).then(() => {
-      expect(mockLoanList).toHaveBeenCalledWith(
-        `(state:ITEM_ON_LOAN AND end_date:%7B*%20TO%20${now}%7D)`
-      );
+    store.dispatch(actions.fetchPendingOverdueDocuments()).then(() => {
+      expect(mockLoanList).toHaveBeenCalledWith(param);
       const actions = store.getActions();
       expect(actions[1]).toEqual(expectedAction);
       done();
     });
   });
 
-  it('should dispatch an error action when loans fetch fails', done => {
+  it('should dispatch an error action when documents fetch fails', done => {
     mockLoanList.mockRejectedValue([500, 'Error']);
 
     const expectedAction = {
@@ -82,10 +77,8 @@ describe('Loans renewed more then 3 times (last week) fetch tests', () => {
       payload: [500, 'Error'],
     };
 
-    store.dispatch(actions.fetchOverdueLoans()).then(() => {
-      expect(mockLoanList).toHaveBeenCalledWith(
-        `(state:ITEM_ON_LOAN AND end_date:%7B*%20TO%20${now}%7D)`
-      );
+    store.dispatch(actions.fetchPendingOverdueDocuments()).then(() => {
+      expect(mockLoanList).toHaveBeenCalledWith(param);
       const actions = store.getActions();
       expect(actions[1]).toEqual(expectedAction);
       done();

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/Home/components/lists/PendingOverdueDocumentsList/state/__tests__/reducer.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/Home/components/lists/PendingOverdueDocumentsList/state/__tests__/reducer.js
@@ -1,0 +1,45 @@
+import reducer, { initialState } from '../reducer';
+import * as types from '../types';
+
+describe('PendingOverdueDocumentsList fetch reducer test', () => {
+  it('should have initial state', () => {
+    expect(reducer(undefined, {})).toEqual(initialState);
+  });
+
+  it('should change loading state on loading action', () => {
+    const action = {
+      type: types.IS_LOADING,
+    };
+    expect(reducer(initialState, action)).toEqual({
+      ...initialState,
+      isLoading: true,
+    });
+  });
+
+  it('should change data state on success action', () => {
+    const entries = [{ field: '123' }, { field: '456' }];
+    const action = {
+      type: types.SUCCESS,
+      payload: entries,
+    };
+    expect(reducer(initialState, action)).toEqual({
+      ...initialState,
+      isLoading: false,
+      data: entries,
+      hasError: false,
+    });
+  });
+
+  it('should change error state on error action', () => {
+    const action = {
+      type: types.HAS_ERROR,
+      payload: 'Error',
+    };
+    expect(reducer(initialState, action)).toEqual({
+      ...initialState,
+      isLoading: false,
+      error: 'Error',
+      hasError: true,
+    });
+  });
+});

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/Home/components/lists/PendingOverdueDocumentsList/state/actions.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/Home/components/lists/PendingOverdueDocumentsList/state/actions.js
@@ -1,0 +1,32 @@
+import { IS_LOADING, SUCCESS, HAS_ERROR } from './types';
+import { document as documentApi } from '../../../../../../../common/api';
+import { sendErrorNotification } from '../../../../../../../common/components/Notifications';
+
+export const fetchPendingOverdueDocuments = () => {
+  return async dispatch => {
+    dispatch({
+      type: IS_LOADING,
+    });
+
+    await documentApi
+      .list(
+        documentApi
+          .query()
+          .pendingOverdue()
+          .qs()
+      )
+      .then(response => {
+        dispatch({
+          type: SUCCESS,
+          payload: response.data,
+        });
+      })
+      .catch(error => {
+        dispatch({
+          type: HAS_ERROR,
+          payload: error,
+        });
+        dispatch(sendErrorNotification(error));
+      });
+  };
+};

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/Home/components/lists/PendingOverdueDocumentsList/state/reducer.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/Home/components/lists/PendingOverdueDocumentsList/state/reducer.js
@@ -1,0 +1,32 @@
+import { IS_LOADING, SUCCESS, HAS_ERROR } from './types';
+
+export const initialState = {
+  isLoading: true,
+  hasError: false,
+  data: { hits: [], total: 0 },
+  error: {},
+};
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case IS_LOADING:
+      return { ...state, isLoading: true };
+    case SUCCESS:
+      return {
+        ...state,
+        isLoading: false,
+        data: action.payload,
+        error: {},
+        hasError: false,
+      };
+    case HAS_ERROR:
+      return {
+        ...state,
+        isLoading: false,
+        error: action.payload,
+        hasError: true,
+      };
+    default:
+      return state;
+  }
+};

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/Home/components/lists/PendingOverdueDocumentsList/state/types.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/Home/components/lists/PendingOverdueDocumentsList/state/types.js
@@ -1,0 +1,3 @@
+export const IS_LOADING = 'fetchPendingOverdueDocuments/IS_LOADING';
+export const SUCCESS = 'fetchPendingOverdueDocuments/SUCCESS';
+export const HAS_ERROR = 'fetchPendingOverdueDocuments/HAS_ERROR';

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/Home/reducer.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/Home/reducer.js
@@ -11,6 +11,9 @@ export {
   default as overdueLoansReducer,
 } from './components/lists/OverdueLoansList/state/reducer';
 export {
+  default as pendingOverdueDocumentsReducer,
+} from './components/lists/PendingOverdueDocumentsList/state/reducer';
+export {
   default as idleLoansReducer,
 } from './components/lists/IdleLoansList/state/reducer';
 export {

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/DocumentsDetails/components/DocumentMetadata/DocumentMetadata.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/frontsite/DocumentsDetails/components/DocumentMetadata/DocumentMetadata.js
@@ -13,9 +13,6 @@ import {
 import PropTypes from 'prop-types';
 import DocumentTab from '../DocumentTab';
 import '../../DocumentsDetails.scss';
-import { goToHandler } from '../../../../../history';
-import { FrontSiteRoutes } from '../../../../../routes/urls';
-import { document as documentApi } from '../../../../../common/api';
 import { BookAttachments, ShareButtons } from '../../../components';
 import { BookInfo } from '../../../components/BookInfo';
 import { BookSeries } from '../../../components/BookSeries';

--- a/invenio_app_ils/ui/src/invenio_app_ils/store.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/store.js
@@ -36,6 +36,7 @@ import {
   documentsCardReducer,
   overbookedDocumentsReducer,
   overdueLoansReducer,
+  pendingOverdueDocumentsReducer,
   idleLoansReducer,
   renewedLoansReducer,
 } from './pages/backoffice/Home/reducer';
@@ -87,6 +88,7 @@ const rootReducer = combineReducers({
   patronItemsCheckout: patronItemCheckoutReducer,
   patronPastLoans: patronPastLoansReducer,
   patronPendingLoans: patronPendingLoansReducer,
+  pendingOverdueDocuments: pendingOverdueDocumentsReducer,
   seriesDetails: seriesDetailsReducer,
   seriesDocuments: seriesDocumentsReducer,
   seriesMultipartMonographs: seriesMultipartMonographsReducer,


### PR DESCRIPTION
Pending overdue documents are documents that:
* Has items with active loans
* No available items
* Has at least one item with a loan that's overdue

Also changes "Overdue Loans" to use `end_date` instead of `request_expire_date`.

![pending-overdue-documents-new](https://user-images.githubusercontent.com/9783490/63351506-accdf900-c35f-11e9-8f0c-6de1ad1a271c.png)

Closes #174 