### PR TITLE
documents: add open_access field

### DIFF
--- a/invenio_app_ils/cli.py
+++ b/invenio_app_ils/cli.py
@@ -306,7 +306,6 @@ class DocumentGenerator(Generator):
                 "authors": random.sample(self.AUTHORS, randint(1, 3)),
                 "abstract": "{}".format(lorem.text()),
                 "document_type": random.choice(self.DOCUMENT_TYPES),
-                "_access": {},
                 "languages": [lang["key"] for lang in random.sample(
                     self.holder.languages, randint(1, 3)
                 )],

--- a/invenio_app_ils/cli.py
+++ b/invenio_app_ils/cli.py
@@ -324,6 +324,7 @@ class DocumentGenerator(Generator):
                 "imprints": [self.IMPRINTS[randint(0, 1)]],
                 "urls": [{"description": "{}".format(lorem.sentence()),
                           "value": "http://random.url"}],
+                "open_access": True,
             }
             for pid in range(1, size + 1)
         ]

--- a/invenio_app_ils/config.py
+++ b/invenio_app_ils/config.py
@@ -596,8 +596,8 @@ RECORDS_REST_ENDPOINTS = dict(
         search_class=DocumentRequestSearch,
         record_class=DocumentRequest,
         indexer_class=DocumentRequestIndexer,
-        search_factory_imp="invenio_app_ils.search.api"
-                           ":filter_by_patron_search_factory",
+        search_factory_imp="invenio_app_ils.search.permissions"
+                           ":search_factory_filter_by_patron",
         record_loaders={
             "application/json": (
                 "invenio_app_ils.records.loaders:document_request_loader"
@@ -788,8 +788,8 @@ CIRCULATION_REST_ENDPOINTS = dict(
         pid_minter=CIRCULATION_LOAN_MINTER,
         pid_fetcher=CIRCULATION_LOAN_FETCHER,
         search_class=IlsLoansSearch,
-        search_factory_imp="invenio_app_ils.search.api"
-                           ":filter_by_patron_search_factory",
+        search_factory_imp="invenio_app_ils.search.permissions"
+                           ":search_factory_filter_by_patron",
         record_class=Loan,
         indexer_class=LoanIndexer,
         record_loaders={
@@ -1021,6 +1021,7 @@ FACET_VENDOR_LIMIT = 5
 RECORDS_REST_FACETS = dict(
     documents=dict(  # DocumentSearch.Meta.index
         aggs=dict(
+            access=dict(terms=dict(field="open_access")),
             tag=dict(terms=dict(field="tags", size=FACET_TAG_LIMIT)),
             language=dict(terms=dict(field="languages")),
             doctype=dict(terms=dict(field="document_type")),
@@ -1036,6 +1037,7 @@ RECORDS_REST_FACETS = dict(
             medium=dict(terms=dict(field="stock.mediums")),
         ),
         post_filters=dict(
+            access=terms_filter("open_access"),
             doctype=terms_filter("document_type"),
             language=terms_filter("languages"),
             tag=terms_filter("tags"),
@@ -1396,3 +1398,12 @@ ILS_VOCABULARY_SOURCES = {
 OPENDEFINITION_JSONRESOLVER_HOST = "inveniosoftware.org"
 
 FILES_REST_PERMISSION_FACTORY = "invenio_app_ils.permissions:files_permission"
+
+ILS_RECORDS_EXPLICIT_PERMISSIONS_ENABLED = False
+"""Enable records restrictions by `_access` field.
+
+When enabled, it allows to define explicit permissions for each record to
+provide read access to specific users or roles.
+When disabled, it will avoid checking for user ids and roles on each search
+query and record fetch.
+"""

--- a/invenio_app_ils/documents/loaders/jsonschemas/document.py
+++ b/invenio_app_ils/documents/loaders/jsonschemas/document.py
@@ -229,6 +229,7 @@ class DocumentSchemaV1(RecordMetadataSchemaJSONV1):
     licenses = fields.List(fields.Str())
     note = fields.Str()
     number_of_pages = fields.Str()
+    open_access = fields.Bool(default=True)
     other_authors = fields.Bool()
     publication_info = fields.List(fields.Nested(PublicationInfoSchema))
     source = fields.Str()

--- a/invenio_app_ils/documents/mappings/v6/documents/document-v1.0.0.json
+++ b/invenio_app_ils/documents/mappings/v6/documents/document-v1.0.0.json
@@ -165,6 +165,9 @@
         "languages": {
           "type": "keyword"
         },
+        "open_access": {
+          "type": "boolean"
+        },
         "pid": {
           "type": "keyword"
         },

--- a/invenio_app_ils/documents/mappings/v7/documents/document-v1.0.0.json
+++ b/invenio_app_ils/documents/mappings/v7/documents/document-v1.0.0.json
@@ -164,6 +164,9 @@
       "languages": {
         "type": "keyword"
       },
+      "open_access": {
+        "type": "boolean"
+      },
       "pid": {
         "type": "keyword"
       },

--- a/invenio_app_ils/documents/schemas/documents/document-v1.0.0.json
+++ b/invenio_app_ils/documents/schemas/documents/document-v1.0.0.json
@@ -4,14 +4,6 @@
     "$schema": {
       "type": "string"
     },
-    "_access": {
-      "properties": {
-        "read": {
-          "type": "array"
-        }
-      },
-      "type": "object"
-    },
     "abstract": {
       "title": "Abstract of the document.",
       "type": "string"
@@ -445,6 +437,11 @@
       "minLength": 1,
       "title": "Number of pages of the physical items",
       "type": "string"
+    },
+    "open_access": {
+      "type": "boolean",
+      "title": "Indicate if the access to this Document is open or not",
+      "default": true
     },
     "other_authors": {
       "title": "Indicates that there are other not listed authors.",

--- a/invenio_app_ils/documents/search.py
+++ b/invenio_app_ils/documents/search.py
@@ -8,6 +8,9 @@
 """ILS Document search APIs."""
 
 from invenio_search import RecordsSearch
+from invenio_search.api import DefaultFilter
+
+from invenio_app_ils.search.permissions import search_filter_record_permissions
 
 
 class DocumentSearch(RecordsSearch):
@@ -18,6 +21,7 @@ class DocumentSearch(RecordsSearch):
 
         index = "documents"
         doc_types = None
+        default_filter = DefaultFilter(search_filter_record_permissions)
 
     def search_by_pid(self, *pids):
         """Retrieve documents with the given pid(s)."""

--- a/invenio_app_ils/records/permissions.py
+++ b/invenio_app_ils/records/permissions.py
@@ -95,8 +95,8 @@ class RecordPermission(Permission):
         Implicit permission = `open_access` field
         Explicit, when defined, takes precedence over implicit which is
         ignored.
-        The record is public when `_access` is not defined and `open_access`
-        is True.
+        The record is public when `_access.read` is not defined and
+        `open_access` is True.
         """
         has_explicit_perm = current_app.config.get(
             "ILS_RECORDS_EXPLICIT_PERMISSIONS_ENABLED"

--- a/invenio_app_ils/schemas/eitems/eitem-v1.0.0.json
+++ b/invenio_app_ils/schemas/eitems/eitem-v1.0.0.json
@@ -41,7 +41,8 @@
     },
     "open_access": {
       "type": "boolean",
-      "title": "Indicate if the access to this EItem is open or not"
+      "title": "Indicate if the access to this EItem is open or not",
+      "default": true
     },
     "pid": {
       "type": "string",

--- a/invenio_app_ils/search/permissions.py
+++ b/invenio_app_ils/search/permissions.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# invenio-app-ils is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""ILS search permissions."""
+
+import re
+
+from elasticsearch_dsl import Q
+from flask import current_app, g, has_request_context, request
+from flask_login import current_user
+
+from invenio_app_ils.errors import SearchQueryError, UnauthorizedSearchError
+from invenio_app_ils.permissions import backoffice_permission
+
+
+def _get_user_provides():
+    """Extract the user's provides from g."""
+    provides = []
+    for need in g.identity.provides:
+        try:
+            provides.append(need.value.lower())
+        except AttributeError:
+            # Add the user ID (integer) to the list
+            provides.append(need.value)
+    return provides
+
+
+def search_filter_record_permissions():
+    """Filter list of results by `_access` and `open_access` fields."""
+    if not has_request_context() or backoffice_permission().allows(g.identity):
+        return Q()
+
+    # A record is public if `open_access` field True or missing
+    open_access_field_missing = ~Q("exists", field="open_access")
+    is_open_access = open_access_field_missing | Q("term", open_access=True)
+
+    combined_filter = is_open_access
+
+    if current_app.config.get("ILS_RECORDS_EXPLICIT_PERMISSIONS_ENABLED"):
+        # if `_access`, check `_access.read` against the user. It takes
+        # precedence over `open_access`.
+        # if not `_access`, check if open access as before.
+        _access_field_exists = Q("exists", field="_access.read")
+        provides = _get_user_provides()
+        user_can_read = _access_field_exists & Q(
+            "terms", **{"_access.read": provides}
+        )
+        combined_filter = user_can_read | (
+            ~_access_field_exists & is_open_access
+        )
+
+    return Q("bool", filter=[combined_filter])
+
+
+def _ils_search_factory(self, search, qs_validator):
+    """Search factory with Query String validator.
+
+    :param self: REST view.
+    :param search: Elastic search DSL search instance.
+    :returns: Tuple with search instance and URL arguments.
+    """
+    def query_parser(qstr=None):
+        """Default parser that uses the Q() from elasticsearch_dsl."""
+        if qstr:
+            return Q('query_string', query=qstr)
+        return Q()
+
+    from invenio_records_rest.facets import default_facets_factory
+    from invenio_records_rest.sorter import default_sorter_factory
+
+    query_string = request.values.get("q")
+
+    if not current_user.is_authenticated:
+        raise UnauthorizedSearchError(query_string)
+
+    query = query_parser(qs_validator(query_string))
+
+    try:
+        search = search.query(query)
+    except SyntaxError:
+        raise SearchQueryError(query_string)
+
+    search_index = search._index[0]
+    search, urlkwargs = default_facets_factory(search, search_index)
+    search, sortkwargs = default_sorter_factory(search, search_index)
+    for key, value in sortkwargs.items():
+        urlkwargs.add(key, value)
+
+    urlkwargs.add("q", query_string)
+    return search, urlkwargs
+
+
+def search_factory_filter_by_patron(self, search):
+    """Prepare query string to filter records by current logged in user."""
+
+    def filter_by_patron(query_string):
+        """Filter search results by patron_pid."""
+        # if the logged in user in not librarian or admin, validate the query
+        if has_request_context() and not backoffice_permission().allows(
+            g.identity
+        ):
+            # patron can find only his records
+            if not query_string:
+                # force query to be patron_pid:<logged in user>
+                query_string = "patron_pid:{}".format(g.identity.id)
+            else:
+                # check for patron_pid query value
+                match = re.match(r"patron_pid:(?P<pid>\d)", query_string)
+                if match and match.group("pid") != str(g.identity.id):
+                    raise UnauthorizedSearchError(query_string, g.identity.id)
+        return query_string
+
+    return _ils_search_factory(self, search, filter_by_patron)

--- a/invenio_app_ils/search/permissions.py
+++ b/invenio_app_ils/search/permissions.py
@@ -99,7 +99,7 @@ def search_factory_filter_by_patron(self, search):
 
     def filter_by_patron(query_string):
         """Filter search results by patron_pid."""
-        # if the logged in user in not librarian or admin, validate the query
+        # if the logged in user is not librarian or admin, validate the query
         if has_request_context() and not backoffice_permission().allows(
             g.identity
         ):
@@ -109,7 +109,7 @@ def search_factory_filter_by_patron(self, search):
                 query_string = "patron_pid:{}".format(g.identity.id)
             else:
                 # check for patron_pid query value
-                match = re.match(r"patron_pid:(?P<pid>\d)", query_string)
+                match = re.match(r"patron_pid:(?P<pid>\d+)", query_string)
                 if match and match.group("pid") != str(g.identity.id):
                     raise UnauthorizedSearchError(query_string, g.identity.id)
         return query_string

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -264,3 +264,11 @@ def bucket(bucket_from_dir):
     with tempfile.TemporaryDirectory(prefix="ils-test-") as temp_dir:
         bucket = bucket_from_dir(temp_dir)
         yield bucket
+
+
+@pytest.fixture()
+def with_access(app):
+    """Enable explicit permission check (`_access`)."""
+    app.config["ILS_RECORDS_EXPLICIT_PERMISSIONS_ENABLED"] = True
+    yield
+    app.config["ILS_RECORDS_EXPLICIT_PERMISSIONS_ENABLED"] = False

--- a/tests/api/document_requests/__init__.py
+++ b/tests/api/document_requests/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# invenio-app-ils is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Document Requests API Tests."""

--- a/tests/api/document_requests/test_document_requests.py
+++ b/tests/api/document_requests/test_document_requests.py
@@ -43,7 +43,7 @@ def test_request_list_permissions(client, testdata, json_headers, users):
         requests_by_patron[req['patron_pid']].append(req['pid'])
 
     for user in users.values():
-        login_user_via_session(client, email=User.query.get(user.id).email)
+        login_user_via_session(client, user=User.query.get(user.id))
         url = url_for("invenio_records_rest.dreqid_list")
         res = client.get(url, headers=json_headers)
         assert res.status_code == 200
@@ -99,7 +99,7 @@ def test_create_document_request(client, testdata, json_headers, users):
         ),
     ]
     for user, expected_status, data in tests:
-        login_user_via_session(client, email=users[user].email)
+        login_user_via_session(client, user=users[user])
         url = url_for("invenio_records_rest.dreqid_list")
         res = client.post(url, headers=json_headers, data=json.dumps(data))
         assert res.status_code == expected_status

--- a/tests/api/documents/test_document_crud.py
+++ b/tests/api/documents/test_document_crud.py
@@ -5,7 +5,7 @@
 # Invenio-Circulation is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
-"""Tests for loan item resolver."""
+"""Tests documents CRUD."""
 
 from invenio_app_ils.documents.api import Document
 

--- a/tests/api/documents/test_document_permissions.py
+++ b/tests/api/documents/test_document_permissions.py
@@ -12,6 +12,7 @@ import json
 from flask import url_for
 from invenio_db import db
 from invenio_indexer.api import RecordIndexer
+from invenio_search import current_search
 from tests.api.helpers import user_login
 
 from invenio_app_ils.documents.api import Document
@@ -29,6 +30,7 @@ def test_open_access_permissions(client, json_headers, testdata, users):
         doc.commit()
         db.session.commit()
         indexer.index(doc)
+    current_search.flush_and_refresh(index="documents")
 
     test_data = [
         ("anonymous", "docid-open-access", 200, 1),
@@ -72,6 +74,7 @@ def test_access_permissions(client, json_headers, testdata, users,
         doc.commit()
         db.session.commit()
         indexer.index(doc)
+    current_search.flush_and_refresh(index="documents")
 
     test_data = [
         ("anonymous", "docid-open-access", 401, 0),

--- a/tests/api/documents/test_document_permissions.py
+++ b/tests/api/documents/test_document_permissions.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# Invenio-Circulation is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Tests documents REST APIs permissions."""
+
+import json
+
+from flask import url_for
+from invenio_db import db
+from invenio_indexer.api import RecordIndexer
+from tests.api.helpers import user_login
+
+from invenio_app_ils.documents.api import Document
+
+
+def test_open_access_permissions(client, json_headers, testdata, users):
+    """Test GET open/close access documents."""
+    # set the documents to have read access only by patron2. `_access` should
+    # be totally ignored.
+    indexer = RecordIndexer()
+    doc1 = Document.get_record_by_pid("docid-open-access")
+    doc2 = Document.get_record_by_pid("docid-closed-access")
+    for doc in [doc1, doc2]:
+        doc.update(dict(_access=dict(read=["patron2"])))
+        doc.commit()
+        db.session.commit()
+        indexer.index(doc)
+
+    test_data = [
+        ("anonymous", "docid-open-access", 200, 1),
+        ("patron1", "docid-open-access", 200, 1),
+        ("patron2", "docid-open-access", 200, 1),
+        ("librarian", "docid-open-access", 200, 1),
+        ("admin", "docid-open-access", 200, 1),
+        ("anonymous", "docid-closed-access", 401, 0),
+        ("patron1", "docid-closed-access", 403, 0),
+        ("patron2", "docid-closed-access", 403, 0),
+        ("librarian", "docid-closed-access", 200, 1),
+        ("admin", "docid-closed-access", 200, 1),
+    ]
+    for user_id, pid, status_code, n_hits in test_data:
+        # item endpoint
+        user_login(user_id, client, users)
+        url = url_for("invenio_records_rest.docid_item", pid_value=pid)
+        res = client.get(url, headers=json_headers)
+        assert res.status_code == status_code
+
+        # list endpoint
+        user_login(user_id, client, users)
+        url = url_for(
+            "invenio_records_rest.docid_list", q="pid:{}".format(pid)
+        )
+        res = client.get(url, headers=json_headers)
+        hits = json.loads(res.data.decode("utf-8"))
+        assert hits["hits"]["total"] == n_hits
+
+
+def test_access_permissions(client, json_headers, testdata, users,
+                            with_access):
+    """Test GET documents with `_access` ignoring `open_access`."""
+    # set the documents to have read access only by patron2. `_access` should
+    # be taken into account and take precedence over `open_access`.
+    indexer = RecordIndexer()
+    doc1 = Document.get_record_by_pid("docid-open-access")
+    doc2 = Document.get_record_by_pid("docid-closed-access")
+    for doc in [doc1, doc2]:
+        doc.update(dict(_access=dict(read=[users["patron2"].id])))
+        doc.commit()
+        db.session.commit()
+        indexer.index(doc)
+
+    test_data = [
+        ("anonymous", "docid-open-access", 401, 0),
+        ("patron1", "docid-open-access", 403, 0),
+        ("patron2", "docid-open-access", 200, 1),  # should have access
+        ("librarian", "docid-open-access", 200, 1),
+        ("admin", "docid-open-access", 200, 1),
+        ("anonymous", "docid-closed-access", 401, 0),
+        ("patron1", "docid-closed-access", 403, 0),
+        ("patron2", "docid-closed-access", 200, 1),  # should have access
+        ("librarian", "docid-closed-access", 200, 1),
+        ("admin", "docid-closed-access", 200, 1),
+    ]
+    for user_id, pid, status_code, n_hits in test_data:
+        # item endpoint
+        user_login(user_id, client, users)
+        url = url_for("invenio_records_rest.docid_item", pid_value=pid)
+        res = client.get(url, headers=json_headers)
+        assert res.status_code == status_code
+
+        # list endpoint
+        user_login(user_id, client, users)
+        url = url_for(
+            "invenio_records_rest.docid_list", q="pid:{}".format(pid)
+        )
+        res = client.get(url, headers=json_headers)
+        hits = json.loads(res.data.decode("utf-8"))
+        assert hits["hits"]["total"] == n_hits

--- a/tests/api/helpers.py
+++ b/tests/api/helpers.py
@@ -9,6 +9,8 @@
 
 from __future__ import absolute_import, print_function
 
+from invenio_accounts.models import User
+from invenio_accounts.testutils import login_user_via_session
 from invenio_db import db
 from invenio_pidstore.models import PersistentIdentifier, PIDStatus
 
@@ -45,3 +47,19 @@ def document_ref_builder(app, item_pid):
         host=app.config["JSONSCHEMAS_HOST"],
         item_pid=item_pid,
     )
+
+
+def user_login(user_id, client, users):
+    """Util function log user in."""
+    user_logout(client)
+    if user_id != "anonymous":
+        user = User.query.get(users[user_id].id)
+        login_user_via_session(client, user)
+        return user
+
+
+def user_logout(client):
+    """Util function to log out user."""
+    with client.session_transaction() as sess:
+        if "user_id" in sess:
+            del sess["user_id"]

--- a/tests/api/test_files.py
+++ b/tests/api/test_files.py
@@ -11,26 +11,9 @@ import json
 
 import pytest
 from flask import url_for
-from invenio_accounts.models import User
-from invenio_accounts.testutils import login_user_via_session
 from invenio_search import current_search
 from six import BytesIO
-
-
-def user_login(user_id, client, users):
-    """Util function log user in."""
-    user_logout(client)
-    if user_id != "anonymous":
-        user = User.query.get(users[user_id].id)
-        login_user_via_session(client, user)
-        return user
-
-
-def user_logout(client):
-    """Util function to log out user."""
-    with client.session_transaction() as sess:
-        if "user_id" in sess:
-            del sess["user_id"]
+from tests.api.helpers import user_login
 
 
 def _test_response(

--- a/tests/api/test_item_permissions_endpoint.py
+++ b/tests/api/test_item_permissions_endpoint.py
@@ -21,9 +21,7 @@ from invenio_accounts.testutils import login_user_via_session
 def user_login(user_id, client, users):
     """Util function log user in."""
     if user_id != "anonymous":
-        login_user_via_session(
-            client, email=User.query.get(users[user_id].id).email
-        )
+        login_user_via_session(client, user=User.query.get(users[user_id].id))
 
 
 def _test_response(client, req_method, url, headers, data, expected_resp_code):
@@ -59,7 +57,14 @@ def _test_data(key, expected_output, res):
     ],
 )
 def test_get_item_endpoint(
-    client, json_headers, testdata, users, user_id, res_id, expected_resp_code
+    client,
+    json_headers,
+    testdata,
+    users,
+    with_access,
+    user_id,
+    res_id,
+    expected_resp_code,
 ):
     """Test GET permissions."""
     user_login(user_id, client, users)
@@ -174,26 +179,26 @@ def test_delete_item_endpoint(
         ("patron2", "itemid-57", 200, False),
         ("librarian", "itemid-56", 200, False),
         ("admin", "itemid-57", 200, False),
-    ]
+    ],
 )
-def test_item_circulation(client, json_headers, testdata, users, user_id,
-                          res_id, expected_resp_code, filtered):
+def test_item_circulation(
+    client,
+    json_headers,
+    testdata,
+    users,
+    user_id,
+    res_id,
+    expected_resp_code,
+    filtered,
+):
     """Test item circulation filtering."""
     user_login(user_id, client, users)
     url = url_for("invenio_records_rest.pitmid_item", pid_value=res_id)
     res = _test_response(
-        client,
-        "get",
-        url,
-        json_headers,
-        None,
-        expected_resp_code
+        client, "get", url, json_headers, None, expected_resp_code
     )
     circulation = res.json["metadata"]["circulation"]
-    filter_keys = [
-        "loan_pid",
-        "patron_pid",
-    ]
+    filter_keys = ["loan_pid", "patron_pid"]
     if filtered:
         for key in filter_keys:
             assert key not in circulation

--- a/tests/api/test_item_update.py
+++ b/tests/api/test_item_update.py
@@ -38,7 +38,7 @@ def test_update_item_status(client, users, json_headers, testdata, db):
                     return t["pid"], active_loan[0]["pid"]
 
     login_user_via_session(
-        client, email=User.query.get(users["admin"].id).email
+        client, user=User.query.get(users["admin"].id)
     )
     item_pid, loan_pid = get_active_loan_pid_and_item_pid()
     item = Item.get_record_by_pid(item_pid)
@@ -49,7 +49,7 @@ def test_update_item_status(client, users, json_headers, testdata, db):
 def test_update_item_document(client, users, json_headers, testdata, db):
     """Test REPLACE document pid on item."""
     login_user_via_session(
-        client, email=User.query.get(users["admin"].id).email
+        client, user=User.query.get(users["admin"].id)
     )
     item = Item.get_record_by_pid("itemid-1")
     item["document_pid"] = "not_found_doc"

--- a/tests/api/test_loaders.py
+++ b/tests/api/test_loaders.py
@@ -27,7 +27,7 @@ NEW_INTERNAL_LOCATION = {
 def user_login(user_id, client, users):
     """Util function log user in."""
     login_user_via_session(
-        client, email=User.query.get(users[user_id].id).email
+        client, user=User.query.get(users[user_id].id)
     )
 
 

--- a/tests/api/test_loan_checkout.py
+++ b/tests/api/test_loan_checkout.py
@@ -35,7 +35,7 @@ NEW_LOAN = {
 
 def _login(client, user, users):
     """Login user and return url."""
-    login_user_via_session(client, email=User.query.get(user.id).email)
+    login_user_via_session(client, user=User.query.get(user.id))
     return user
 
 

--- a/tests/api/test_loan_item_permissions.py
+++ b/tests/api/test_loan_item_permissions.py
@@ -28,7 +28,7 @@ NEW_LOAN = {
 def _fetch_loan(client, json_headers, loan, user=None):
     """Return the loan fetched with a REST call."""
     if user:
-        login_user_via_session(client, email=User.query.get(user.id).email)
+        login_user_via_session(client, user=User.query.get(user.id))
     url = url_for('invenio_records_rest.loanid_item',
                   pid_value=loan["pid"])
     return client.get(url, headers=json_headers)
@@ -135,7 +135,7 @@ def test_patron_cannot_update_loans(client, json_headers, users, testdata):
     user = users['patron1']
 
     loanid = 'loanid-1'
-    login_user_via_session(client, email=User.query.get(user.id).email)
+    login_user_via_session(client, user=User.query.get(user.id))
     _test_post_new_loan(client, json_headers, 403)
     _test_replace_existing_loan(client, json_headers, loanid, 403)
     _test_delete_existing_loan(client, json_headers, loanid, 403)

--- a/tests/api/test_loan_list_permissions.py
+++ b/tests/api/test_loan_list_permissions.py
@@ -18,7 +18,7 @@ from invenio_accounts.testutils import login_user_via_session
 
 from invenio_app_ils.circulation.search import IlsLoansSearch
 from invenio_app_ils.errors import UnauthorizedSearchError
-from invenio_app_ils.search.api import filter_by_patron_search_factory
+from invenio_app_ils.search.permissions import search_factory_filter_by_patron
 
 NEW_LOAN = {
     "item_pid": "200",
@@ -32,7 +32,7 @@ NEW_LOAN = {
 def _search_loans(client, json_headers, user=None, **kwargs):
     """Return the loan fetched with a REST call."""
     if user:
-        login_user_via_session(client, email=User.query.get(user.id).email)
+        login_user_via_session(client, user=User.query.get(user.id))
     url = url_for('invenio_records_rest.loanid_list', **kwargs)
     return client.get(url, headers=json_headers)
 
@@ -57,7 +57,7 @@ def test_anonymous_loans_search(app):
     """Test that not logged in users are unable to search."""
     with app.test_request_context("/"):
         with pytest.raises(UnauthorizedSearchError):
-            filter_by_patron_search_factory(None, IlsLoansSearch())
+            search_factory_filter_by_patron(None, IlsLoansSearch())
 
 
 def test_patrons_can_search_their_own_loans(client, json_headers, users,

--- a/tests/api/test_loan_request.py
+++ b/tests/api/test_loan_request.py
@@ -33,7 +33,7 @@ NEW_LOAN = {
 def _login(client, users):
     """Login user and return url."""
     user = users["patron1"]
-    login_user_via_session(client, email=User.query.get(user.id).email)
+    login_user_via_session(client, user=User.query.get(user.id))
     return user
 
 

--- a/tests/api/test_record_permissions.py
+++ b/tests/api/test_record_permissions.py
@@ -39,7 +39,8 @@ from invenio_app_ils.records.permissions import RecordPermission, \
         ({"_access": {"delete": [1, "librarian"]}}, "delete", True),
     ],
 )
-def test_record_generic_access(db, users, access, action, is_allowed):
+def test_record_generic_access(db, users, with_access, access, action,
+                               is_allowed):
     """Test access control for records."""
 
     @identity_loaded.connect
@@ -71,45 +72,6 @@ def test_record_generic_access(db, users, access, action, is_allowed):
     login_and_test(users["librarian"].id)
     # Test superuser access
     login_and_test(users["admin"].id)
-
-
-@pytest.mark.parametrize(
-    "access,action,is_allowed",
-    [
-        ({"foo": "bar"}, "update", True),
-        ({"foo": "bar"}, "delete", False),
-        ({"_access": {"delete": ["librarian"]}}, "delete", True),
-        ({"_access": {"delete": ["1"]}}, "delete", False),
-        ({"_access": {"update": ["1"]}}, "update", True),
-    ],
-)
-def test_record_librarian_access(db, users, access, action, is_allowed):
-    """Test Librarian access."""
-    login_user(users["librarian"])
-    id = uuid.uuid4()
-    record = Record.create(access, id_=id)
-    factory = RecordPermission(record, action)
-    assert factory.can() if is_allowed else not factory.can()
-
-
-@pytest.mark.parametrize(
-    "access,action,is_allowed",
-    [
-        ({"foo": "bar"}, "update", False),
-        ({"foo": "bar"}, "delete", False),
-        ({"_access": {"delete": [1]}}, "delete", True),
-        ({"_access": {"update": [1]}}, "update", True),
-        ({"_access": {"update": ["1"]}}, "update", True),
-        ({"_access": {"update": ["1"]}}, "delete", False),
-    ],
-)
-def test_record_patron_access(db, users, access, action, is_allowed):
-    """Test patron access."""
-    login_user(users["patron1"])
-    id = uuid.uuid4()
-    record = Record.create(access, id_=id)
-    factory = RecordPermission(record, action)
-    assert factory.can() if is_allowed else not factory.can()
 
 
 @pytest.mark.parametrize(

--- a/tests/api/test_record_relations.py
+++ b/tests/api/test_record_relations.py
@@ -605,7 +605,7 @@ def test_parent_child_relations(client, json_headers, testdata, users):
     ], status_code=401)
 
     user = users['librarian']
-    login_user_via_session(client, email=User.query.get(user.id).email)
+    login_user_via_session(client, user=User.query.get(user.id))
 
     # only one test method to speed up tests and avoid testdata recreation at
     # each test. As drawback, testdata is not cleaned between each test, so
@@ -1117,7 +1117,7 @@ def test_siblings_relations(client, json_headers, testdata, users):
     ], status_code=401)
 
     user = users['librarian']
-    login_user_via_session(client, email=User.query.get(user.id).email)
+    login_user_via_session(client, user=User.query.get(user.id))
 
     # docid-1 --language--> docid-2
     _test_sibl_language_relation(client, json_headers)

--- a/tests/api/test_stats.py
+++ b/tests/api/test_stats.py
@@ -48,7 +48,7 @@ def test_stats_most_loaned_documents(client, json_headers,
                                      testdata_most_loaned, users):
     """Test most loaned documents API endpoint."""
     user = users['librarian']
-    login_user_via_session(client, email=User.query.get(user.id).email)
+    login_user_via_session(client, user=User.query.get(user.id))
 
     # Dates covering all loans
     assert_most_loaned(

--- a/tests/data/documents.json
+++ b/tests/data/documents.json
@@ -143,5 +143,21 @@
     "authors": [{ "full_name": "Buhmann, Stefan Yoshi" }],
     "abstract": "This is a document volume v.1 part of a MULTIPART MONOGRAPH part of a SERIAL",
     "document_type": "BOOK"
+  },
+  {
+    "pid": "docid-closed-access",
+    "title": "Closed access document",
+    "authors": [{ "full_name": "Buhmann, Stefan Yoshi" }],
+    "abstract": "Just an abstract",
+    "document_type": "BOOK",
+    "open_access": false
+  },
+  {
+    "pid": "docid-open-access",
+    "title": "Open access document",
+    "authors": [{ "full_name": "Buhmann, Stefan Yoshi" }],
+    "abstract": "Just an abstract",
+    "document_type": "BOOK",
+    "open_access": true
   }
 ]

--- a/ui/src/config/searchConfig.js
+++ b/ui/src/config/searchConfig.js
@@ -50,6 +50,11 @@ const searchConfig = {
         field: 'stock.mediums',
         aggName: 'medium',
       },
+      {
+        title: 'Open access',
+        field: 'open_access',
+        aggName: 'access',
+      },
     ],
     sortBy: {
       onEmptyQuery: 'mostrecent',

--- a/ui/src/pages/backoffice/Document/DocumentForms/DocumentEditor/components/DocumentForm/DocumentForm.js
+++ b/ui/src/pages/backoffice/Document/DocumentForms/DocumentEditor/components/DocumentForm/DocumentForm.js
@@ -114,6 +114,7 @@ export class DocumentForm extends Component {
         />
         <AuthorsField fieldPath="authors" />
         <BooleanField label="Other authors" fieldPath="other_authors" toggle />
+        <BooleanField label="Open access" fieldPath="open_access" toggle />
         <BooleanField label="Document is curated" fieldPath="curated" toggle />
         <TextField label="Abstract" fieldPath="abstract" rows={5} optimized />
         <TextField label="Notes" fieldPath="note" rows={5} optimized />

--- a/ui/src/pages/backoffice/Item/ItemSearch/ItemSearch.js
+++ b/ui/src/pages/backoffice/Item/ItemSearch/ItemSearch.js
@@ -32,7 +32,7 @@ export class ItemSearch extends Component {
   renderSearchBar = (_, queryString, onInputChange, executeSearch) => {
     const helperFields = [
       {
-        name: 'barcode',
+        name: 'Barcode',
         field: 'barcode',
         defaultValue: '"1234567"',
       },
@@ -40,6 +40,11 @@ export class ItemSearch extends Component {
         name: 'ISBN',
         field: 'isbn',
         defaultValue: '"1234567"',
+      },
+      {
+        name: 'Shelf',
+        field: 'shelf',
+        defaultValue: '"Cw-Ax-Bs"',
       },
       {
         name: 'created',


### PR DESCRIPTION
* documents can be restricted by `open_access` field (implicit permissions)
* `_access` (explicit permissions), if and when defined`, takes always precedence
* refactor records item/list permissions to filter out closed access
  documents for non-admins/librarians
* changed records restrictions to use _access only when configured. In
  this way, the field is not evaluated on each search query when
  disabled.
* closes #687
* closes #681