### PR TITLE
Acquisition: Backoffice search pages

### DIFF
--- a/invenio_app_ils/cli.py
+++ b/invenio_app_ils/cli.py
@@ -670,14 +670,15 @@ class OrderGenerator(Generator):
 
     def random_order_lines(self):
         """Generate random order lines."""
-        count = randint(1, 5)
         doc_pids = self.holder.pids("documents", "pid")
-        for _ in range(randint(1, count + 1)):
+        count = randint(1, 6)
+        doc_pids = random.sample(doc_pids, count)
+        for i in range(count):
             ordered = randint(1, 5)
             yield dict(
                 copies_ordered=ordered,
                 copies_received=randint(1, ordered),
-                document_pid=random.choice(doc_pids),
+                document_pid=doc_pids[i],
                 is_donation=random.choice([True, False]),
                 is_patron_suggestion=random.choice([True, False]),
                 medium="PAPER",

--- a/invenio_app_ils/config.py
+++ b/invenio_app_ils/config.py
@@ -964,17 +964,11 @@ RECORDS_REST_SORT_OPTIONS = dict(
             default_order="desc",
             order=4,
         ),
-        # order_line_count=dict(
-        #     fields=[""],
-        #     title="Number of order lines",
-        #     default_order="desc",
-        #     order=5,
-        # ),
         bestmatch=dict(
             fields=["-_score"],
             title="Best match",
             default_order="asc",
-            order=2,
+            order=5,
         ),
     ),
     acq_vendors=dict(  # VendorSearch.Meta.index
@@ -988,7 +982,7 @@ RECORDS_REST_SORT_OPTIONS = dict(
             fields=["-_score"],
             title="Best match",
             default_order="asc",
-            order=6,
+            order=2,
         ),
     ),
 )
@@ -1074,14 +1068,12 @@ RECORDS_REST_FACETS = dict(
             ),
             payment_mode=dict(terms=dict(field="order_lines.payment_mode")),
             medium=dict(terms=dict(field="order_lines.medium")),
-            currency=dict(terms=dict(field="grand_total.currency")),
         ),
         post_filters=dict(
             status=terms_filter("status"),
             vendor=terms_filter("vendor.name.keyword"),
             payment_mode=terms_filter("order_lines.payment_mode"),
             medium=terms_filter("order_lines.medium"),
-            currency=terms_filter("grand_total.currency"),
         ),
     ),
     series=dict(  # SeriesSearch.Meta.index

--- a/ui/src/api/acquisition/__tests__/order.serializer.test.js
+++ b/ui/src/api/acquisition/__tests__/order.serializer.test.js
@@ -1,0 +1,72 @@
+import { fromISO } from '@api/date';
+import { orderSerializer as serializer } from '../serializers';
+
+const stringDate = '2018-01-01T11:05:00+01:00';
+const price = {
+  value: 10.5,
+  currency: 'CHF',
+};
+
+describe('Order object serialization', () => {
+  it('should serialize dates', () => {
+    const serialized = serializer.fromJSON({
+      id: 123,
+      updated: stringDate,
+      created: stringDate,
+      metadata: {},
+    });
+
+    expect(serialized).toEqual({
+      id: 123,
+      created: fromISO(stringDate),
+      updated: fromISO(stringDate),
+    });
+  });
+
+  it('should serialize all fields', () => {
+    const serialized = serializer.fromJSON({
+      id: 123,
+      updated: stringDate,
+      created: stringDate,
+      links: 'test',
+      metadata: {
+        pid: '123',
+        cancel_reason: 'abc',
+        delivery_date: stringDate,
+        expected_delivery_date: stringDate,
+        funds: ['abc'],
+        grand_total: price,
+        grand_total_main_currency: price,
+        notes: 'abc',
+        order_date: stringDate,
+        order_lines: [],
+        payment: {},
+        status: 'RECEIVED',
+        vendor_pid: '1',
+      },
+    });
+
+    expect(serialized).toEqual({
+      pid: '123',
+      id: 123,
+      updated: fromISO(stringDate),
+      created: fromISO(stringDate),
+      links: 'test',
+      metadata: {
+        pid: '123',
+        cancel_reason: 'abc',
+        delivery_date: fromISO(stringDate),
+        expected_delivery_date: fromISO(stringDate),
+        funds: ['abc'],
+        grand_total: price,
+        grand_total_main_currency: price,
+        notes: 'abc',
+        order_date: fromISO(stringDate),
+        order_lines: [],
+        payment: {},
+        status: 'RECEIVED',
+        vendor_pid: '1',
+      },
+    });
+  });
+});

--- a/ui/src/api/acquisition/__tests__/order.test.js
+++ b/ui/src/api/acquisition/__tests__/order.test.js
@@ -1,0 +1,27 @@
+import { order as orderApi } from '../order';
+
+describe('Order query builder tests', () => {
+  it('should build the query string with patron', () => {
+    const query = orderApi
+      .query()
+      .withPatron('123')
+      .qs();
+    expect(query).toEqual('order_lines.patron_pid:123');
+  });
+
+  it('should build the query string with recipient', () => {
+    const query = orderApi
+      .query()
+      .withRecipient('PATRON')
+      .qs();
+    expect(query).toEqual('recipient:PATRON');
+  });
+
+  it('should build the query string with vendor', () => {
+    const query = orderApi
+      .query()
+      .withVendor('My vendor')
+      .qs();
+    expect(query).toEqual('vendor.name:"My vendor"');
+  });
+});

--- a/ui/src/api/acquisition/__tests__/vendor.serializer.test.js
+++ b/ui/src/api/acquisition/__tests__/vendor.serializer.test.js
@@ -1,0 +1,54 @@
+import { fromISO } from '@api/date';
+import { vendorSerializer as serializer } from '../serializers';
+
+const stringDate = '2018-01-01T11:05:00+01:00';
+
+describe('Vendor object serialization', () => {
+  it('should serialize dates', () => {
+    const serialized = serializer.fromJSON({
+      id: 123,
+      updated: stringDate,
+      created: stringDate,
+      metadata: {},
+    });
+
+    expect(serialized).toEqual({
+      id: 123,
+      created: fromISO(stringDate),
+      updated: fromISO(stringDate),
+    });
+  });
+
+  it('should serialize all fields', () => {
+    const serialized = serializer.fromJSON({
+      id: 123,
+      updated: stringDate,
+      created: stringDate,
+      links: 'test',
+      metadata: {
+        pid: '123',
+        name: 'My vendor',
+        address: 'Address',
+        email: 'test@test.ch',
+        phone: '12345',
+        notes: 'Test',
+      },
+    });
+
+    expect(serialized).toEqual({
+      pid: '123',
+      id: 123,
+      updated: fromISO(stringDate),
+      created: fromISO(stringDate),
+      links: 'test',
+      metadata: {
+        pid: '123',
+        name: 'My vendor',
+        address: 'Address',
+        email: 'test@test.ch',
+        phone: '12345',
+        notes: 'Test',
+      },
+    });
+  });
+});

--- a/ui/src/api/acquisition/__tests__/vendor.test.js
+++ b/ui/src/api/acquisition/__tests__/vendor.test.js
@@ -1,0 +1,27 @@
+import { vendor as vendorApi } from '../vendor';
+
+describe('Document query builder tests', () => {
+  it('should build the query string with address', () => {
+    const query = vendorApi
+      .query()
+      .withAddress('Address')
+      .qs();
+    expect(query).toEqual('address:"Address"');
+  });
+
+  it('should build the query string with name', () => {
+    const query = vendorApi
+      .query()
+      .withName('Name')
+      .qs();
+    expect(query).toEqual('name:"Name"');
+  });
+
+  it('should build the query string with email', () => {
+    const query = vendorApi
+      .query()
+      .withEmail('email')
+      .qs();
+    expect(query).toEqual('email:"email"');
+  });
+});

--- a/ui/src/api/acquisition/index.js
+++ b/ui/src/api/acquisition/index.js
@@ -1,1 +1,2 @@
+export { order } from './order';
 export { vendor } from './vendor';

--- a/ui/src/api/acquisition/order.js
+++ b/ui/src/api/acquisition/order.js
@@ -1,0 +1,108 @@
+import { http, apiConfig } from '../base';
+import { orderSerializer as serializer } from './serializers';
+
+const orderURL = '/acquisition/orders/';
+
+const get = pid => {
+  return http.get(`${orderURL}${pid}`).then(response => {
+    response.data = serializer.fromJSON(response.data);
+    return response;
+  });
+};
+
+const create = async data => {
+  const resp = await http.post(`${orderURL}`, data);
+  resp.data = serializer.fromJSON(resp.data);
+  return resp;
+};
+
+const update = async (pid, data) => {
+  const response = await http.put(`${orderURL}${pid}`, data);
+  response.data = serializer.fromJSON(response.data);
+  return response;
+};
+
+const list = async query => {
+  const response = await http.get(`${orderURL}?q=${query}`);
+  response.data.total = response.data.hits.total;
+  response.data.hits = response.data.hits.hits.map(hit =>
+    serializer.fromJSON(hit)
+  );
+  return response;
+};
+
+const count = query => {
+  return http.get(`${orderURL}?q=${query}`).then(response => {
+    response.data = response.data.hits.total;
+    return response;
+  });
+};
+
+class QueryBuilder {
+  constructor() {
+    this.patronQuery = [];
+    this.recipientQuery = [];
+    this.vendorQuery = [];
+    this.vendorPidQuery = [];
+    this.sortByQuery = '';
+  }
+
+  withPatron(patronPid) {
+    if (!patronPid) {
+      throw TypeError('Patron PID argument missing');
+    }
+    this.patronQuery.push(`order_lines.patron_pid:${patronPid}`);
+    return this;
+  }
+
+  withRecipient(recipient) {
+    if (!recipient) {
+      throw TypeError('Recipient argument missing');
+    }
+    this.recipientQuery.push(`recipient:${recipient}`);
+    return this;
+  }
+
+  withVendor(name) {
+    if (!name) {
+      throw TypeError('Vendor name argument missing');
+    }
+    this.vendorQuery.push(`vendor.name:"${name}"`);
+    return this;
+  }
+
+  withVendorPid(pid) {
+    if (!pid) {
+      throw TypeError('Vendor pid argument missing');
+    }
+    this.vendorQuery.push(`vendor_pid:${pid}`);
+    return this;
+  }
+
+  sortBy(order = 'bestmatch') {
+    this.sortByQuery = `&sort=${order}`;
+    return this;
+  }
+
+  qs() {
+    const searchCriteria = this.patronQuery
+      .concat(this.recipientQuery, this.vendorQuery)
+      .join(' AND ');
+    return `${searchCriteria}${this.sortByQuery}`;
+  }
+}
+
+const queryBuilder = () => {
+  return new QueryBuilder();
+};
+
+export const order = {
+  searchBaseURL: `${apiConfig.baseURL}${orderURL}`,
+  get: get,
+  create: create,
+  update: update,
+  list: list,
+  count: count,
+  query: queryBuilder,
+  serializer: serializer,
+};

--- a/ui/src/api/acquisition/serializers.js
+++ b/ui/src/api/acquisition/serializers.js
@@ -1,0 +1,56 @@
+import isEmpty from 'lodash/isEmpty';
+import { fromISO } from '../date';
+
+function serializeOrderResponse(hit) {
+  let result = {};
+  if (!isEmpty(hit)) {
+    result.id = hit.id;
+    result.created = fromISO(hit.created);
+    result.updated = fromISO(hit.updated);
+    if (hit.links) {
+      result.links = hit.links;
+    }
+    if (!isEmpty(hit.metadata)) {
+      const {
+        delivery_date,
+        expected_delivery_date,
+        order_date,
+      } = hit.metadata;
+      result.metadata = hit.metadata;
+      result.metadata.order_date = order_date ? fromISO(order_date) : null;
+      result.metadata.delivery_date = delivery_date
+        ? fromISO(delivery_date)
+        : null;
+      result.metadata.expected_delivery_date = expected_delivery_date
+        ? fromISO(expected_delivery_date)
+        : null;
+      result.pid = hit.metadata.pid;
+    }
+  }
+  return result;
+}
+
+function serializeVendorResponse(hit) {
+  let result = {};
+  if (!isEmpty(hit)) {
+    result['id'] = hit.id;
+    result['created'] = fromISO(hit.created);
+    result['updated'] = fromISO(hit.updated);
+    if (hit.links) {
+      result['links'] = hit.links;
+    }
+    if (!isEmpty(hit.metadata)) {
+      result['metadata'] = hit.metadata;
+      result['pid'] = hit.metadata.pid;
+    }
+  }
+  return result;
+}
+
+export const vendorSerializer = {
+  fromJSON: serializeVendorResponse,
+};
+
+export const orderSerializer = {
+  fromJSON: serializeOrderResponse,
+};

--- a/ui/src/api/index.js
+++ b/ui/src/api/index.js
@@ -11,4 +11,4 @@ export { patron } from './patrons/patron';
 export { series } from './series/series';
 export { stats, circulationStats } from './stats';
 export { vocabulary } from './vocabularies/vocabulary';
-export { vendor } from './acquisition';
+export { order, vendor } from './acquisition';

--- a/ui/src/api/utils.js
+++ b/ui/src/api/utils.js
@@ -1,3 +1,5 @@
+import { invenioConfig } from "@config";
+
 export const prepareDateQuery = (field, date, dateFrom, dateTo) => {
   if (
     (!date || typeof date !== 'string') &&
@@ -79,4 +81,13 @@ export const siblingRelationPayload = (relationType, extra, second) => {
     relation_type: relationType,
     ...extra,
   };
+};
+
+export const formatPrice = price => {
+  if (!price) return null;
+
+  return new Intl.NumberFormat(invenioConfig.i18n.priceLocale, {
+    style: 'currency',
+    currency: price.currency,
+  }).format(price.value);
 };

--- a/ui/src/config/__mocks__/invenioConfig.js
+++ b/ui/src/config/__mocks__/invenioConfig.js
@@ -10,6 +10,22 @@ export const invenioConfig = {
     deliveryMethods: { DELIVERY: '', 'PICK UP': '' },
     requestDuration: 60,
   },
+  orders: {
+    currencies: [
+      { value: 'EUR', text: 'Euro' },
+      { value: 'CHF', text: 'Swiss Francs' },
+    ],
+    paymentModes: [
+      { value: 'CREDIT_CARD', text: 'Credit Card' },
+      { value: 'CASH', text: 'Cash' },
+    ],
+    statuses: [
+      { value: 'CANCELLED', text: 'Cancelled' },
+      { value: 'RECEIVED', text: 'Received' },
+      { value: 'ORDERED', text: 'Ordered' },
+      { value: 'PENDING', text: 'Pending' },
+    ],
+  },
   relationTypes: [
     {
       id: 0,

--- a/ui/src/config/invenioConfig.js
+++ b/ui/src/config/invenioConfig.js
@@ -27,6 +27,9 @@ export const invenioConfig = {
   eitems: {
     maxFiles: 5,
   },
+  i18n: {
+    priceLocale: 'en-GB',
+  },
   items: {
     canCirculateStates: ['CAN_CIRCULATE'],
     circulationRestrictions: [
@@ -51,15 +54,24 @@ export const invenioConfig = {
       { value: 'IN_BINDING', text: 'In binding' },
       { value: 'SCANNING', text: 'Scanning' },
     ],
-    circulationStates:[
-      {value: 'ITEM_ON_LOAN', text: 'On loan'},
-      {value: 'NOT_ON_LOAN', text: 'Not loaned'},
-    ]
+    circulationStates: [
+      { value: 'ITEM_ON_LOAN', text: 'On loan' },
+      { value: 'NOT_ON_LOAN', text: 'Not loaned' },
+    ],
   },
   loans: {
     maxExtensionsCount: 3,
   },
   max_results_window: 10000,
+  orders: {
+    maxShowOrderLines: 3,
+    statuses: [
+      { value: 'CANCELLED', text: 'Cancelled' },
+      { value: 'RECEIVED', text: 'Received' },
+      { value: 'ORDERED', text: 'Ordered' },
+      { value: 'PENDING', text: 'Pending' },
+    ],
+  },
   relationTypes: [
     {
       id: 3,

--- a/ui/src/config/searchConfig.js
+++ b/ui/src/config/searchConfig.js
@@ -261,6 +261,94 @@ const searchConfig = {
     },
     sortOrder: ['asc', 'desc'],
   },
+  orders: {
+    filters: [
+      {
+        title: 'Status',
+        field: 'status',
+        aggName: 'status',
+        labels: invenioConfig.orders.statuses,
+      },
+      {
+        title: 'Vendor',
+        field: 'vendor.name',
+        aggName: 'vendor',
+      },
+      {
+        title: 'Payment mode',
+        field: 'order_lines.payment_mode',
+        aggName: 'payment_mode',
+      },
+      {
+        title: 'Medium',
+        field: 'order_lines.medium',
+        aggName: 'medium',
+        labels: invenioConfig.items.mediums,
+      },
+      {
+        title: 'Currency',
+        field: 'grand_total.currency',
+        aggName: 'currency',
+      },
+    ],
+    sortBy: {
+      onEmptyQuery: 'order_date',
+      values: [
+        {
+          default_order: 'desc',
+          field: 'order_date',
+          order: 1,
+          title: 'Order date',
+        },
+        {
+          default_order: 'desc',
+          field: 'grand_total_main_currency.value',
+          order: 2,
+          title: 'Grand total',
+        },
+        {
+          default_order: 'desc',
+          field: 'delivery_date',
+          order: 3,
+          title: 'Delivery date',
+        },
+        {
+          default_order: 'desc',
+          field: 'expected_delivery_date',
+          order: 4,
+          title: 'Expected delivery date',
+        },
+        {
+          default_order: 'asc',
+          field: 'bestmatch',
+          order: 5,
+          title: 'Best match',
+        },
+      ],
+    },
+    sortOrder: ['desc', 'asc'],
+  },
+  vendors: {
+    filters: [],
+    sortBy: {
+      onEmptyQuery: 'name',
+      values: [
+        {
+          default_order: 'asc',
+          field: 'name',
+          order: 1,
+          title: 'Name',
+        },
+        {
+          default_order: 'asc',
+          field: 'bestmatch',
+          order: 2,
+          title: 'Best match',
+        },
+      ],
+    },
+    sortOrder: ['asc', 'desc'],
+  },
 };
 
 export const getSearchConfig = (modelName, extraOptions = {}) => {

--- a/ui/src/pages/backoffice/Acquisition/Order/OrderSearch/OrderSearch.js
+++ b/ui/src/pages/backoffice/Acquisition/Order/OrderSearch/OrderSearch.js
@@ -1,0 +1,139 @@
+import React, { Component } from 'react';
+import { Container, Grid, Header } from 'semantic-ui-react';
+import {
+  Error,
+  ResultsList,
+  ReactSearchKit,
+  ResultsLoader,
+  SearchBar,
+  InvenioSearchApi,
+} from 'react-searchkit';
+import {
+  Error as IlsError,
+  SearchBar as OrdersSearchBar,
+  SearchControls,
+} from '@components';
+import { order as orderApi } from '@api';
+import { getSearchConfig } from '@config';
+import { AcquisitionRoutes } from '@routes/urls';
+import {
+  OrderList,
+  ExportReactSearchKitResults,
+  NewButton,
+} from '../../../components';
+import {
+  SearchFooter,
+  SearchEmptyResults,
+  SearchAggregationsCards,
+} from '@components/SearchControls/components/';
+import history from '@history';
+
+class OrderResponseSerializer {
+  serialize(results) {
+    const hits = results.hits.hits.map(hit =>
+      orderApi.serializer.fromJSON(hit)
+    );
+    return {
+      aggregations: results.aggregations || {},
+      hits: hits,
+      total: results.hits.total,
+    };
+  }
+}
+
+export class OrderSearch extends Component {
+  searchApi = new InvenioSearchApi({
+    invenio: {
+      responseSerializer: OrderResponseSerializer,
+    },
+    url: orderApi.searchBaseURL,
+    withCredentials: true,
+  });
+  searchConfig = getSearchConfig('orders');
+
+  renderSearchBar = (_, queryString, onInputChange, executeSearch) => {
+    const helperFields = [
+      {
+        name: 'vendor',
+        field: 'vendor.name',
+        defaultValue: '"Dolor"',
+      },
+      {
+        name: 'recipient',
+        field: 'order_lines.recipient',
+        defaultValue: 'PATRON',
+      },
+      {
+        name: 'patron id',
+        field: 'order_lines.patron_pid',
+        defaultValue: '1',
+      },
+    ];
+    return (
+      <OrdersSearchBar
+        currentQueryString={queryString}
+        onInputChange={onInputChange}
+        executeSearch={executeSearch}
+        placeholder={'Search for orders'}
+        queryHelperFields={helperFields}
+      />
+    );
+  };
+
+  renderEmptyResultsExtra = () => {
+    return <NewButton text={'Add order'} to={AcquisitionRoutes.orderCreate} />;
+  };
+
+  renderError = error => {
+    return <IlsError error={error} />;
+  };
+
+  renderOrderList = results => {
+    return <OrderList hits={results} />;
+  };
+
+  render() {
+    return (
+      <>
+        <Header as="h2">Purchase Orders</Header>
+        <ReactSearchKit searchApi={this.searchApi} history={history}>
+          <Container fluid className="spaced">
+            <SearchBar renderElement={this.renderSearchBar} />
+          </Container>
+          <Container fluid className="bo-search-body">
+            <Grid>
+              <Grid.Row columns={2}>
+                <ResultsLoader>
+                  <Grid.Column width={3} className={'search-aggregations'}>
+                    <Header content={'Filter by'} />
+                    <SearchAggregationsCards modelName={'orders'} />
+                  </Grid.Column>
+                  <Grid.Column width={13}>
+                    <Grid columns={2}>
+                      <Grid.Column width={8}>
+                        <NewButton
+                          text={'Add order'}
+                          to={AcquisitionRoutes.orderCreate}
+                        />
+                      </Grid.Column>
+                      <Grid.Column width={8} textAlign={'right'}>
+                        <ExportReactSearchKitResults
+                          exportBaseUrl={orderApi.searchBaseURL}
+                        />
+                      </Grid.Column>
+                    </Grid>
+                    <SearchEmptyResults extras={this.renderEmptyResultsExtra} />
+                    <Error renderElement={this.renderError} />
+                    <SearchControls modelName={'orders'} />
+                    <ResultsList renderElement={this.renderOrderList} />
+                    <SearchFooter />
+                  </Grid.Column>
+                </ResultsLoader>
+              </Grid.Row>
+            </Grid>
+          </Container>
+        </ReactSearchKit>
+      </>
+    );
+  }
+}

--- a/ui/src/pages/backoffice/Acquisition/Order/OrderSearch/__tests__/OrderSearch.test.js
+++ b/ui/src/pages/backoffice/Acquisition/Order/OrderSearch/__tests__/OrderSearch.test.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Settings } from 'luxon';
+import { fromISO } from '@api/date';
+import { ResultsTable } from '@components';
+import { Button } from 'semantic-ui-react';
+
+jest.mock('@pages/backoffice/components');
+
+Settings.defaultZoneName = 'utc';
+const stringDate = fromISO('2018-01-01T11:05:00+01:00');
+const data = [
+  {
+    id: 3,
+    created: stringDate,
+    updated: stringDate,
+    pid: '3',
+    metadata: {
+      pid: '3',
+      authors: [{ full_name: 'Author1' }],
+      title: 'This is a title',
+    },
+  },
+];
+const mockViewDetails = jest.fn();
+const columns = [
+  {
+    title: 'view',
+    field: '',
+    formatter: () => <Button onClick={mockViewDetails}>View</Button>,
+  },
+  { title: 'Title', field: 'metadata.title' },
+];
+
+let component;
+afterEach(() => {
+  mockViewDetails.mockClear();
+  component.unmount();
+});
+
+describe('OrdersSearch ResultsTable tests', () => {
+  it('should not render when empty results', () => {
+    component = mount(<ResultsTable data={[]} columns={columns} />);
+    expect(component).toMatchSnapshot();
+  });
+
+  it('should render a list of results', () => {
+    component = mount(<ResultsTable data={data} columns={columns} />);
+    expect(component).toMatchSnapshot();
+    const firstResult = data[0];
+    const resultRows = component
+      .find('TableRow')
+      .filterWhere(
+        element => element.prop('data-test') === firstResult.metadata.pid
+      );
+    expect(resultRows).toHaveLength(1);
+
+    const mappedStatusElements = resultRows
+      .find('TableCell')
+      .filterWhere(
+        element => element.prop('data-test') === `1-${firstResult.metadata.pid}`
+      );
+    expect(mappedStatusElements).toHaveLength(1);
+    expect(mappedStatusElements.text()).toEqual(firstResult.metadata.title);
+  });
+
+  it('should call click handler on view details click', () => {
+    component = mount(<ResultsTable data={data} columns={columns} />);
+    const firstId = data[0].pid;
+    const button = component
+      .find('TableRow')
+      .filterWhere(element => element.prop('data-test') === firstId)
+      .find('button');
+    button.simulate('click');
+    expect(mockViewDetails).toHaveBeenCalled();
+  });
+});

--- a/ui/src/pages/backoffice/Acquisition/Order/OrderSearch/__tests__/__snapshots__/OrderSearch.test.js.snap
+++ b/ui/src/pages/backoffice/Acquisition/Order/OrderSearch/__tests__/__snapshots__/OrderSearch.test.js.snap
@@ -1,0 +1,366 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OrdersSearch ResultsTable tests should not render when empty results 1`] = `
+<ResultsTable
+  columns={
+    Array [
+      Object {
+        "field": "",
+        "formatter": [Function],
+        "title": "view",
+      },
+      Object {
+        "field": "metadata.title",
+        "title": "Title",
+      },
+    ]
+  }
+  currentPage={1}
+  data={Array []}
+  headerActionComponent={null}
+  paginationComponent={null}
+  seeAllComponent={null}
+  showAllResults={false}
+  showMaxRows={10}
+  singleLine={false}
+  subtitle=""
+  title=""
+>
+  <Grid>
+    <div
+      className="ui grid"
+    >
+      <GridRow>
+        <div
+          className="row"
+        >
+          <GridColumn
+            verticalAlign="middle"
+            width={16}
+          >
+            <div
+              className="middle aligned sixteen wide column"
+            />
+          </GridColumn>
+          <GridColumn
+            textAlign="right"
+            width={8}
+          >
+            <div
+              className="right aligned eight wide column"
+            />
+          </GridColumn>
+        </div>
+      </GridRow>
+    </div>
+  </Grid>
+  <Message
+    data-test="no-results"
+    icon={true}
+    info={true}
+  >
+    <div
+      className="ui icon info message"
+      data-test="no-results"
+    >
+      <MessageContent>
+        <div
+          className="content"
+        >
+          <MessageHeader>
+            <div
+              className="header"
+            >
+              No results found
+            </div>
+          </MessageHeader>
+          There are no 
+          .
+        </div>
+      </MessageContent>
+    </div>
+  </Message>
+</ResultsTable>
+`;
+
+exports[`OrdersSearch ResultsTable tests should render a list of results 1`] = `
+<ResultsTable
+  columns={
+    Array [
+      Object {
+        "field": "",
+        "formatter": [Function],
+        "title": "view",
+      },
+      Object {
+        "field": "metadata.title",
+        "title": "Title",
+      },
+    ]
+  }
+  currentPage={1}
+  data={
+    Array [
+      Object {
+        "created": "2018-01-01T10:05:00.000Z",
+        "id": 3,
+        "metadata": Object {
+          "authors": Array [
+            Object {
+              "full_name": "Author1",
+            },
+          ],
+          "pid": "3",
+          "title": "This is a title",
+        },
+        "pid": "3",
+        "updated": "2018-01-01T10:05:00.000Z",
+      },
+    ]
+  }
+  headerActionComponent={null}
+  paginationComponent={null}
+  seeAllComponent={null}
+  showAllResults={false}
+  showMaxRows={10}
+  singleLine={false}
+  subtitle=""
+  title=""
+>
+  <Grid>
+    <div
+      className="ui grid"
+    >
+      <GridRow>
+        <div
+          className="row"
+        >
+          <GridColumn
+            verticalAlign="middle"
+            width={16}
+          >
+            <div
+              className="middle aligned sixteen wide column"
+            />
+          </GridColumn>
+          <GridColumn
+            textAlign="right"
+            width={8}
+          >
+            <div
+              className="right aligned eight wide column"
+            />
+          </GridColumn>
+        </div>
+      </GridRow>
+    </div>
+  </Grid>
+  <Table
+    as="table"
+    compact={true}
+    selectable={true}
+    striped={true}
+    subtitle=""
+    title=""
+    unstackable={true}
+  >
+    <table
+      className="ui selectable striped unstackable compact table"
+      subtitle=""
+      title=""
+    >
+      <ResultsTableHeader
+        columns={
+          Array [
+            Object {
+              "field": "",
+              "formatter": [Function],
+              "title": "view",
+            },
+            Object {
+              "field": "metadata.title",
+              "title": "Title",
+            },
+          ]
+        }
+      >
+        <TableHeader
+          as="thead"
+        >
+          <thead
+            className=""
+          >
+            <TableRow
+              as="tr"
+              cellAs="td"
+              data-test="header"
+            >
+              <tr
+                className=""
+                data-test="header"
+              >
+                <TableHeaderCell
+                  as="th"
+                  key="view"
+                >
+                  <TableCell
+                    as="th"
+                    className=""
+                  >
+                    <th
+                      className=""
+                    >
+                      view
+                    </th>
+                  </TableCell>
+                </TableHeaderCell>
+                <TableHeaderCell
+                  as="th"
+                  key="Title"
+                >
+                  <TableCell
+                    as="th"
+                    className=""
+                  >
+                    <th
+                      className=""
+                    >
+                      Title
+                    </th>
+                  </TableCell>
+                </TableHeaderCell>
+              </tr>
+            </TableRow>
+          </thead>
+        </TableHeader>
+      </ResultsTableHeader>
+      <ResultsTableBody
+        columns={
+          Array [
+            Object {
+              "field": "",
+              "formatter": [Function],
+              "title": "view",
+            },
+            Object {
+              "field": "metadata.title",
+              "title": "Title",
+            },
+          ]
+        }
+        rows={
+          Array [
+            Object {
+              "created": "2018-01-01T10:05:00.000Z",
+              "id": 3,
+              "metadata": Object {
+                "authors": Array [
+                  Object {
+                    "full_name": "Author1",
+                  },
+                ],
+                "pid": "3",
+                "title": "This is a title",
+              },
+              "pid": "3",
+              "updated": "2018-01-01T10:05:00.000Z",
+            },
+          ]
+        }
+      >
+        <TableBody
+          as="tbody"
+        >
+          <tbody
+            className=""
+          >
+            <TableRow
+              as="tr"
+              cellAs="td"
+              data-test="3"
+              key="3"
+            >
+              <tr
+                className=""
+                data-test="3"
+              >
+                <TableCell
+                  as="td"
+                  data-label="view"
+                  data-test="0-3"
+                  key="0-3"
+                >
+                  <td
+                    className=""
+                    data-label="view"
+                    data-test="0-3"
+                  >
+                    <Button
+                      as="button"
+                      onClick={[MockFunction]}
+                    >
+                      <Ref
+                        innerRef={
+                          Object {
+                            "current": <button
+                              class="ui button"
+                            >
+                              View
+                            </button>,
+                          }
+                        }
+                      >
+                        <RefFindNode
+                          innerRef={
+                            Object {
+                              "current": <button
+                                class="ui button"
+                              >
+                                View
+                              </button>,
+                            }
+                          }
+                        >
+                          <button
+                            className="ui button"
+                            onClick={[Function]}
+                          >
+                            View
+                          </button>
+                        </RefFindNode>
+                      </Ref>
+                    </Button>
+                  </td>
+                </TableCell>
+                <TableCell
+                  as="td"
+                  data-label="Title"
+                  data-test="1-3"
+                  key="1-3"
+                >
+                  <td
+                    className=""
+                    data-label="Title"
+                    data-test="1-3"
+                  >
+                    This is a title
+                  </td>
+                </TableCell>
+              </tr>
+            </TableRow>
+          </tbody>
+        </TableBody>
+      </ResultsTableBody>
+      <ResultsTableFooter
+        allRowsNumber={1}
+        columnsNumber={2}
+        currentPage={1}
+        paginationComponent={null}
+        seeAllComponent={null}
+        showAllResults={false}
+        showMaxRows={10}
+      />
+    </table>
+  </Table>
+</ResultsTable>
+`;

--- a/ui/src/pages/backoffice/Acquisition/Order/OrderSearch/index.js
+++ b/ui/src/pages/backoffice/Acquisition/Order/OrderSearch/index.js
@@ -1,0 +1,1 @@
+export { OrderSearch } from './OrderSearch';

--- a/ui/src/pages/backoffice/Acquisition/Order/index.js
+++ b/ui/src/pages/backoffice/Acquisition/Order/index.js
@@ -1,0 +1,1 @@
+export { OrderSearch } from './OrderSearch';

--- a/ui/src/pages/backoffice/Acquisition/Vendor/VendorSearch/VendorSearch.js
+++ b/ui/src/pages/backoffice/Acquisition/Vendor/VendorSearch/VendorSearch.js
@@ -1,0 +1,120 @@
+import React, { Component } from 'react';
+import { Container, Grid, Header } from 'semantic-ui-react';
+import {
+  Error,
+  ResultsList,
+  ReactSearchKit,
+  ResultsLoader,
+  SearchBar,
+  InvenioSearchApi,
+} from 'react-searchkit';
+import {
+  Error as IlsError,
+  SearchBar as VendorsSearchBar,
+  SearchControls,
+} from '@components';
+import { vendor as vendorApi } from '@api';
+import { getSearchConfig } from '@config';
+import { AcquisitionRoutes } from '@routes/urls';
+import {
+  VendorList,
+  ExportReactSearchKitResults,
+  NewButton,
+} from '../../../components';
+import {
+  SearchFooter,
+  SearchEmptyResults,
+} from '@components/SearchControls/components/';
+import history from '@history';
+
+export class VendorSearch extends Component {
+  searchApi = new InvenioSearchApi({
+    url: vendorApi.searchBaseURL,
+    withCredentials: true,
+  });
+  searchConfig = getSearchConfig('vendors');
+
+  renderSearchBar = (_, queryString, onInputChange, executeSearch) => {
+    const helperFields = [
+      {
+        name: 'name',
+        field: 'name',
+        defaultValue: '"Test vendor"',
+      },
+      {
+        name: 'email',
+        field: 'email',
+        defaultValue: '"info@vendor.com"',
+      },
+      {
+        name: 'address',
+        field: 'address',
+        defaultValue: '"Geneva"',
+      },
+    ];
+    return (
+      <VendorsSearchBar
+        currentQueryString={queryString}
+        onInputChange={onInputChange}
+        executeSearch={executeSearch}
+        placeholder={'Search for vendors'}
+        queryHelperFields={helperFields}
+      />
+    );
+  };
+
+  renderEmptyResultsExtra = () => {
+    return (
+      <NewButton text={'Add vendor'} to={AcquisitionRoutes.vendorCreate} />
+    );
+  };
+
+  renderError = error => {
+    return <IlsError error={error} />;
+  };
+
+  renderVendorList = results => {
+    return <VendorList hits={results} />;
+  };
+
+  render() {
+    return (
+      <>
+        <Header as="h2">Vendors</Header>
+        <ReactSearchKit searchApi={this.searchApi} history={history}>
+          <Container fluid className="spaced">
+            <SearchBar renderElement={this.renderSearchBar} />
+          </Container>
+          <Container fluid className="bo-search-body">
+            <Grid>
+              <Grid.Row columns={2}>
+                <ResultsLoader>
+                  <Grid.Column width={16}>
+                    <Grid columns={2}>
+                      <Grid.Column width={8}>
+                        <NewButton
+                          text={'Add vendor'}
+                          to={AcquisitionRoutes.vendorCreate}
+                        />
+                      </Grid.Column>
+                      <Grid.Column width={8} textAlign={'right'}>
+                        <ExportReactSearchKitResults
+                          exportBaseUrl={vendorApi.searchBaseURL}
+                        />
+                      </Grid.Column>
+                    </Grid>
+                    <SearchEmptyResults extras={this.renderEmptyResultsExtra} />
+                    <Error renderElement={this.renderError} />
+                    <SearchControls modelName={'vendors'} />
+                    <ResultsList renderElement={this.renderVendorList} />
+                    <SearchFooter />
+                  </Grid.Column>
+                </ResultsLoader>
+              </Grid.Row>
+            </Grid>
+          </Container>
+        </ReactSearchKit>
+      </>
+    );
+  }
+}

--- a/ui/src/pages/backoffice/Acquisition/Vendor/VendorSearch/index.js
+++ b/ui/src/pages/backoffice/Acquisition/Vendor/VendorSearch/index.js
@@ -1,2 +1,1 @@
-export { VendorEditor } from './VendorEditor';
 export { VendorSearch } from './VendorSearch';

--- a/ui/src/pages/backoffice/Acquisition/index.js
+++ b/ui/src/pages/backoffice/Acquisition/index.js
@@ -1,1 +1,2 @@
-export { VendorEditor } from './Vendor';
+export { VendorEditor, VendorSearch } from './Vendor';
+export { OrderSearch } from './Order';

--- a/ui/src/pages/backoffice/components/OrderList/OrderList.js
+++ b/ui/src/pages/backoffice/components/OrderList/OrderList.js
@@ -1,0 +1,35 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Message, Item } from 'semantic-ui-react';
+import OrderListEntry from './OrderListEntry';
+
+export default class OrderList extends Component {
+  renderListEntry = order => {
+    if (this.props.renderListEntryElement) {
+      return this.props.renderListEntryElement(order);
+    }
+    return (
+      <OrderListEntry key={order.metadata.pid} order={order} />
+    );
+  };
+
+  render() {
+    const { hits } = this.props;
+
+    if (!hits.length)
+      return <Message data-test="no-results">There are no orders.</Message>;
+
+    return (
+      <Item.Group divided className={'bo-document-search'}>
+        {hits.map(hit => {
+          return this.renderListEntry(hit);
+        })}
+      </Item.Group>
+    );
+  }
+}
+
+OrderList.propTypes = {
+  hits: PropTypes.array.isRequired,
+  renderListEntryElement: PropTypes.func,
+};

--- a/ui/src/pages/backoffice/components/OrderList/OrderListEntry.js
+++ b/ui/src/pages/backoffice/components/OrderList/OrderListEntry.js
@@ -1,0 +1,162 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { Grid, Header, Item, List, Icon } from 'semantic-ui-react';
+import { BackOfficeRoutes, AcquisitionRoutes } from '@routes/urls';
+import { toShortDateTime } from '@api/date';
+import { formatPrice } from '@api/utils';
+import { invenioConfig } from '@config';
+import { getDisplayVal } from '@config/invenioConfig';
+
+export default class OrderListEntry extends Component {
+  renderLeftColumn = order => {
+    return (
+      <>
+        <Item.Description>
+          <Item.Meta>
+            Ordered: {toShortDateTime(order.metadata.order_date)}
+          </Item.Meta>
+        </Item.Description>
+        <Item.Description>
+          <label>status </label>
+          {getDisplayVal('orders.statuses', order.metadata.status).text}
+        </Item.Description>
+        <Item.Description>
+          <label>vendor </label>
+          <Link
+            to={AcquisitionRoutes.vendorDetailsFor(order.metadata.vendor_pid)}
+          >
+            {order.metadata.vendor.name}
+          </Link>
+        </Item.Description>
+        <Item.Description>
+          <label>total</label> {formatPrice(order.metadata.grand_total)}
+        </Item.Description>
+      </>
+    );
+  };
+
+  renderOrderLine = (orderLine, index) => {
+    const documentPid = orderLine.document_pid;
+    const patronPid = orderLine.patron_pid;
+    const medium = getDisplayVal('items.mediums', orderLine.medium).text;
+    const documentLink = (
+      <Link to={BackOfficeRoutes.documentDetailsFor(documentPid)}>
+        <code>{documentPid}</code>
+      </Link>
+    );
+    const totalPrice = formatPrice(orderLine.total_price);
+    return (
+      <List.Item
+        as="li"
+        key={documentPid}
+        value={`${orderLine.copies_ordered}x`}
+      >
+        Document {documentLink} - {medium}
+        {patronPid && (
+          <>
+            {' '} - Patron{' '}
+            <Link to={BackOfficeRoutes.patronDetailsFor(patronPid)}>
+              <code>{patronPid}</code>
+            </Link>
+          </>
+        )}{' '}
+        - <em>{totalPrice}</em>
+      </List.Item>
+    );
+  };
+
+  renderMiddleColumn = order => {
+    if (this.props.renderMiddleColumn) {
+      return this.props.renderMiddleColumn(order);
+    }
+    const showMax = invenioConfig.orders.maxShowOrderLines;
+    const orderLines = order.metadata.order_lines;
+    return (
+      <List as="ol">
+        {orderLines
+          .slice(0, showMax)
+          .map((ol, index) => this.renderOrderLine(ol, index))}
+        {orderLines.length > showMax && (
+          <List.Item as="li" value="...">
+            of {orderLines.length} order lines
+          </List.Item>
+        )}
+      </List>
+    );
+  };
+
+  renderRightColumn = order => {
+    if (this.props.renderRightColumn) {
+      return this.props.renderRightColumn(order);
+    }
+    const { delivery_date, expected_delivery_date, payment } = order.metadata;
+    return (
+      <List verticalAlign="middle" className={'document-circulation'}>
+        <List.Item>
+          <List.Content floated="right">
+            <strong>{payment.mode}</strong>
+          </List.Content>
+          <List.Content>payment mode</List.Content>
+        </List.Item>
+        {delivery_date && (
+          <List.Item>
+            <List.Content floated="right">
+              <strong>{toShortDateTime(delivery_date)}</strong>
+            </List.Content>
+            <List.Content>delivered</List.Content>
+          </List.Item>
+        )}
+        {expected_delivery_date && (
+          <List.Item>
+            <List.Content floated="right">
+              <strong>{toShortDateTime(expected_delivery_date)}</strong>
+            </List.Content>
+            <List.Content>expected delivery date</List.Content>
+          </List.Item>
+        )}
+      </List>
+    );
+  };
+
+  render() {
+    const { order } = this.props;
+    return (
+      <Item>
+        <Item.Content>
+          <Item.Header
+            as={Link}
+            to={AcquisitionRoutes.orderDetailsFor(order.metadata.pid)}
+            data-test={`navigate-${order.metadata.pid}`}
+          >
+            <Icon name="shopping cart" />
+            Order: {order.metadata.pid}
+          </Item.Header>
+          <Grid highlight={3}>
+            <Grid.Column computer={5} largeScreen={5}>
+              {this.renderLeftColumn(order)}
+            </Grid.Column>
+            <Grid.Column computer={6} largeScreen={6}>
+              {this.renderMiddleColumn(order)}
+            </Grid.Column>
+            <Grid.Column width={1} />
+            <Grid.Column computer={3} largeScreen={3}>
+              {this.renderRightColumn(order)}
+            </Grid.Column>
+          </Grid>
+        </Item.Content>
+        <Item.Meta className={'pid-field'}>
+          <Header disabled as="h5" className={'pid-field'}>
+            #{order.metadata.pid}
+          </Header>
+        </Item.Meta>
+      </Item>
+    );
+  }
+}
+
+OrderListEntry.propTypes = {
+  order: PropTypes.object.isRequired,
+  renderMiddleColumn: PropTypes.func,
+  renderRightColumn: PropTypes.func,
+};

--- a/ui/src/pages/backoffice/components/OrderList/index.js
+++ b/ui/src/pages/backoffice/components/OrderList/index.js
@@ -1,0 +1,2 @@
+export { default as OrderList } from './OrderList';
+export { default as OrderListEntry } from './OrderListEntry';

--- a/ui/src/pages/backoffice/components/Sidebar/Sidebar.js
+++ b/ui/src/pages/backoffice/components/Sidebar/Sidebar.js
@@ -2,7 +2,11 @@ import React, { Component } from 'react';
 import { withRouter } from 'react-router';
 import { Link } from 'react-router-dom';
 import { Header, Icon, Menu, Divider } from 'semantic-ui-react';
-import { BackOfficeRoutes, FrontSiteRoutes } from '@routes/urls';
+import {
+  AcquisitionRoutes,
+  BackOfficeRoutes,
+  FrontSiteRoutes,
+} from '@routes/urls';
 import has from 'lodash/has';
 
 class Sidebar extends Component {
@@ -20,6 +24,8 @@ class Sidebar extends Component {
     const documentsActive = activePath === BackOfficeRoutes.documentsList;
     const documentRequestsActive =
       activePath === BackOfficeRoutes.documentRequestsList;
+    const ordersActive = activePath === AcquisitionRoutes.ordersList;
+    const vendorsActive = activePath === AcquisitionRoutes.vendorsList;
     const patronsActive = activePath === BackOfficeRoutes.patronsList;
     const seriesActive = activePath === BackOfficeRoutes.seriesList;
     const statsActive = activePath === BackOfficeRoutes.stats.home;
@@ -98,6 +104,26 @@ class Sidebar extends Component {
                 to={BackOfficeRoutes.eitemsList}
               >
                 Electronic Items
+              </Menu.Item>
+            </Menu.Menu>
+          </Menu.Item>
+
+          <Menu.Item>
+            <Menu.Header>Acquisition</Menu.Header>
+            <Menu.Menu>
+              <Menu.Item
+                as={Link}
+                active={ordersActive}
+                to={AcquisitionRoutes.ordersList}
+              >
+                Orders
+              </Menu.Item>
+              <Menu.Item
+                as={Link}
+                active={vendorsActive}
+                to={AcquisitionRoutes.vendorsList}
+              >
+                Vendors
               </Menu.Item>
             </Menu.Menu>
           </Menu.Item>

--- a/ui/src/pages/backoffice/components/VendorList/VendorList.js
+++ b/ui/src/pages/backoffice/components/VendorList/VendorList.js
@@ -1,0 +1,33 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Message, Item } from 'semantic-ui-react';
+import VendorListEntry from './VendorListEntry';
+
+export default class VendorList extends Component {
+  renderListEntry = vendor => {
+    if (this.props.renderListEntryElement) {
+      return this.props.renderListEntryElement(vendor);
+    }
+    return <VendorListEntry key={vendor.metadata.pid} vendor={vendor} />;
+  };
+
+  render() {
+    const { hits } = this.props;
+
+    if (!hits.length)
+      return <Message data-test="no-results">There are no vendors.</Message>;
+
+    return (
+      <Item.Group divided className={'bo-document-search'}>
+        {hits.map(hit => {
+          return this.renderListEntry(hit);
+        })}
+      </Item.Group>
+    );
+  }
+}
+
+VendorList.propTypes = {
+  hits: PropTypes.array.isRequired,
+  renderListEntryElement: PropTypes.func,
+};

--- a/ui/src/pages/backoffice/components/VendorList/VendorListEntry.js
+++ b/ui/src/pages/backoffice/components/VendorList/VendorListEntry.js
@@ -1,0 +1,115 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { Grid, Header, Icon, Item, List } from 'semantic-ui-react';
+import { AcquisitionRoutes, BackOfficeRoutes } from '@routes/urls';
+import { order as orderApi } from '@api';
+
+const VendorListInfo = ({ vendor }) => (
+  <List verticalAlign="middle" className={'document-circulation'}>
+    <List.Item>
+      <List.Content floated="right">
+        <strong>{vendor.metadata.email}</strong>
+      </List.Content>
+      <List.Content>email</List.Content>
+    </List.Item>
+    <List.Item>
+      <List.Content floated="right">
+        <strong>{vendor.metadata.phone}</strong>
+      </List.Content>
+      <List.Content>phone</List.Content>
+    </List.Item>
+  </List>
+);
+
+const VendorOrderSearch = ({ vendor }) => {
+  const orderQuery = orderApi
+    .query()
+    .withVendorPid(vendor.metadata.pid)
+    .qs();
+  return (
+    <List.Item>
+      <List.Content>
+        <Link to={AcquisitionRoutes.ordersListWithQuery(orderQuery)}>
+          <Icon name="search" />
+          Find purchase orders
+        </Link>
+      </List.Content>
+    </List.Item>
+  );
+};
+
+export default class VendorListEntry extends Component {
+  renderMiddleColumn = vendor => {
+    if (this.props.renderMiddleColumn) {
+      return this.props.renderMiddleColumn(vendor);
+    }
+    return <VendorListInfo vendor={vendor} />;
+  };
+
+  renderRightColumn = vendor => {
+    if (this.props.renderRightColumn) {
+      return this.props.renderRightColumn(vendor);
+    }
+    return <VendorOrderSearch vendor={vendor} />;
+  };
+
+  renderAddress = () => {
+    const address = this.props.vendor.metadata.address;
+    if (!address) return null;
+
+    return (
+      <Item.Description>
+        <p>
+          {address.split('\n').map((line, index) => (
+            <React.Fragment key={index}>
+              {line}
+              <br />
+            </React.Fragment>
+          ))}
+        </p>
+      </Item.Description>
+    );
+  };
+
+  render() {
+    const { vendor } = this.props;
+    return (
+      <Item>
+        <Item.Content>
+          <Item.Header
+            as={Link}
+            to={AcquisitionRoutes.vendorDetailsFor(vendor.metadata.pid)}
+            data-test={`navigate-${vendor.metadata.pid}`}
+          >
+            {vendor.metadata.name}
+          </Item.Header>
+          <Item.Meta>Address:</Item.Meta>
+          <Grid highlight={3}>
+            <Grid.Column computer={6} largeScreen={6}>
+              {this.renderAddress()}
+            </Grid.Column>
+            <Grid.Column computer={4} largeScreen={4}>
+              {this.renderMiddleColumn(vendor)}
+            </Grid.Column>
+            <Grid.Column width={1} />
+            <Grid.Column computer={2} largeScreen={2}>
+              {this.renderRightColumn(vendor)}
+            </Grid.Column>
+          </Grid>
+        </Item.Content>
+        <Item.Meta className={'pid-field'}>
+          <Header disabled as="h5" className={'pid-field'}>
+            #{vendor.metadata.pid}
+          </Header>
+        </Item.Meta>
+      </Item>
+    );
+  }
+}
+
+VendorListEntry.propTypes = {
+  vendor: PropTypes.object.isRequired,
+  renderMiddleColumn: PropTypes.func,
+  renderRightColumn: PropTypes.func,
+};

--- a/ui/src/pages/backoffice/components/VendorList/index.js
+++ b/ui/src/pages/backoffice/components/VendorList/index.js
@@ -1,0 +1,2 @@
+export { default as VendorList } from './VendorList';
+export { default as VendorListEntry } from './VendorListEntry';

--- a/ui/src/pages/backoffice/components/index.js
+++ b/ui/src/pages/backoffice/components/index.js
@@ -7,4 +7,6 @@ export {
 export { OverdueLoanSendMailModal } from './OverdueLoanSendMailModal';
 export { Sidebar } from './Sidebar';
 export { DocumentList } from './DocumentList';
+export { OrderList } from './OrderList';
+export { VendorList } from './VendorList';
 export { EditButton, NewButton, SeeAllButton } from './buttons';

--- a/ui/src/pages/backoffice/index.js
+++ b/ui/src/pages/backoffice/index.js
@@ -15,7 +15,8 @@ export {
   LocationEditor,
   LocationList,
 } from './Location';
+export { OrderSearch } from './Acquisition/Order';
 export { PatronDetails, PatronSearch } from './Patron';
 export { SeriesEditor, SeriesDetails, SeriesSearch } from './Series';
 export { Stats } from './Stats';
-export { VendorEditor } from './Acquisition';
+export { VendorEditor, VendorSearch } from './Acquisition';

--- a/ui/src/routes/components/BackOffice/BackOfficeRoutesSwitch.js
+++ b/ui/src/routes/components/BackOffice/BackOfficeRoutesSwitch.js
@@ -19,6 +19,7 @@ import {
   LoanDetails,
   LocationEditor,
   LocationList,
+  OrderSearch,
   PatronDetails,
   PatronSearch,
   SeriesEditor,
@@ -26,6 +27,7 @@ import {
   SeriesSearch,
   Stats,
   VendorEditor,
+  VendorSearch,
 } from '@pages/backoffice';
 
 export default class extends Component {
@@ -165,6 +167,7 @@ export default class extends Component {
           path={BackOfficeRoutes.documentRequestsList}
           component={DocumentRequestSearch}
         />
+        {/* vendors */}
         <Route
           exact
           path={AcquisitionRoutes.vendorCreate}
@@ -174,6 +177,17 @@ export default class extends Component {
           exact
           path={AcquisitionRoutes.vendorEdit}
           component={VendorEditor}
+        />
+        <Route
+          exact
+          path={AcquisitionRoutes.vendorsList}
+          component={VendorSearch}
+        />
+        {/* orders */}
+        <Route
+          exact
+          path={AcquisitionRoutes.ordersList}
+          component={OrderSearch}
         />
         <Route exact path={BackOfficeRoutes.stats.home} component={Stats} />
       </Switch>

--- a/ui/src/routes/urls.js
+++ b/ui/src/routes/urls.js
@@ -27,33 +27,33 @@ const BackOfficeBase = '/backoffice';
 
 const BackOfficeRoutesList = {
   home: BackOfficeBase,
-  documentEdit: `${BackOfficeBase}/documents/:documentPid/edit`,
   documentCreate: `${BackOfficeBase}/documents/create`,
-  documentsList: `${BackOfficeBase}/documents`,
   documentDetails: `${BackOfficeBase}/documents/:documentPid`,
-  documentRequestsList: `${BackOfficeBase}/document-requests`,
+  documentEdit: `${BackOfficeBase}/documents/:documentPid/edit`,
   documentRequestDetails: `${BackOfficeBase}/document-requests/:documentRequestPid`,
-  eitemsList: `${BackOfficeBase}/eitems`,
-  eitemDetails: `${BackOfficeBase}/eitems/:eitemPid`,
+  documentRequestsList: `${BackOfficeBase}/document-requests`,
+  documentsList: `${BackOfficeBase}/documents`,
   eitemCreate: `${BackOfficeBase}/eitems/create`,
+  eitemDetails: `${BackOfficeBase}/eitems/:eitemPid`,
   eitemEdit: `${BackOfficeBase}/eitems/:eitemPid/edit`,
-  itemsList: `${BackOfficeBase}/items`,
-  itemDetails: `${BackOfficeBase}/items/:itemPid`,
-  itemCreate: `${BackOfficeBase}/items/create`,
-  itemEdit: `${BackOfficeBase}/items/:itemPid/edit`,
-  loansList: `${BackOfficeBase}/loans`,
-  loanDetails: `${BackOfficeBase}/loans/:loanPid`,
-  patronsList: `${BackOfficeBase}/patrons`,
-  patronDetails: `${BackOfficeBase}/patrons/:patronPid`,
+  eitemsList: `${BackOfficeBase}/eitems`,
   ilocationsCreate: `${BackOfficeBase}/internal-locations/create`,
   ilocationsEdit: `${BackOfficeBase}/internal-locations/:ilocationPid/edit`,
+  itemCreate: `${BackOfficeBase}/items/create`,
+  itemDetails: `${BackOfficeBase}/items/:itemPid`,
+  itemEdit: `${BackOfficeBase}/items/:itemPid/edit`,
+  itemsList: `${BackOfficeBase}/items`,
+  loanDetails: `${BackOfficeBase}/loans/:loanPid`,
+  loansList: `${BackOfficeBase}/loans`,
   locationsCreate: `${BackOfficeBase}/locations/create`,
   locationsEdit: `${BackOfficeBase}/locations/:locationPid/edit`,
   locationsList: `${BackOfficeBase}/locations`,
+  patronDetails: `${BackOfficeBase}/patrons/:patronPid`,
+  patronsList: `${BackOfficeBase}/patrons`,
   seriesCreate: `${BackOfficeBase}/series/create`,
+  seriesDetails: `${BackOfficeBase}/series/:seriesPid`,
   seriesEdit: `${BackOfficeBase}/series/:seriesPid/edit`,
   seriesList: `${BackOfficeBase}/series`,
-  seriesDetails: `${BackOfficeBase}/series/:seriesPid`,
   stats: {
     home: `${BackOfficeBase}/stats`,
   },
@@ -114,13 +114,22 @@ export const BackOfficeRoutes = {
 const AcquisitionBase = `${BackOfficeBase}/acquisition`;
 
 const AcquisitionRoutesList = {
+  orderCreate: `${AcquisitionBase}/orders/create`,
+  orderDetails: `${AcquisitionBase}/orders/:orderPid`,
+  orderEdit: `${AcquisitionBase}/orders/:orderPid/edit`,
+  ordersList: `${AcquisitionBase}/orders`,
   vendorCreate: `${AcquisitionBase}/vendors/create`,
   vendorDetails: `${AcquisitionBase}/vendors/:vendorPid`,
   vendorEdit: `${AcquisitionBase}/vendors/:vendorPid/edit`,
-  vendorList: `${AcquisitionBase}/vendors`,
+  vendorsList: `${AcquisitionBase}/vendors`,
 };
 
 const AcquisitionRouteGenerators = {
+  orderDetailsFor: orderPid =>
+    generatePath(AcquisitionRoutesList.orderDetails, { orderPid: orderPid }),
+  orderEditFor: orderPid =>
+    generatePath(AcquisitionRoutesList.orderEdit, { orderPid: orderPid }),
+  ordersListWithQuery: qs => `${AcquisitionRoutesList.ordersList}?q=${qs}`,
   vendorDetailsFor: vendorPid =>
     generatePath(AcquisitionRoutesList.vendorDetails, {
       vendorPid: vendorPid,
@@ -129,6 +138,7 @@ const AcquisitionRouteGenerators = {
     generatePath(AcquisitionRoutesList.vendorEdit, {
       vendorPid: vendorPid,
     }),
+  vendorsListWithQuery: qs => `${AcquisitionRoutesList.vendorsList}?q=${qs}`,
 };
 
 export const AcquisitionRoutes = {


### PR DESCRIPTION
Added search pages for acquisition vendors and orders.

Requires #649 

Vendor search:
![acq-vendor-search-new1](https://user-images.githubusercontent.com/9783490/70518480-b9f33b80-1b3a-11ea-9aac-439d7e601f6d.png)

Order search (updated):
![acq-order-search-updated](https://user-images.githubusercontent.com/9783490/70621044-ef6e5680-1c18-11ea-8616-534d7d4af1ab.png)

