### PR TITLE
ui: fix mutation of active states in config

### DIFF
--- a/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/DocumentDetails/components/DocumentMetadata/DocumentMetadata.js
+++ b/invenio_app_ils/ui/src/invenio_app_ils/pages/backoffice/DocumentDetails/components/DocumentMetadata/DocumentMetadata.js
@@ -150,7 +150,6 @@ export default class DocumentMetadata extends Component {
 
   createRefProps(documentPid) {
     const loanStates = invenioConfig.circulation.loanActiveStates;
-    loanStates.push('PENDING');
 
     const loanRefProps = {
       refType: 'Loan',
@@ -160,7 +159,7 @@ export default class DocumentMetadata extends Component {
           loanApi
             .query()
             .withDocPid(documentPid)
-            .withState(loanStates)
+            .withState(loanStates.concat(['PENDING']))
             .qs()
         ),
     };


### PR DESCRIPTION
Fixes the bug with empty `item_pid` passed to the routing 
( closes #431 )