### PR TITLE
acquisition: vendor details page

### DIFF
--- a/invenio_app_ils/acquisition/ext.py
+++ b/invenio_app_ils/acquisition/ext.py
@@ -30,16 +30,19 @@ class _InvenioIlsAcquisitionState(object):
         self.app = app
 
     def record_class_by_pid_type(self, pid_type):
+        """Return a record class by pid type."""
         endpoints = self.app.config.get('RECORDS_REST_ENDPOINTS', [])
         return endpoints[pid_type]['record_class']
 
-    def search_by_pid_type(self, pid_type):
+    def search_class_by_pid_type(self, pid_type):
+        """Return a search class by pid type."""
         endpoints = self.app.config.get("RECORDS_REST_ENDPOINTS", [])
         return endpoints[pid_type]["search_class"]
 
     def indexer_by_pid_type(self, pid_type):
+        """Return an indexer instance by pid type."""
         endpoints = self.app.config.get("RECORDS_REST_ENDPOINTS", [])
-        return endpoints[pid_type]["indexer_class"]
+        return endpoints[pid_type]["indexer_class"]()
 
     @cached_property
     def order_record_cls(self):
@@ -52,14 +55,14 @@ class _InvenioIlsAcquisitionState(object):
         return self.record_class_by_pid_type(VENDOR_PID_TYPE)
 
     @cached_property
-    def order_indexer_cls(self):
-        """Return the Order indexer class."""
-        return self.record_class_by_pid_type(ORDER_PID_TYPE)
+    def order_indexer(self):
+        """Return an Order indexer instance."""
+        return self.indexer_by_pid_type(ORDER_PID_TYPE)
 
     @cached_property
-    def vendor_indexer_cls(self):
-        """Return the Vendor indexer class."""
-        return self.indexer_class_by_pid_type(VENDOR_PID_TYPE)
+    def vendor_indexer(self):
+        """Return a Vendor indexer instance."""
+        return self.indexer_by_pid_type(VENDOR_PID_TYPE)
 
     @cached_property
     def order_search_cls(self):

--- a/invenio_app_ils/acquisition/search.py
+++ b/invenio_app_ils/acquisition/search.py
@@ -31,6 +31,21 @@ class OrderSearch(RecordsSearch):
         index = "acq_orders"
         doc_types = None
 
+    def search_by_document_pid(self, document_pid=None):
+        """Search by document pid."""
+        search = self
+
+        if document_pid:
+            search = search.filter(
+                "term",
+                order_lines__document_pid=document_pid
+            )
+        else:
+            raise MissingRequiredParameterError(
+                description="document_pid is required"
+            )
+        return search
+
     def search_by_vendor_pid(self, vendor_pid=None):
         """Search by vendor pid."""
         search = self
@@ -41,5 +56,4 @@ class OrderSearch(RecordsSearch):
             raise MissingRequiredParameterError(
                 description="vendor_pid is required"
             )
-
         return search

--- a/invenio_app_ils/cli.py
+++ b/invenio_app_ils/cli.py
@@ -796,7 +796,7 @@ class OrderGenerator(Generator):
             if obj["status"] == "CANCELLED":
                 obj["cancel_reason"] = lorem.sentence()
             elif obj["status"] == "RECEIVED":
-                obj["received_date"] = self.random_date(order_date, datetime.now()).isoformat()
+                obj["received_date"] = self.random_date(order_date, now).isoformat()
             objs.append(obj)
 
         self.holder.orders["objs"] = objs

--- a/ui/src/api/date.js
+++ b/ui/src/api/date.js
@@ -25,7 +25,7 @@ export const toISO = date => {
  *  @re
  */
 export const toShortDateTime = date => {
-  return date.toFormat('yyyy-MM-dd HH:mm');
+  return date ? date.toFormat('yyyy-MM-dd HH:mm') : date;
 };
 
 /**
@@ -34,7 +34,7 @@ export const toShortDateTime = date => {
  *  @re
  */
 export const toShortDate = date => {
-  return date.toFormat('yyyy-MM-dd');
+  return date ? date.toFormat('yyyy-MM-dd') : date;
 };
 
 /**

--- a/ui/src/config/invenioConfig.js
+++ b/ui/src/config/invenioConfig.js
@@ -28,7 +28,7 @@ export const invenioConfig = {
     maxFiles: 5,
   },
   i18n: {
-    priceLocale: 'en-GB',
+    priceLocale: 'fr-CH',
   },
   items: {
     canCirculateStates: ['CAN_CIRCULATE'],

--- a/ui/src/pages/backoffice/Acquisition/Order/OrderDetails/OrderDetails.js
+++ b/ui/src/pages/backoffice/Acquisition/Order/OrderDetails/OrderDetails.js
@@ -21,7 +21,8 @@ import {
   EditButton,
 } from '@pages/backoffice/components';
 import { toShortDate } from '@api/date';
-import { AcquisitionRoutes } from '@routes/urls';
+import { AcquisitionRoutes, BackOfficeRoutes } from '@routes/urls';
+import { PatronIcon, OrderIcon } from '@pages/backoffice/components/icons';
 
 export default class OrderDetails extends React.Component {
   constructor(props) {
@@ -112,7 +113,7 @@ export default class OrderDetails extends React.Component {
     );
   }
 
-  renderDetails = () => {
+  renderDetails() {
     const { data } = this.props;
     const panels = [
       {
@@ -143,7 +144,7 @@ export default class OrderDetails extends React.Component {
         content: (
           <Accordion.Content>
             <div ref={this.orderLinesRef}>
-              <OrderLines lines={data.metadata.order_lines} />
+              <OrderLines lines={data.metadata.resolved_order_lines} />
             </div>
           </Accordion.Content>
         ),
@@ -162,7 +163,13 @@ export default class OrderDetails extends React.Component {
       <>
         <label>Order</label> #{pid} <CopyButton text={pid} />
         <br />
-        <label>Ordered by</label> Someone
+        <label>Ordered by </label>
+        <Link
+          to={BackOfficeRoutes.patronDetailsFor(data.metadata.created_by_pid)}
+        >
+          <PatronIcon />
+          patron {data.metadata.created_by_pid}
+        </Link>
         <br />
         <label>On</label> {toShortDate(data.metadata.order_date)}
       </>
@@ -180,7 +187,7 @@ export default class OrderDetails extends React.Component {
             subTitle={<>From {vendorLink}</>}
             details={details}
             pid={data.metadata.pid}
-            icon="shopping cart"
+            icon={<OrderIcon />}
             recordType="Order"
           />
           <Container>
@@ -200,7 +207,7 @@ export default class OrderDetails extends React.Component {
         </div>
       </Ref>
     );
-  };
+  }
 
   render() {
     const { isLoading, error, hasError } = this.props;

--- a/ui/src/pages/backoffice/Acquisition/Order/OrderDetails/OrderInformation.js
+++ b/ui/src/pages/backoffice/Acquisition/Order/OrderDetails/OrderInformation.js
@@ -10,7 +10,7 @@ export class OrderInformation extends React.Component {
     const leftTable = [
       { key: 'Status', value: order.status },
       { key: 'Ordered at', value: toShortDateTime(order.order_date) },
-      { key: 'Delivered on', value: toShortDateTime(order.delivery_date) },
+      { key: 'Delivered on', value: toShortDateTime(order.received_date) },
       {
         key: 'Expected delivery',
         value: toShortDate(order.expected_delivery_date),
@@ -36,3 +36,7 @@ export class OrderInformation extends React.Component {
     );
   }
 }
+
+OrderInformation.proptTypes = {
+  order: PropTypes.object.isRequired,
+};

--- a/ui/src/pages/backoffice/Acquisition/Order/OrderDetails/OrderLines.js
+++ b/ui/src/pages/backoffice/Acquisition/Order/OrderDetails/OrderLines.js
@@ -1,31 +1,32 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { Message, Item, Icon, Grid, Popup } from 'semantic-ui-react';
 import { BackOfficeRoutes } from '@routes/urls';
 import { formatPrice } from '@api/utils';
+import { DocumentIcon } from '@pages/backoffice/components';
+import { PatronIcon } from '@pages/backoffice/components/icons';
 
 const OrderLineLeftColumn = ({ line }) => {
   return (
     <>
-      {line.recipient === 'PATRON' && (
+      {line.patron && (
         <Item.Description>
           <label>Patron: </label>
           <Link to={BackOfficeRoutes.patronDetailsFor(line.patron_pid)}>
-            <Icon name="user" /> {line.patron_pid}
+            <PatronIcon /> {line.patron.name}
           </Link>
         </Item.Description>
       )}
-      <Item.Description>
-        <label>Document: </label>
-        <Link to={BackOfficeRoutes.documentDetailsFor(line.document_pid)}>
-          {line.document_pid}
-        </Link>
-      </Item.Description>
       <Item.Description>
         <label>Medium: </label> {line.medium}
       </Item.Description>
       <Item.Description>
         <label>Recipient: </label> {line.recipient}
+      </Item.Description>
+      <Item.Description>
+        <label>Purchase type: </label>
+        {line.purchase_type}
       </Item.Description>
     </>
   );
@@ -43,8 +44,8 @@ const OrderLineMiddleColumn = ({ line }) => {
         {line.copies_received}
       </Item.Description>
       <Item.Description>
-        <label>Purchase type: </label>
-        {line.purchase_type}
+        <label>Payment mode: </label>
+        {line.payment_mode}
       </Item.Description>
       <Item.Description>
         <label>IDT ID: </label>
@@ -61,10 +62,6 @@ const OrderLineMiddleColumn = ({ line }) => {
 const OrderLineRightColumn = ({ line }) => {
   return (
     <>
-      <Item.Description>
-        <label>Payment mode: </label>
-        {line.payment_mode}
-      </Item.Description>
       <Item.Description>
         <label>Budget code: </label>
         {line.budget_code}
@@ -85,6 +82,13 @@ const OrderLine = ({ index, line }) => {
   return (
     <Item>
       <Item.Content>
+        <Item.Header
+          as={Link}
+          to={BackOfficeRoutes.documentDetailsFor(line.document.pid)}
+        >
+          <DocumentIcon />
+          {line.document.title}
+        </Item.Header>
         <Grid columns={3}>
           <Grid.Column>
             <OrderLineLeftColumn line={line} />
@@ -119,3 +123,7 @@ export class OrderLines extends React.Component {
     );
   }
 }
+
+OrderLines.proptTypes = {
+  lines: PropTypes.array.isRequired,
+};

--- a/ui/src/pages/backoffice/Acquisition/Order/OrderDetails/OrderStatistics.js
+++ b/ui/src/pages/backoffice/Acquisition/Order/OrderDetails/OrderStatistics.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Statistic } from 'semantic-ui-react';
 import { formatPrice } from '@api/utils';
 import { toShortDate } from '@api/date';
@@ -20,7 +21,7 @@ export class OrderStatistics extends React.Component {
       <Statistic color="green">
         <Statistic.Label>Delivered</Statistic.Label>
         <Statistic.Value>
-          {toShortDate(this.props.order.delivery_date)}
+          {toShortDate(this.props.order.received_date)}
         </Statistic.Value>
       </Statistic>
     );
@@ -40,8 +41,8 @@ export class OrderStatistics extends React.Component {
   renderStatusPending() {
     return (
       <Statistic>
+        <Statistic.Label>Status</Statistic.Label>
         <Statistic.Value>Pending</Statistic.Value>
-        <Statistic.Label>???</Statistic.Label>
       </Statistic>
     );
   }
@@ -106,3 +107,7 @@ export class OrderStatistics extends React.Component {
     );
   }
 }
+
+OrderStatistics.proptTypes = {
+  order: PropTypes.object.isRequired,
+};

--- a/ui/src/pages/backoffice/Acquisition/Order/OrderDetails/PaymentInformation.js
+++ b/ui/src/pages/backoffice/Acquisition/Order/OrderDetails/PaymentInformation.js
@@ -7,17 +7,27 @@ export class PaymentInformation extends React.Component {
   render() {
     const order = this.props.order;
     const payment = order.payment;
-    if (!payment) return null;
     const leftTable = [
       {
-        key: `Total (${order.grand_total_main_currency.currency})`,
+        key: (
+          <>
+            Total (local {order.grand_total_main_currency.currency})
+            <Popup
+              content="The total amount in the local currency."
+              trigger={<Icon name="info circle" />}
+            />
+          </>
+        ),
         value: formatPrice(order.grand_total_main_currency),
       },
       {
         key: `Total (${order.grand_total.currency})`,
         value: formatPrice(order.grand_total),
       },
-      { key: 'Debit cost', value: formatPrice(payment.debit_cost) },
+      {
+        key: 'Debit cost',
+        value: formatPrice(payment.debit_cost),
+      },
     ];
     const rightTable = [
       { key: 'Mode', value: payment.mode },

--- a/ui/src/pages/backoffice/Acquisition/Vendor/VendorDetails/VendorDetails.js
+++ b/ui/src/pages/backoffice/Acquisition/Vendor/VendorDetails/VendorDetails.js
@@ -1,0 +1,178 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { Container, Accordion, Ref, Divider, List } from 'semantic-ui-react';
+import history from '@history';
+import { CopyButton, Loader, Error } from '@components';
+import { VendorInformation } from './VendorInformation';
+import {
+  DetailsHeader,
+  DetailsMenu,
+  EditButton,
+  DeleteRecordModal,
+} from '@pages/backoffice/components';
+import { AcquisitionRoutes } from '@routes/urls';
+import { order as orderApi } from '@api';
+import { VendorIcon } from '@pages/backoffice/components/icons';
+import { DeleteButton } from '@pages/backoffice/components/DeleteRecordModal/components/DeleteButton';
+
+const DeleteVendorButton = props => {
+  return (
+    <DeleteButton
+      fluid
+      content="Delete vendor"
+      labelPosition="left"
+      {...props}
+    />
+  );
+};
+
+class VendorDetailsInner extends React.Component {
+  constructor(props) {
+    super(props);
+    this.contextRef = React.createRef();
+  }
+
+  createRefProps(vendorPid) {
+    const orderRefProps = {
+      refType: 'Order',
+      onRefClick: orderPid =>
+        window.open(
+          AcquisitionRoutes.orderDetailsFor(orderPid),
+          `_order_${orderPid}`
+        ),
+      getRefData: () =>
+        orderApi.list(
+          orderApi
+            .query()
+            .withVendorPid(vendorPid)
+            .qs()
+        ),
+    };
+
+    return [orderRefProps];
+  }
+
+  renderStickyMenu() {
+    const vendor = this.props.data.metadata;
+    return (
+      <DetailsMenu contextRef={this.contextRef}>
+        <List>
+          <List.Item>
+            <EditButton
+              fluid
+              to={AcquisitionRoutes.vendorEditFor(vendor.pid)}
+            />
+            <DeleteRecordModal
+              deleteHeader={`Are you sure you want to delete the Vendor record
+              with ID ${vendor.pid}?`}
+              refProps={this.createRefProps(vendor.pid)}
+              onDelete={() => this.deleteVendor(vendor.pid)}
+              trigger={DeleteVendorButton}
+            />
+          </List.Item>
+        </List>
+        <Divider horizontal>Navigation</Divider>
+        <List>
+          <List.Item>
+            <List.Icon name="search" />
+            <List.Content>
+              <Link
+                to={AcquisitionRoutes.ordersListWithQuery(
+                  orderApi
+                    .query()
+                    .withVendorPid(vendor.pid)
+                    .qs()
+                )}
+              >
+                Orders from {vendor.name}
+              </Link>
+            </List.Content>
+          </List.Item>
+        </List>
+      </DetailsMenu>
+    );
+  }
+
+  render() {
+    const { data } = this.props;
+    const panels = [
+      {
+        key: 'vendor-info',
+        title: 'Vendor information',
+        content: (
+          <Accordion.Content>
+            <div ref={this.vendorInfoRef}>
+              <VendorInformation vendor={data.metadata} />
+            </div>
+          </Accordion.Content>
+        ),
+      },
+    ];
+    const defaultIndexes =
+      data.metadata.status === 'CANCELLED' ? [0] : [0, 1, 2];
+    const pid = data.metadata.pid;
+    const details = (
+      <>
+        <label>Vendor</label> #{pid} <CopyButton text={pid} />
+      </>
+    );
+    return (
+      <Ref innerRef={this.contextRef}>
+        <div className="bo-details">
+          <DetailsHeader
+            title={data.metadata.name}
+            details={details}
+            pid={data.metadata.pid}
+            icon={<VendorIcon />}
+            recordType="Vendor"
+          />
+          <Container>
+            <Divider />
+            <div className="bo-details-content">
+              {this.renderStickyMenu()}
+              <Accordion
+                fluid
+                styled
+                panels={panels}
+                exclusive={false}
+                defaultActiveIndex={defaultIndexes}
+              />
+            </div>
+          </Container>
+        </div>
+      </Ref>
+    );
+  }
+}
+
+export default class VendorDetails extends React.Component {
+  componentDidMount() {
+    this.unlisten = history.listen(loc => {
+      if (loc.state && loc.state.pid && loc.state.type === 'Vendor') {
+        this.props.fetchVendorDetails(loc.state.pid);
+      }
+    });
+    this.props.fetchVendorDetails(this.props.match.params.vendorPid);
+  }
+
+  componentWillUnmount() {
+    this.unlisten();
+  }
+
+  render() {
+    const { data, isLoading, error } = this.props;
+    return (
+      <Loader isLoading={isLoading}>
+        <Error error={error}>
+          <VendorDetailsInner data={data} />
+        </Error>
+      </Loader>
+    );
+  }
+}
+
+VendorDetails.propTypes = {
+  data: PropTypes.object.isRequired,
+  fetchVendorDetails: PropTypes.func.isRequired,
+};

--- a/ui/src/pages/backoffice/Acquisition/Vendor/VendorDetails/VendorInformation.js
+++ b/ui/src/pages/backoffice/Acquisition/Vendor/VendorDetails/VendorInformation.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Grid } from 'semantic-ui-react';
+import { KeyValueTable } from '@pages/backoffice/components';
+import { EmailLink } from '@components/EmailLink/EmailLink';
+
+export class VendorInformation extends React.Component {
+  render() {
+    const vendor = this.props.vendor;
+    const leftTable = [
+      { key: 'Name', value: vendor.name },
+      { key: 'Email', value: <EmailLink email={vendor.email} /> },
+      { key: 'Phone', value: vendor.phone },
+    ];
+    const rightTable = [
+      { key: 'Address', value: vendor.address },
+      { key: 'Notes', value: vendor.notes },
+    ];
+    return (
+      <Grid columns={2} id="vendor-info">
+        <Grid.Row>
+          <Grid.Column>
+            <KeyValueTable data={leftTable} />
+          </Grid.Column>
+          <Grid.Column>
+            <KeyValueTable keyWidth={3} data={rightTable} />
+          </Grid.Column>
+        </Grid.Row>
+      </Grid>
+    );
+  }
+}

--- a/ui/src/pages/backoffice/Acquisition/Vendor/VendorDetails/index.js
+++ b/ui/src/pages/backoffice/Acquisition/Vendor/VendorDetails/index.js
@@ -1,0 +1,20 @@
+import { connect } from 'react-redux';
+
+import { fetchVendorDetails } from './state/actions';
+import VendorDetailsComponent from './VendorDetails';
+
+const mapStateToProps = state => ({
+  data: state.vendorDetails.data,
+  isLoading: state.vendorDetails.isLoading,
+  error: state.vendorDetails.error,
+  hasError: state.vendorDetails.hasError,
+});
+
+const mapDispatchToProps = dispatch => ({
+  fetchVendorDetails: vendorPid => dispatch(fetchVendorDetails(vendorPid)),
+});
+
+export const VendorDetails = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(VendorDetailsComponent);

--- a/ui/src/pages/backoffice/Acquisition/Vendor/VendorDetails/state/actions.js
+++ b/ui/src/pages/backoffice/Acquisition/Vendor/VendorDetails/state/actions.js
@@ -1,0 +1,25 @@
+import { HAS_ERROR, IS_LOADING, SUCCESS } from './types';
+import { sendErrorNotification } from '@components/Notifications';
+import { vendor as vendorApi } from '@api';
+
+export const fetchVendorDetails = pid => {
+  return async dispatch => {
+    dispatch({
+      type: IS_LOADING,
+    });
+
+    try {
+      const response = await vendorApi.get(pid);
+      dispatch({
+        type: SUCCESS,
+        payload: response.data,
+      });
+    } catch (error) {
+      dispatch({
+        type: HAS_ERROR,
+        payload: error,
+      });
+      dispatch(sendErrorNotification(error));
+    }
+  };
+};

--- a/ui/src/pages/backoffice/Acquisition/Vendor/VendorDetails/state/reducer.js
+++ b/ui/src/pages/backoffice/Acquisition/Vendor/VendorDetails/state/reducer.js
@@ -1,0 +1,32 @@
+import { IS_LOADING, SUCCESS, HAS_ERROR } from './types';
+
+export const initialState = {
+  isLoading: true,
+  hasError: false,
+  data: {},
+  error: {},
+};
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case IS_LOADING:
+      return { ...state, isLoading: true };
+    case SUCCESS:
+      return {
+        ...state,
+        isLoading: false,
+        data: action.payload,
+        error: {},
+        hasError: false,
+      };
+    case HAS_ERROR:
+      return {
+        ...state,
+        isLoading: false,
+        error: action.payload,
+        hasError: true,
+      };
+    default:
+      return state;
+  }
+};

--- a/ui/src/pages/backoffice/Acquisition/Vendor/VendorDetails/state/types.js
+++ b/ui/src/pages/backoffice/Acquisition/Vendor/VendorDetails/state/types.js
@@ -1,0 +1,3 @@
+export const IS_LOADING = 'fetchVendorDetails/IS_LOADING';
+export const SUCCESS = 'fetchVendorDetails/SUCCESS';
+export const HAS_ERROR = 'fetchVendorDetails/HAS_ERROR';

--- a/ui/src/pages/backoffice/Acquisition/Vendor/index.js
+++ b/ui/src/pages/backoffice/Acquisition/Vendor/index.js
@@ -1,2 +1,3 @@
+export { VendorDetails } from './VendorDetails';
 export { VendorEditor } from './VendorEditor';
 export { VendorSearch } from './VendorSearch';

--- a/ui/src/pages/backoffice/Acquisition/index.js
+++ b/ui/src/pages/backoffice/Acquisition/index.js
@@ -1,5 +1,8 @@
-export { VendorEditor, VendorSearch } from './Vendor';
+export { VendorDetails, VendorEditor, VendorSearch } from './Vendor';
 export { OrderDetails, OrderSearch } from './Order';
 export {
   default as orderDetailsReducer,
 } from './Order/OrderDetails/state/reducer';
+export {
+  default as vendorDetailsReducer,
+} from './Vendor/VendorDetails/state/reducer';

--- a/ui/src/pages/backoffice/components/DeleteRecordModal/DeleteRecordModal.js
+++ b/ui/src/pages/backoffice/components/DeleteRecordModal/DeleteRecordModal.js
@@ -118,9 +118,10 @@ export default class DeleteRecordModal extends Component {
 
   render() {
     const { isLoading, error } = this.props;
+    const TriggerButton = this.props.trigger || DeleteButton;
     return (
       <Modal
-        trigger={<DeleteButton onClick={this.toggleModal} />}
+        trigger={<TriggerButton onClick={this.toggleModal} />}
         open={this.state.isModalOpen}
         onOpen={() => this.handleOpen()}
         onClose={this.toggleModal}
@@ -144,6 +145,7 @@ DeleteRecordModal.propTypes = {
       getRefData: PropTypes.func.isRequired,
     })
   ),
+  trigger: PropTypes.func,
 };
 
 DeleteRecordModal.defaultProps = {

--- a/ui/src/pages/backoffice/components/DetailsHeader/DetailsHeader.js
+++ b/ui/src/pages/backoffice/components/DetailsHeader/DetailsHeader.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Container, Header, Icon, Segment } from 'semantic-ui-react';
+import { Container, Header, Segment } from 'semantic-ui-react';
 
 export class DetailsHeader extends React.Component {
   renderHeader = () => {
@@ -11,7 +11,7 @@ export class DetailsHeader extends React.Component {
           {this.props.details}
         </Segment>
         <Header as="h1">
-          {icon && <Icon name={icon} />}
+          {icon}
           <Header.Content>
             {title}
             <Header.Subheader>{subTitle}</Header.Subheader>
@@ -32,7 +32,7 @@ export class DetailsHeader extends React.Component {
 
 DetailsHeader.propTypes = {
   details: PropTypes.any,
-  icon: PropTypes.string,
+  icon: PropTypes.node,
   pid: PropTypes.string,
   recordType: PropTypes.string,
   subTitle: PropTypes.any,

--- a/ui/src/pages/backoffice/components/OrderList/OrderListEntry.js
+++ b/ui/src/pages/backoffice/components/OrderList/OrderListEntry.js
@@ -1,12 +1,13 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import { Grid, Header, Item, List, Icon } from 'semantic-ui-react';
+import { Grid, Header, Item, List } from 'semantic-ui-react';
 import { AcquisitionRoutes, BackOfficeRoutes } from '@routes/urls';
 import { toShortDateTime } from '@api/date';
 import { formatPrice } from '@api/utils';
 import { invenioConfig } from '@config';
 import { getDisplayVal } from '@config/invenioConfig';
+import { OrderIcon } from '../icons';
 
 export default class OrderListEntry extends Component {
   renderLeftColumn = order => {
@@ -19,7 +20,7 @@ export default class OrderListEntry extends Component {
         </Item.Description>
         <Item.Description>
           <label>status </label>
-          {order.metadata.status}
+          {getDisplayVal('orders.statuses', order.metadata.status)}
         </Item.Description>
         <Item.Description>
           <label>vendor </label>
@@ -39,7 +40,7 @@ export default class OrderListEntry extends Component {
   renderOrderLine = (orderLine, index) => {
     const documentPid = orderLine.document_pid;
     const patronPid = orderLine.patron_pid;
-    const medium = getDisplayVal('items.mediums', orderLine.medium).text;
+    const medium = getDisplayVal('items.mediums', orderLine.medium);
     const documentLink = (
       <Link to={BackOfficeRoutes.documentDetailsFor(documentPid)}>
         <code>{documentPid}</code>
@@ -55,7 +56,8 @@ export default class OrderListEntry extends Component {
         Document {documentLink} - {medium}
         {patronPid && (
           <>
-            {' '} - Patron{' '}
+            {' '}
+            - Patron{' '}
             <Link to={BackOfficeRoutes.patronDetailsFor(patronPid)}>
               <code>{patronPid}</code>
             </Link>
@@ -129,7 +131,7 @@ export default class OrderListEntry extends Component {
             to={AcquisitionRoutes.orderDetailsFor(order.metadata.pid)}
             data-test={`navigate-${order.metadata.pid}`}
           >
-            <Icon name="shopping cart" />
+            <OrderIcon />
             Order: {order.metadata.pid}
           </Item.Header>
           <Grid highlight={3}>

--- a/ui/src/pages/backoffice/components/icons/Icons.js
+++ b/ui/src/pages/backoffice/components/icons/Icons.js
@@ -1,28 +1,45 @@
 import React, { Component } from 'react';
-import {Icon} from "semantic-ui-react";
+import { Icon } from 'semantic-ui-react';
 
-export class DocumentIcon extends Component{
+export class DocumentIcon extends Component {
   render() {
-    return <Icon name="book"/>
+    return <Icon name="book" />;
   }
 }
 
-export class ItemIcon extends Component{
+export class ItemIcon extends Component {
   render() {
-    return <Icon name="barcode"/>
+    return <Icon name="barcode" />;
   }
 }
 
-export class EItemIcon extends Component{
+export class EItemIcon extends Component {
   render() {
-    return <Icon name="desktop"/>
+    return <Icon name="desktop" />;
   }
 }
 
-
-export class LoanIcon extends Component{
+export class LoanIcon extends Component {
   render() {
-    return <Icon name="bookmark outline"/>
+    return <Icon name="bookmark outline" />;
+  }
+}
+
+export class OrderIcon extends Component {
+  render() {
+    return <Icon name="shopping cart" />;
+  }
+}
+
+export class PatronIcon extends Component {
+  render() {
+    return <Icon name="user" />;
+  }
+}
+
+export class VendorIcon extends Component {
+  render() {
+    return <Icon name="industry" />;
   }
 }
 

--- a/ui/src/pages/backoffice/components/icons/index.js
+++ b/ui/src/pages/backoffice/components/icons/index.js
@@ -1,7 +1,10 @@
 export {
   DocumentIcon,
+  DocumentRequestIcon,
+  EItemIcon,
   ItemIcon,
   LoanIcon,
-  EItemIcon,
-  DocumentRequestIcon,
+  OrderIcon,
+  PatronIcon,
+  VendorIcon,
 } from './Icons';

--- a/ui/src/pages/backoffice/components/index.js
+++ b/ui/src/pages/backoffice/components/index.js
@@ -10,13 +10,7 @@ export { DocumentList } from './DocumentList';
 export { OrderList } from './OrderList';
 export { VendorList } from './VendorList';
 export { EditButton, NewButton, SeeAllButton } from './buttons';
-export {
-  DocumentIcon,
-  ItemIcon,
-  LoanIcon,
-  EItemIcon,
-  DocumentRequestIcon,
-} from './icons';
+export * from './icons';
 export { DetailsHeader } from './DetailsHeader';
 export { DetailsMenu } from './DetailsMenu';
 export { KeyValueTable } from './KeyValueTable';

--- a/ui/src/pages/backoffice/index.js
+++ b/ui/src/pages/backoffice/index.js
@@ -21,6 +21,7 @@ export { Stats } from './Stats';
 export {
   OrderDetails,
   OrderSearch,
+  VendorDetails,
   VendorEditor,
   VendorSearch,
 } from './Acquisition';

--- a/ui/src/routes/components/BackOffice/BackOfficeRoutesSwitch.js
+++ b/ui/src/routes/components/BackOffice/BackOfficeRoutesSwitch.js
@@ -33,6 +33,7 @@ import {
   SeriesDetails,
   SeriesSearch,
   Stats,
+  VendorDetails,
   VendorEditor,
   VendorSearch,
 } from '@pages/backoffice';
@@ -189,6 +190,11 @@ export default class extends Component {
           exact
           path={AcquisitionRoutes.vendorsList}
           component={VendorSearch}
+        />
+        <Route
+          exact
+          path={AcquisitionRoutes.vendorDetails}
+          component={VendorDetails}
         />
         {/* orders */}
         <Route

--- a/ui/src/semantic-ui/site/globals/site.overrides
+++ b/ui/src/semantic-ui/site/globals/site.overrides
@@ -164,6 +164,15 @@ form {
       .right.floated.segment {
         color: #9e9e9e;
         padding-top: 0;
+
+        a {
+          color: #9e9e9e;
+          font-weight: bold;
+
+          &:hover {
+            color: #000;
+          }
+        }
       }
 
       .button.copy {

--- a/ui/src/store.js
+++ b/ui/src/store.js
@@ -64,6 +64,7 @@ import {
   patronPastDocumentRequestsReducer,
 } from '@pages/frontsite/PatronProfile/reducer';
 import { orderDetailsReducer } from '@pages/backoffice/Acquisition';
+import { vendorDetailsReducer } from '@pages/backoffice/Acquisition';
 
 const rootReducer = combineReducers({
   availableItems: availableItemsReducer,
@@ -108,6 +109,7 @@ const rootReducer = combineReducers({
   seriesMultipartMonographs: seriesMultipartMonographsReducer,
   seriesRelations: seriesRelationsReducer,
   statsMostLoanedDocuments: mostLoanedDocumentsReducer,
+  vendorDetails: vendorDetailsReducer,
 });
 
 const composeEnhancers = composeWithDevTools({


### PR DESCRIPTION
Re-index orders if a document in an order line was updated.

Vendor details page:
![acq-vendor-details-v3](https://user-images.githubusercontent.com/9783490/71000911-6a81b200-20dc-11ea-9255-f7199a5eca4b.png)


Updated order details page:
![acq-order-details-v3](https://user-images.githubusercontent.com/9783490/71000926-70779300-20dc-11ea-89ae-f16968059121.png)
