### PR TITLE
fix: all no-unused-vars cause by for loops

### DIFF
--- a/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/ESRelatedSelector.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/ESRelatedSelector.js
@@ -56,11 +56,11 @@ export default class ESRelatedSelector extends Component {
 
     result.metadata.extraFields = result.metadata.extraFields || {};
     if (!isEmpty(this.extraRefs)) {
-      for (const name in this.props.extraFields) {
+      this.props.extraFields.forEach(name => {
         const input = this.extraRefs[name].inputRef;
         result.metadata.extraFields[name] = input.value;
         input.value = '';
-      }
+      });
     }
 
     this.serializeSelection(result);
@@ -72,10 +72,10 @@ export default class ESRelatedSelector extends Component {
 
   onSearchChange = query => {
     if (query) {
-      for (const [name, input] of Object.entries(this.extraRefs)) {
+      Object.entries(this.extraRefs).forEach(([name, input]) => {
         const value = input.inputRef.value;
         this.setState({ showPopup: { [name]: value === '' } });
-      }
+      });
     }
   };
 
@@ -117,27 +117,27 @@ export default class ESRelatedSelector extends Component {
   prepareSelections(selections) {
     const findRecordType = pidType => {
       const recordTypes = Object.entries(this.props.recordTypes);
-      for (const [recordType, obj] of recordTypes) {
+      recordTypes.forEach(([recordType, obj]) => {
         if (obj.pidType === pidType) {
           return recordType;
         }
-      }
+      });
       return null;
     };
 
     const records = {};
-    for (const recordType in this.props.recordTypes) {
+    this.props.recordTypes.forEach(recordType => {
       records[recordType] = [];
-    }
+    });
 
-    for (const selection of selections) {
+    selections.forEach(selection => {
       const pidType = selection.metadata.pidType;
       const recordType = findRecordType(pidType);
       if (!recordType) {
         return [];
       }
       records[recordType].push(selection);
-    }
+    });
     return records;
   }
 
@@ -183,7 +183,7 @@ export default class ESRelatedSelector extends Component {
 
     if (!extraFields) return null;
 
-    for (const [name, field] of Object.entries(extraFields)) {
+    Object.entries(extraFields).forEach(([name, field]) => {
       const FieldComponent = field.component;
       fields.push(
         <Form.Group inline key={name}>
@@ -203,7 +203,7 @@ export default class ESRelatedSelector extends Component {
           />
         </Form.Group>
       );
-    }
+    });
     return fields;
   }
 

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/ESSelector.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/ESSelector.js
@@ -10,13 +10,12 @@ export default class ESSelector extends Component {
     super(props);
 
     const selections = [];
-    for (const selection of props.initialSelections) {
+    props.initialSelections.forEach(selection => {
       if (props.onSelectResult) {
         props.onSelectResult(selection, true);
       }
       selections.push(selection);
-    }
-
+    });
     this.searchRef = null;
     this.props.updateSelections(selections);
   }

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/HitsSearch.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/components/ESSelector/HitsSearch.js
@@ -50,9 +50,7 @@ export class HitsSearch extends Component {
         : searchQuery;
       const response = await this.props.query(queryString);
       const results = [];
-      for (let hit of response.data.hits) {
-        results.push(serialize(hit));
-      }
+      response.data.hits.forEach(hit => results.push(serialize(hit)));
       if (this.props.onResults) {
         this.props.onResults(results);
       }

--- a/invenio_app_ils/ui/src/invenio_app_ils/common/components/ManageRelationsButton/utils.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/common/components/ManageRelationsButton/utils.js
@@ -12,10 +12,10 @@ export function formatPidTypeToName(pidType) {
 }
 
 export function getRelationTypeByName(name) {
-  for (const type of invenioConfig.relationTypes) {
+  invenioConfig.relationTypes.forEach(type => {
     if (type.name === name) {
       return type;
     }
-  }
+  });
   throw Error(`No relation with name: ${name}`);
 }

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/DocumentDetails/components/DocumentMetadata/DocumentMetadata.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/DocumentDetails/components/DocumentMetadata/DocumentMetadata.js
@@ -125,14 +125,15 @@ export default class DocumentMetadata extends Component {
 
   async getRelationRefs() {
     const hits = [];
-    for (const [relation, records] of Object.entries(this.props.relations)) {
-      for (const record of records) {
-        const type = formatPidTypeToName(record.pid_type);
+    Object.entries(this.props.relations).forEach(([relation, records]) => {
+      records.forEach(record => {
         hits.push({
-          id: `${type} ${record.pid} (${relation})`,
+          id: `${formatPidTypeToName(record.pid_type)} ${
+            record.pid
+          } (${relation})`,
         });
-      }
-    }
+      });
+    });
     const obj = {
       data: {
         hits: hits,

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/DocumentDetails/components/DocumentRelations/DocumentRelations.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/DocumentDetails/components/DocumentRelations/DocumentRelations.js
@@ -159,15 +159,15 @@ export default class DocumentRelations extends Component {
     if (this.props.relations[relationName]) {
       const relations = this.props.relations[relationName];
 
-      for (const obj of relations) {
+      relations.forEach(obj => {
         const id = `${obj.pid}-${obj.pid_type}-${relationName}`;
         const type = formatPidTypeToName(obj.pid_type);
         const extraFields = {};
-        for (const key in obj) {
+        obj.forEach(key => {
           if (!['pid', 'pid_type', 'title'].includes(key)) {
             extraFields[key] = obj[key];
           }
-        }
+        });
         selections.push({
           id: id,
           key: id,
@@ -182,7 +182,7 @@ export default class DocumentRelations extends Component {
             extraFields: extraFields,
           },
         });
-      }
+      });
     }
     return selections;
   }
@@ -191,13 +191,13 @@ export default class DocumentRelations extends Component {
     const rows = [];
     if (!this.props.relations[relation]) return [];
 
-    for (const obj of this.props.relations[relation]) {
+    this.props.relations[relation].forEach(obj => {
       const record = formatter.related.toTable(
         obj,
         getRelationTypeByName(relation).label
       );
       rows.push(pick(record, pickColumns));
-    }
+    });
     return rows;
   }
 
@@ -209,7 +209,7 @@ export default class DocumentRelations extends Component {
         return parentChildRelationPayload;
       return siblingRelationPayload;
     };
-    for (const result of results) {
+    results.forEach(result => {
       const createPayload = generateCreatePayload(result.metadata.relationType);
       if (result.metadata.new) {
         createRelations.push(
@@ -221,8 +221,8 @@ export default class DocumentRelations extends Component {
           )
         );
       }
-    }
-    for (const result of this.state.removedRelations) {
+    });
+    this.state.removedRelations.forEach(result => {
       const createPayload = generateCreatePayload(result.metadata.relationType);
       if (!result.metadata.new) {
         deleteRelations.push(
@@ -234,7 +234,7 @@ export default class DocumentRelations extends Component {
           )
         );
       }
-    }
+    });
     const pid = this.props.document.pid;
     this.props.createRelations(pid, createRelations);
     this.props.deleteRelations(pid, deleteRelations);

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/SeriesDetails/components/SeriesDocuments/SeriesDocuments.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/SeriesDetails/components/SeriesDocuments/SeriesDocuments.js
@@ -38,9 +38,9 @@ export default class SeriesDocuments extends Component {
   prepareData(data) {
     const serials = this.props.series.metadata.relations.serial || [];
     const volumes = {};
-    for (const serial of serials) {
-      volumes[[serial.pid, serial.pid_type]] = serial.volume;
-    }
+    serials.forEach(
+      serial => (volumes[[serial.pid, serial.pid_type]] = serial.volume)
+    );
     return data.hits.map(row => {
       const key = [row.metadata.pid, 'docid'];
       const volume = key in volumes ? volumes[key] : '?';

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/SeriesDetails/components/SeriesMetadata/SeriesMetadata.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/SeriesDetails/components/SeriesMetadata/SeriesMetadata.js
@@ -15,14 +15,14 @@ export default class SeriesMetadata extends Component {
 
   async getRelationRefs() {
     const hits = [];
-    for (const [relation, records] of Object.entries(this.props.relations)) {
-      for (const record of records) {
+    Object.entries(this.props.relations).forEach(([relation, records]) => {
+      records.forEach(record => {
         const type = formatPidTypeToName(record.pid_type);
         hits.push({
           id: `${type} ${record.pid} (${relation})`,
         });
-      }
-    }
+      });
+    });
     const obj = {
       data: {
         hits: hits,

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/SeriesDetails/components/SeriesMultipartMonographs/SeriesMultipartMonographs.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/SeriesDetails/components/SeriesMultipartMonographs/SeriesMultipartMonographs.js
@@ -35,9 +35,9 @@ export default class SeriesMultipartMonographs extends Component {
   prepareData(data) {
     const serials = this.props.series.metadata.relations.serial || [];
     const volumes = {};
-    for (const serial of serials) {
-      volumes[[serial.pid, serial.pid_type]] = serial.volume;
-    }
+    serials.forEach(
+      serial => (volumes[[serial.pid, serial.pid_type]] = serial.volume)
+    );
     return data.hits.map(row => {
       const key = [row.metadata.pid, 'serid'];
       const volume = key in volumes ? volumes[key] : '?';

--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/SeriesDetails/components/SeriesRelations/SeriesRelations.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/SeriesDetails/components/SeriesRelations/SeriesRelations.js
@@ -158,15 +158,15 @@ export default class SeriesRelations extends Component {
     if (this.props.relations[relationName]) {
       const relations = this.props.relations[relationName];
 
-      for (const obj of relations) {
+      relations.forEach(obj => {
         const id = `${obj.pid}-${obj.pid_type}-${relationName}`;
         const type = formatPidTypeToName(obj.pid_type);
         const extraFields = {};
-        for (const key in obj) {
+        obj.forEach(key => {
           if (!['pid', 'pid_type', 'title'].includes(key)) {
             extraFields[key] = obj[key];
           }
-        }
+        });
         selections.push({
           id: id,
           key: id,
@@ -181,7 +181,7 @@ export default class SeriesRelations extends Component {
             extraFields: extraFields,
           },
         });
-      }
+      });
     }
     return selections;
   }
@@ -190,13 +190,13 @@ export default class SeriesRelations extends Component {
     const rows = [];
     if (!this.props.relations[relation]) return [];
 
-    for (const obj of this.props.relations[relation]) {
+    this.props.relations[relation].forEach(obj => {
       const record = formatter.related.toTable(
         obj,
         getRelationTypeByName(relation).label
       );
       rows.push(pick(record, pickColumns));
-    }
+    });
     return rows;
   }
 
@@ -210,7 +210,7 @@ export default class SeriesRelations extends Component {
       return siblingRelationPayload;
     };
 
-    for (const result of results) {
+    results.forEach(result => {
       const relation = result.metadata.relationType;
       const createPayload = generateCreatePayload(relation);
       const addAction =
@@ -234,7 +234,7 @@ export default class SeriesRelations extends Component {
           )
         );
       }
-    }
+    });
     return actions;
   }
 


### PR DESCRIPTION
The main reason for all these warnings is demonstrated below.

The following code does not consider usage of the variable `some`, which is defined in the loop scope, since it is just an index to our array, but no interaction with the actual variable.
```
for (let some in something) {
    someArray[some] = 'thing'
}
```

As a counter strategy for it, it is suggested to use `forEach`. I am not the biggest fan of forEach but I prefer it from warnings.