### PR TITLE
acq: orders sorting

### DIFF
--- a/invenio_app_ils/config.py
+++ b/invenio_app_ils/config.py
@@ -970,13 +970,13 @@ RECORDS_REST_SORT_OPTIONS = dict(
         ),
         grand_total=dict(
             fields=["grand_total_main_currency.value"],
-            title="Grand total",
+            title="Total",
             default_order="desc",
             order=2,
         ),
         received_date=dict(
             fields=["received_date"],
-            title="Delivery date",
+            title="Received date",
             default_order="desc",
             order=3,
         ),

--- a/ui/src/components/Pagination/Pagination.js
+++ b/ui/src/components/Pagination/Pagination.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Pagination as Paginator } from 'semantic-ui-react';
+import { invenioConfig } from '@config';
 
 export class Pagination extends Component {
   constructor(props) {
@@ -37,5 +38,6 @@ Pagination.propTypes = {
 };
 
 Pagination.defaultProps = {
+  currentSize: invenioConfig.defaultResultsSize,
   renderElement: null,
 };

--- a/ui/src/components/ResultsTable/ResultsTable.js
+++ b/ui/src/components/ResultsTable/ResultsTable.js
@@ -4,6 +4,7 @@ import { Message, Header, Table, Grid } from 'semantic-ui-react';
 import ResultsTableHeader from './ResultsTableHeader';
 import ResultsTableBody from './ResultsTableBody';
 import ResultsTableFooter from './ResultsTableFooter';
+import { invenioConfig } from '@config';
 
 export class ResultsTable extends Component {
   renderTable = () => {
@@ -123,7 +124,7 @@ ResultsTable.defaultProps = {
   paginationComponent: null,
   seeAllComponent: null,
   showAllResults: false,
-  showMaxRows: 10,
+  showMaxRows: invenioConfig.defaultResultsSize,
   singleLine: false,
   subtitle: '',
   title: '',

--- a/ui/src/components/SearchBar/__tests__/__snapshots__/SearchBar.test.js.snap
+++ b/ui/src/components/SearchBar/__tests__/__snapshots__/SearchBar.test.js.snap
@@ -115,6 +115,7 @@ exports[`LoansSearch SearchBar tests should render search bar with query helper 
         },
       ]
     }
+    size={15}
     updateQueryString={[MockFunction]}
   >
     <Grid>

--- a/ui/src/components/SearchBar/components/QueryBuildHelper/QueryBuildHelper.js
+++ b/ui/src/components/SearchBar/components/QueryBuildHelper/QueryBuildHelper.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { List, Grid } from 'semantic-ui-react';
+import { invenioConfig } from '@config';
 
 export default class QueryBuildHelper extends Component {
   constructor(props) {
@@ -68,4 +69,9 @@ QueryBuildHelper.propTypes = {
   fields: PropTypes.array.isRequired,
   currentQueryString: PropTypes.string.isRequired,
   updateQueryString: PropTypes.func.isRequired,
+  size: PropTypes.number,
+};
+
+QueryBuildHelper.defaultProps = {
+  size: invenioConfig.defaultResultsSize,
 };

--- a/ui/src/config/__mocks__/invenioConfig.js
+++ b/ui/src/config/__mocks__/invenioConfig.js
@@ -11,6 +11,7 @@ export const invenioConfig = {
     requestDuration: 60,
   },
   orders: {
+    defaultCurrency: 'CHF',
     paymentModes: [
       { value: 'CREDIT_CARD', text: 'Credit Card' },
       { value: 'CASH', text: 'Cash' },

--- a/ui/src/config/invenioConfig.js
+++ b/ui/src/config/invenioConfig.js
@@ -64,6 +64,7 @@ export const invenioConfig = {
   },
   max_results_window: 10000,
   orders: {
+    defaultCurrency: 'CHF',
     maxShowOrderLines: 3,
     statuses: [
       { value: 'CANCELLED', text: 'Cancelled' },
@@ -101,7 +102,6 @@ export const invenioConfig = {
   ],
   rest_mimetype_query_arg_name: 'format',
   support_email: 'info@inveniosoftware.org',
-  order: { defaultCurrency: 'CHF' },
   vocabularies: {
     document: {
       alternativeIdentifier: {

--- a/ui/src/config/searchConfig.js
+++ b/ui/src/config/searchConfig.js
@@ -353,15 +353,15 @@ const searchConfig = {
         },
         {
           default_order: 'desc',
-          field: 'grand_total_main_currency.value',
+          field: 'grand_total',
           order: 2,
-          title: 'Grand total',
+          title: `Total (${invenioConfig.orders.defaultCurrency})`,
         },
         {
           default_order: 'desc',
           field: 'received_date',
           order: 3,
-          title: 'Delivery date',
+          title: 'Received date',
         },
         {
           default_order: 'desc',

--- a/ui/src/forms/core/PriceField.js
+++ b/ui/src/forms/core/PriceField.js
@@ -46,7 +46,7 @@ export class PriceField extends Component {
       />
     ) : (
       <Label name={`${fieldPath}.currency`}>
-        {invenioConfig.order.defaultCurrency}
+        {invenioConfig.orders.defaultCurrency}
       </Label>
     );
   };

--- a/ui/src/pages/backoffice/Acquisition/Order/OrderDetails/PaymentInformation.js
+++ b/ui/src/pages/backoffice/Acquisition/Order/OrderDetails/PaymentInformation.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Grid, Popup, Icon } from 'semantic-ui-react';
 import { formatPrice } from '@api/utils';
-import {KeyValueTable, MetadataTable} from '@pages/backoffice/components';
+import { MetadataTable } from '@pages/backoffice/components';
 
 export class PaymentInformation extends React.Component {
   render() {

--- a/ui/src/pages/backoffice/Acquisition/Order/OrderEditor/components/OrderForm/OrderForm.js
+++ b/ui/src/pages/backoffice/Acquisition/Order/OrderEditor/components/OrderForm/OrderForm.js
@@ -92,7 +92,7 @@ export class OrderForm extends Component {
   };
 
   getDefaultValues() {
-    const defaultCurrency = invenioConfig.order.defaultCurrency;
+    const defaultCurrency = invenioConfig.orders.defaultCurrency;
     return {
       create_by: sessionManager.user.id,
       grand_total: { currency: defaultCurrency },

--- a/ui/src/pages/backoffice/Acquisition/Order/OrderEditor/components/OrderForm/components/OrderLines.js
+++ b/ui/src/pages/backoffice/Acquisition/Order/OrderEditor/components/OrderForm/components/OrderLines.js
@@ -163,8 +163,8 @@ export class OrderLines extends Component {
       <ArrayField
         fieldPath="resolved_order_lines"
         defaultNewValue={{
-          unit_price: { currency: invenioConfig.order.defaultCurrency },
-          total_price: { currency: invenioConfig.order.defaultCurrency },
+          unit_price: { currency: invenioConfig.orders.defaultCurrency },
+          total_price: { currency: invenioConfig.orders.defaultCurrency },
         }}
         renderArrayItem={this.renderArrayItem}
         addButtonLabel="Add new order line"

--- a/ui/src/pages/backoffice/Acquisition/Order/OrderSearch/OrderSearch.js
+++ b/ui/src/pages/backoffice/Acquisition/Order/OrderSearch/OrderSearch.js
@@ -14,7 +14,6 @@ import {
   SearchControls,
 } from '@components';
 import { order as orderApi } from '@api';
-import { getSearchConfig } from '@config';
 import { AcquisitionRoutes } from '@routes/urls';
 import {
   OrderList,
@@ -49,7 +48,6 @@ export class OrderSearch extends Component {
     url: orderApi.searchBaseURL,
     withCredentials: true,
   });
-  searchConfig = getSearchConfig('orders');
 
   renderSearchBar = (_, queryString, onInputChange, executeSearch) => {
     const helperFields = [

--- a/ui/src/pages/backoffice/Acquisition/Order/OrderSearch/__tests__/__snapshots__/OrderSearch.test.js.snap
+++ b/ui/src/pages/backoffice/Acquisition/Order/OrderSearch/__tests__/__snapshots__/OrderSearch.test.js.snap
@@ -21,7 +21,7 @@ exports[`OrdersSearch ResultsTable tests should not render when empty results 1`
   paginationComponent={null}
   seeAllComponent={null}
   showAllResults={false}
-  showMaxRows={10}
+  showMaxRows={15}
   singleLine={false}
   subtitle=""
   title=""
@@ -122,7 +122,7 @@ exports[`OrdersSearch ResultsTable tests should render a list of results 1`] = `
   paginationComponent={null}
   seeAllComponent={null}
   showAllResults={false}
-  showMaxRows={10}
+  showMaxRows={15}
   singleLine={false}
   subtitle=""
   title=""
@@ -358,7 +358,7 @@ exports[`OrdersSearch ResultsTable tests should render a list of results 1`] = `
         paginationComponent={null}
         seeAllComponent={null}
         showAllResults={false}
-        showMaxRows={10}
+        showMaxRows={15}
       />
     </table>
   </Table>

--- a/ui/src/pages/backoffice/Acquisition/Vendor/VendorDetails/VendorDetails.js
+++ b/ui/src/pages/backoffice/Acquisition/Vendor/VendorDetails/VendorDetails.js
@@ -6,9 +6,7 @@ import {
   Accordion,
   Ref,
   Divider,
-  List,
   Sticky,
-  Menu,
   Icon,
   Grid,
 } from 'semantic-ui-react';
@@ -91,7 +89,7 @@ class ActionMenu extends React.Component {
 
 class VendorHeader extends React.Component {
   render() {
-    const {data} = this.props;
+    const { data } = this.props;
     return (
       <DetailsHeader
         title={data.metadata.name}

--- a/ui/src/pages/backoffice/Document/DocumentRequestSearch/__tests__/__snapshots__/DocumentRequestSearch.test.js.snap
+++ b/ui/src/pages/backoffice/Document/DocumentRequestSearch/__tests__/__snapshots__/DocumentRequestSearch.test.js.snap
@@ -9,7 +9,7 @@ exports[`DocumentRequestsSearch ResultsTable tests should not render when empty 
   paginationComponent={null}
   seeAllComponent={null}
   showAllResults={false}
-  showMaxRows={10}
+  showMaxRows={15}
   singleLine={false}
   subtitle=""
   title=""
@@ -109,7 +109,7 @@ exports[`DocumentRequestsSearch ResultsTable tests should render a list of resul
   paginationComponent={null}
   seeAllComponent={null}
   showAllResults={false}
-  showMaxRows={10}
+  showMaxRows={15}
   singleLine={false}
   subtitle=""
   title=""
@@ -344,7 +344,7 @@ exports[`DocumentRequestsSearch ResultsTable tests should render a list of resul
         paginationComponent={null}
         seeAllComponent={null}
         showAllResults={false}
-        showMaxRows={10}
+        showMaxRows={15}
       />
     </table>
   </Table>

--- a/ui/src/pages/backoffice/Document/DocumentSearch/__tests__/__snapshots__/DocumentSearch.test.js.snap
+++ b/ui/src/pages/backoffice/Document/DocumentSearch/__tests__/__snapshots__/DocumentSearch.test.js.snap
@@ -21,7 +21,7 @@ exports[`DocumentsSearch ResultsTable tests should not render when empty results
   paginationComponent={null}
   seeAllComponent={null}
   showAllResults={false}
-  showMaxRows={10}
+  showMaxRows={15}
   singleLine={false}
   subtitle=""
   title=""
@@ -122,7 +122,7 @@ exports[`DocumentsSearch ResultsTable tests should render a list of results 1`] 
   paginationComponent={null}
   seeAllComponent={null}
   showAllResults={false}
-  showMaxRows={10}
+  showMaxRows={15}
   singleLine={false}
   subtitle=""
   title=""
@@ -358,7 +358,7 @@ exports[`DocumentsSearch ResultsTable tests should render a list of results 1`] 
         paginationComponent={null}
         seeAllComponent={null}
         showAllResults={false}
-        showMaxRows={10}
+        showMaxRows={15}
       />
     </table>
   </Table>

--- a/ui/src/pages/backoffice/EItem/EItemSearch/__tests__/__snapshots__/EItemSearch.test.js.snap
+++ b/ui/src/pages/backoffice/EItem/EItemSearch/__tests__/__snapshots__/EItemSearch.test.js.snap
@@ -9,7 +9,7 @@ exports[`EItemsSearch ResultsTable tests should not render when empty results 1`
   paginationComponent={null}
   seeAllComponent={null}
   showAllResults={false}
-  showMaxRows={10}
+  showMaxRows={15}
   singleLine={false}
   subtitle=""
   title=""
@@ -121,7 +121,7 @@ exports[`EItemsSearch ResultsTable tests should render a list of results 1`] = `
   paginationComponent={null}
   seeAllComponent={null}
   showAllResults={false}
-  showMaxRows={10}
+  showMaxRows={15}
   singleLine={false}
   subtitle=""
   title=""
@@ -442,7 +442,7 @@ exports[`EItemsSearch ResultsTable tests should render a list of results 1`] = `
         paginationComponent={null}
         seeAllComponent={null}
         showAllResults={false}
-        showMaxRows={10}
+        showMaxRows={15}
       />
     </table>
   </Table>

--- a/ui/src/pages/backoffice/Item/ItemSearch/__tests__/__snapshots__/ItemSearch.test.js.snap
+++ b/ui/src/pages/backoffice/Item/ItemSearch/__tests__/__snapshots__/ItemSearch.test.js.snap
@@ -9,7 +9,7 @@ exports[`ItemsSearch ResultsList tests should not render when empty results 1`] 
   paginationComponent={null}
   seeAllComponent={null}
   showAllResults={false}
-  showMaxRows={10}
+  showMaxRows={15}
   singleLine={false}
   subtitle=""
   title=""
@@ -113,7 +113,7 @@ exports[`ItemsSearch ResultsList tests should render a list of results 1`] = `
   paginationComponent={null}
   seeAllComponent={null}
   showAllResults={false}
-  showMaxRows={10}
+  showMaxRows={15}
   singleLine={false}
   subtitle=""
   title=""
@@ -352,7 +352,7 @@ exports[`ItemsSearch ResultsList tests should render a list of results 1`] = `
         paginationComponent={null}
         seeAllComponent={null}
         showAllResults={false}
-        showMaxRows={10}
+        showMaxRows={15}
       />
     </table>
   </Table>

--- a/ui/src/pages/backoffice/Loan/LoanDetails/components/AvailableItems/AvailableItems.js
+++ b/ui/src/pages/backoffice/Loan/LoanDetails/components/AvailableItems/AvailableItems.js
@@ -114,7 +114,6 @@ export default class AvailableItems extends Component {
         title={'Available items'}
         name={'available items'}
         seeAllComponent={this.seeAllButton()}
-        showMaxRows={this.props.showMaxItems}
       />
     );
   }
@@ -146,9 +145,4 @@ AvailableItems.propTypes = {
   data: PropTypes.object.isRequired,
   loan: PropTypes.object.isRequired,
   fetchAvailableItems: PropTypes.func.isRequired,
-  showMaxAvailableItems: PropTypes.number,
-};
-
-AvailableItems.defaultProps = {
-  showMaxAvailableItems: 10,
 };

--- a/ui/src/pages/backoffice/Loan/LoanSearch/__tests__/__snapshots__/LoanSearch.test.js.snap
+++ b/ui/src/pages/backoffice/Loan/LoanSearch/__tests__/__snapshots__/LoanSearch.test.js.snap
@@ -21,7 +21,7 @@ exports[`LoansSearch ResultsTable tests should not render when empty results 1`]
   paginationComponent={null}
   seeAllComponent={null}
   showAllResults={false}
-  showMaxRows={10}
+  showMaxRows={15}
   singleLine={false}
   subtitle=""
   title=""
@@ -120,7 +120,7 @@ exports[`LoansSearch ResultsTable tests should render a list of results 1`] = `
   paginationComponent={null}
   seeAllComponent={null}
   showAllResults={false}
-  showMaxRows={10}
+  showMaxRows={15}
   singleLine={false}
   subtitle=""
   title=""
@@ -354,7 +354,7 @@ exports[`LoansSearch ResultsTable tests should render a list of results 1`] = `
         paginationComponent={null}
         seeAllComponent={null}
         showAllResults={false}
-        showMaxRows={10}
+        showMaxRows={15}
       />
     </table>
   </Table>

--- a/ui/src/pages/backoffice/Location/LocationList/LocationList.js
+++ b/ui/src/pages/backoffice/Location/LocationList/LocationList.js
@@ -112,5 +112,4 @@ LocationList.propTypes = {
   deleteLocation: PropTypes.func.isRequired,
   isLoading: PropTypes.bool.isRequired,
   hasError: PropTypes.bool.isRequired,
-  showMaxItems: PropTypes.number,
 };

--- a/ui/src/pages/backoffice/Patron/PatronDetails/components/ItemsSearch/__tests__/__snapshots__/ItemsSearch.test.js.snap
+++ b/ui/src/pages/backoffice/Patron/PatronDetails/components/ItemsSearch/__tests__/__snapshots__/ItemsSearch.test.js.snap
@@ -345,7 +345,6 @@ exports[`PatronLoans tests should render items in search 1`] = `
                         paginationComponent={null}
                         seeAllComponent={null}
                         showAllResults={false}
-                        showMaxRows={10}
                         singleLine={false}
                         subtitle=""
                         title=""
@@ -740,7 +739,6 @@ exports[`PatronLoans tests should render items in search 1`] = `
                               paginationComponent={null}
                               seeAllComponent={null}
                               showAllResults={false}
-                              showMaxRows={10}
                             />
                           </table>
                         </Table>

--- a/ui/src/pages/backoffice/Patron/PatronSearch/__tests__/__snapshots__/PatronSearch.test.js.snap
+++ b/ui/src/pages/backoffice/Patron/PatronSearch/__tests__/__snapshots__/PatronSearch.test.js.snap
@@ -29,7 +29,7 @@ exports[`PatronsSearch ResultsList tests should not render when empty results 1`
   paginationComponent={null}
   seeAllComponent={null}
   showAllResults={false}
-  showMaxRows={10}
+  showMaxRows={15}
   singleLine={false}
   subtitle=""
   title=""
@@ -133,7 +133,7 @@ exports[`PatronsSearch ResultsList tests should render a list of results 1`] = `
   paginationComponent={null}
   seeAllComponent={null}
   showAllResults={false}
-  showMaxRows={10}
+  showMaxRows={15}
   singleLine={false}
   subtitle=""
   title=""
@@ -438,7 +438,7 @@ exports[`PatronsSearch ResultsList tests should render a list of results 1`] = `
         paginationComponent={null}
         seeAllComponent={null}
         showAllResults={false}
-        showMaxRows={10}
+        showMaxRows={15}
       />
     </table>
   </Table>

--- a/ui/src/pages/backoffice/Series/SeriesDetails/components/SeriesMultipartMonographs/__tests__/__snapshots__/SeriesMultipartMonographs.test.js.snap
+++ b/ui/src/pages/backoffice/Series/SeriesDetails/components/SeriesMultipartMonographs/__tests__/__snapshots__/SeriesMultipartMonographs.test.js.snap
@@ -42,7 +42,7 @@ exports[`SeriesMultipartMonographs tests should load the SeriesMultipartMonograp
         />
       }
       showAllResults={false}
-      showMaxRows={10}
+      showMaxRows={15}
       singleLine={false}
       subtitle=""
       title="Multipart Monographs"

--- a/ui/src/pages/backoffice/Series/SeriesSearch/__tests__/__snapshots__/SeriesSearch.test.js.snap
+++ b/ui/src/pages/backoffice/Series/SeriesSearch/__tests__/__snapshots__/SeriesSearch.test.js.snap
@@ -21,7 +21,7 @@ exports[`SeriesSearch ResultsTable tests should not render when empty results 1`
   paginationComponent={null}
   seeAllComponent={null}
   showAllResults={false}
-  showMaxRows={10}
+  showMaxRows={15}
   singleLine={false}
   subtitle=""
   title=""
@@ -126,7 +126,7 @@ exports[`SeriesSearch ResultsTable tests should render a list of results 1`] = `
   paginationComponent={null}
   seeAllComponent={null}
   showAllResults={false}
-  showMaxRows={10}
+  showMaxRows={15}
   singleLine={false}
   subtitle=""
   title=""
@@ -366,7 +366,7 @@ exports[`SeriesSearch ResultsTable tests should render a list of results 1`] = `
         paginationComponent={null}
         seeAllComponent={null}
         showAllResults={false}
-        showMaxRows={10}
+        showMaxRows={15}
       />
     </table>
   </Table>

--- a/ui/src/pages/backoffice/components/DetailsHeader/DetailsHeader.js
+++ b/ui/src/pages/backoffice/components/DetailsHeader/DetailsHeader.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Container, Grid, Header, Icon} from 'semantic-ui-react';
+import { Grid, Header } from 'semantic-ui-react';
 
 export class DetailsHeader extends React.Component {
   render() {

--- a/ui/src/pages/backoffice/components/OrderList/OrderListEntry.js
+++ b/ui/src/pages/backoffice/components/OrderList/OrderListEntry.js
@@ -31,7 +31,12 @@ export default class OrderListEntry extends Component {
           </Link>
         </Item.Description>
         <Item.Description>
-          <label>total</label> {formatPrice(order.metadata.grand_total)}
+          <label>total</label>
+          {formatPrice(order.metadata.grand_total_main_currency)}
+          {order.metadata.grand_total.currency !==
+          order.metadata.grand_total_main_currency.currency
+            ? `(${formatPrice(order.metadata.grand_total)})`
+            : ''}
         </Item.Description>
       </>
     );
@@ -106,7 +111,7 @@ export default class OrderListEntry extends Component {
             <List.Content floated="right">
               <strong>{toShortDateTime(received_date)}</strong>
             </List.Content>
-            <List.Content>delivered</List.Content>
+            <List.Content>received</List.Content>
           </List.Item>
         )}
         {expected_delivery_date && (
@@ -114,7 +119,7 @@ export default class OrderListEntry extends Component {
             <List.Content floated="right">
               <strong>{toShortDateTime(expected_delivery_date)}</strong>
             </List.Content>
-            <List.Content>expected delivery date</List.Content>
+            <List.Content>expected</List.Content>
           </List.Item>
         )}
       </List>

--- a/ui/src/pages/backoffice/components/buttons/NewButton/NewButton.js
+++ b/ui/src/pages/backoffice/components/buttons/NewButton/NewButton.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 
 export default class NewButton extends Component {
   render() {
-    const { fluid, disabled, to } = this.props;
     return (
       <Button
         icon

--- a/ui/src/pages/frontsite/PatronProfile/PatronCurrentDocumentRequests/PatronCurrentDocumentRequests.js
+++ b/ui/src/pages/frontsite/PatronProfile/PatronCurrentDocumentRequests/PatronCurrentDocumentRequests.js
@@ -5,7 +5,6 @@ import _startCase from 'lodash/startCase';
 import { Loader, Error, ResultsTable, Pagination } from '@components';
 import { dateFormatter } from '@api/date';
 import { FrontSiteRoutes } from '@routes/urls';
-import { invenioConfig } from '@config';
 import { Button, Header, Item } from 'semantic-ui-react';
 import { ILSItemPlaceholder } from '@components/ILSPlaceholder/ILSPlaceholder';
 import { NoResultsMessage } from '../../components/NoResultsMessage';
@@ -31,7 +30,6 @@ export default class PatronCurrentDocumentRequests extends Component {
     return (
       <Pagination
         currentPage={this.state.activePage}
-        currentSize={invenioConfig.defaultResultsSize}
         loading={this.props.isLoading}
         totalResults={this.props.data.total}
         onPageChange={this.onPageChange}
@@ -106,7 +104,6 @@ export default class PatronCurrentDocumentRequests extends Component {
               totalHitsCount={data.total}
               title={''}
               name={'book requests'}
-              showMaxRows={invenioConfig.defaultResultsSize}
               paginationComponent={this.paginationComponent()}
               currentPage={this.state.activePage}
               renderEmptyResultsElement={this.renderNoResults}

--- a/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/PatronCurrentLoans.js
+++ b/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/PatronCurrentLoans.js
@@ -95,7 +95,6 @@ export default class PatronCurrentLoans extends Component {
     return (
       <Pagination
         currentPage={this.state.activePage}
-        currentSize={invenioConfig.defaultResultsSize}
         loading={this.props.isLoading}
         totalResults={this.props.data.total}
         onPageChange={this.onPageChange}

--- a/ui/src/pages/frontsite/PatronProfile/PatronPastDocumentRequests/PatronPastDocumentRequests.js
+++ b/ui/src/pages/frontsite/PatronProfile/PatronPastDocumentRequests/PatronPastDocumentRequests.js
@@ -5,7 +5,6 @@ import _startCase from 'lodash/startCase';
 import { Loader, Error, ResultsTable, Pagination } from '@components';
 import { dateFormatter } from '@api/date';
 import { FrontSiteRoutes } from '@routes/urls';
-import { invenioConfig } from '@config';
 import { Header, Item } from 'semantic-ui-react';
 import { ILSItemPlaceholder } from '@components/ILSPlaceholder/ILSPlaceholder';
 import { NoResultsMessage } from '../../components/NoResultsMessage';
@@ -31,7 +30,6 @@ export default class PatronPastDocumentRequests extends Component {
     return (
       <Pagination
         currentPage={this.state.activePage}
-        currentSize={invenioConfig.defaultResultsSize}
         loading={this.props.isLoading}
         totalResults={this.props.data.total}
         onPageChange={this.onPageChange}
@@ -97,7 +95,6 @@ export default class PatronPastDocumentRequests extends Component {
               totalHitsCount={data.total}
               title={''}
               name={'past literature requests'}
-              showMaxRows={invenioConfig.defaultResultsSize}
               paginationComponent={this.paginationComponent()}
               currentPage={this.state.activePage}
               renderEmptyResultsElement={this.renderEmpty}

--- a/ui/src/pages/frontsite/PatronProfile/PatronPastLoans/PatronPastLoans.js
+++ b/ui/src/pages/frontsite/PatronProfile/PatronPastLoans/PatronPastLoans.js
@@ -84,7 +84,6 @@ export default class PatronPastLoans extends Component {
     return (
       <Pagination
         currentPage={this.state.activePage}
-        currentSize={invenioConfig.defaultResultsSize}
         loading={this.props.isLoading}
         totalResults={this.props.data.total}
         onPageChange={this.onPageChange}

--- a/ui/src/pages/frontsite/PatronProfile/PatronPendingLoans/PatronPendingLoans.js
+++ b/ui/src/pages/frontsite/PatronProfile/PatronPendingLoans/PatronPendingLoans.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Loader, Error, Pagination } from '@components';
-import { invenioConfig } from '@config';
 import {
   Container,
   Grid,
@@ -108,7 +107,6 @@ export default class PatronPendingLoans extends Component {
     return (
       <Pagination
         currentPage={this.state.activePage}
-        currentSize={invenioConfig.defaultResultsSize}
         loading={this.props.isLoading}
         totalResults={this.props.data.total}
         onPageChange={this.onPageChange}


### PR DESCRIPTION
- changed naming of delivery date to received
- changed results per page to match default Elastic results (10) so SearchResultsPerPage isn't broken in first render
- cleaned unused imports
- fixed sorting for grand total in main currency, also added currency indication to make it more clear
- display grand total on an alternative currency only if its available
- defaultResultSize inside Pagination and ResultTable components instead of explicit default in every instance
- defaultResultSize for QueryBuildHelper, which fixes the ResulstPerPage components
- closes #672