### PR TITLE
Series: display number of documents

### DIFF
--- a/invenio_app_ils/records/views.py
+++ b/invenio_app_ils/records/views.py
@@ -26,15 +26,16 @@ from invenio_app_ils.signals import record_viewed
 class UserInfoResource(UserInfoView):
     """Retrieve current user's information."""
 
-    def response(self, user):
+    def success_response(self, user):
         """Return response with current user's information."""
         user_payload = default_user_payload(user)
         user_payload["roles"] = [role.name for role in user.roles]
         user_payload.update(
             dict(
                 locationPid=current_app.config["ILS_DEFAULT_LOCATION_PID"],
-                username=user.email
-            ))
+                username=user.email,
+            )
+        )
         return jsonify(user_payload), 200
 
 

--- a/ui/src/pages/backoffice/Series/SeriesDetails/SeriesDetails.js
+++ b/ui/src/pages/backoffice/Series/SeriesDetails/SeriesDetails.js
@@ -41,7 +41,6 @@ export default class SeriesDetails extends Component {
 
   seriesPanels = () => {
     const { data } = this.props;
-    console.log("DATA: ", data)
     let literatureNum = 0
     if (data.metadata && data.metadata.relations_metadata) {
       literatureNum = data.metadata.relations_metadata.serial ?

--- a/ui/src/pages/backoffice/Series/SeriesDetails/SeriesDetails.js
+++ b/ui/src/pages/backoffice/Series/SeriesDetails/SeriesDetails.js
@@ -42,13 +42,18 @@ export default class SeriesDetails extends Component {
 
   seriesPanels = () => {
     const { data } = this.props;
-    const serialsCount = _get(data, 'metadata.relations_metadata.serial', []).length
-    const monographsCount = _get(data, 'metadata.relations_metadata.multipart_monograph', []).length
-    const documentsCount = serialsCount + monographsCount
+    const serialsCount = _get(data, 'metadata.relations_metadata.serial', [])
+      .length;
+    const monographsCount = _get(
+      data,
+      'metadata.relations_metadata.multipart_monograph',
+      []
+    ).length;
+    const documentsCount = serialsCount + monographsCount;
     const panes = [
       {
         key: 'series-documents',
-        title: 'Literature in this series (' + documentsCount + ')',
+        title: `Literature in this series (${documentsCount})`,
         content: (
           <Accordion.Content>
             <div id="series-documents">

--- a/ui/src/pages/backoffice/Series/SeriesDetails/SeriesDetails.js
+++ b/ui/src/pages/backoffice/Series/SeriesDetails/SeriesDetails.js
@@ -5,6 +5,7 @@ import { SeriesActionMenu } from './';
 import { SeriesHeader } from './SeriesHeader';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import _get from 'lodash/get';
 import {
   Accordion,
   Container,
@@ -41,18 +42,13 @@ export default class SeriesDetails extends Component {
 
   seriesPanels = () => {
     const { data } = this.props;
-    let literatureNum = 0
-    if (data.metadata && data.metadata.relations_metadata) {
-      literatureNum = data.metadata.relations_metadata.serial ?
-        data.metadata.relations_metadata.serial.length :
-        data.metadata.relations_metadata.multipart_monograph.length
-    } else {
-      literatureNum = 0
-    }
+    const serialsCount = _get(data, 'metadata.relations_metadata.serial', []).length
+    const monographsCount = _get(data, 'metadata.relations_metadata.multipart_monograph', []).length
+    const documentsCount = serialsCount + monographsCount
     const panes = [
       {
         key: 'series-documents',
-        title: 'Literature in this series (' + literatureNum + ')',
+        title: 'Literature in this series (' + documentsCount + ')',
         content: (
           <Accordion.Content>
             <div id="series-documents">

--- a/ui/src/pages/backoffice/Series/SeriesDetails/SeriesDetails.js
+++ b/ui/src/pages/backoffice/Series/SeriesDetails/SeriesDetails.js
@@ -41,10 +41,19 @@ export default class SeriesDetails extends Component {
 
   seriesPanels = () => {
     const { data } = this.props;
+    console.log("DATA: ", data)
+    let literatureNum = 0
+    if (data.metadata && data.metadata.relations_metadata) {
+      literatureNum = data.metadata.relations_metadata.serial ?
+        data.metadata.relations_metadata.serial.length :
+        data.metadata.relations_metadata.multipart_monograph.length
+    } else {
+      literatureNum = 0
+    }
     const panes = [
       {
         key: 'series-documents',
-        title: 'Literature in this series',
+        title: 'Literature in this series (' + literatureNum + ')',
         content: (
           <Accordion.Content>
             <div id="series-documents">

--- a/ui/src/pages/backoffice/Series/SeriesSearch/SeriesListEntry.js
+++ b/ui/src/pages/backoffice/Series/SeriesSearch/SeriesListEntry.js
@@ -33,6 +33,17 @@ export class SeriesListEntry extends Component {
 
   renderRelations = () => {
     const { series } = this.props;
+    let literatureNum;
+    let searchStr;
+    if (series.metadata.relations_metadata) {
+      literatureNum = series.metadata.relations_metadata.serial ?
+        series.metadata.relations_metadata.serial.length :
+        series.metadata.relations_metadata.multipart_monograph.length
+      searchStr = series.metadata.relations_metadata.serial ?
+        'serial' : 'multipart_monograph'
+    } else {
+      literatureNum = 0
+    }
     return (
       <>
         <Item.Description>
@@ -83,6 +94,22 @@ export class SeriesListEntry extends Component {
                 )}
               </List.Item>
             )}
+
+            {!_isEmpty(series.metadata.relations_metadata) && (
+              <List.Item>
+                <List.Content>
+                  <Link
+                    to={BackOfficeRoutes.documentsListWithQuery(
+                      'relations.' + searchStr + '.pid:' + series.metadata.pid
+                    )}
+                  >
+                    See all volumes in this series ({literatureNum}){' '}
+                    <DocumentIcon />
+                  </Link>
+                </List.Content>
+              </List.Item>
+            )}
+
           </List>
         </Item.Description>
       </>

--- a/ui/src/pages/backoffice/Series/SeriesSearch/SeriesListEntry.js
+++ b/ui/src/pages/backoffice/Series/SeriesSearch/SeriesListEntry.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { Grid, Header, Icon, Item, List } from 'semantic-ui-react';
+import _get from 'lodash/get';
 
 export class SeriesListEntry extends Component {
   renderMiddleColumn = series => {
@@ -33,17 +34,19 @@ export class SeriesListEntry extends Component {
 
   renderRelations = () => {
     const { series } = this.props;
-    let literatureNum;
-    let searchStr;
-    if (series.metadata.relations_metadata) {
-      literatureNum = series.metadata.relations_metadata.serial ?
-        series.metadata.relations_metadata.serial.length :
-        series.metadata.relations_metadata.multipart_monograph.length
-      searchStr = series.metadata.relations_metadata.serial ?
-        'serial' : 'multipart_monograph'
-    } else {
-      literatureNum = 0
-    }
+    const serialsCount = _get(series, 'metadata.relations_metadata.serial', [])
+      .length;
+    const monographsCount = _get(
+      series,
+      'metadata.relations_metadata.multipart_monograph',
+      []
+    ).length;
+    const documentsCount = serialsCount + monographsCount;
+    const seriesType =
+      series.metadata.relations_metadata &&
+      series.metadata.relations_metadata.multipart_monograph
+        ? 'multipart_monograph'
+        : 'serial';
     return (
       <>
         <Item.Description>
@@ -100,16 +103,15 @@ export class SeriesListEntry extends Component {
                 <List.Content>
                   <Link
                     to={BackOfficeRoutes.documentsListWithQuery(
-                      'relations.' + searchStr + '.pid:' + series.metadata.pid
+                      `relations.${seriesType}.pid:${series.metadata.pid}`
                     )}
                   >
-                    See all volumes in this series ({literatureNum}){' '}
+                    See all volumes in this series ({documentsCount}){' '}
                     <DocumentIcon />
                   </Link>
                 </List.Content>
               </List.Item>
             )}
-
           </List>
         </Item.Description>
       </>

--- a/ui/src/pages/frontsite/components/Series/SeriesLiteratureSearch/SeriesLiteratureSearch.js
+++ b/ui/src/pages/frontsite/components/Series/SeriesLiteratureSearch/SeriesLiteratureSearch.js
@@ -49,6 +49,14 @@ export class SeriesLiteratureSearch extends React.Component {
 
   render() {
     const { metadata } = this.props;
+    let literatureNum
+    if (metadata.relations_metadata) {
+      literatureNum = metadata.relations_metadata.serial ?
+        metadata.relations_metadata.serial.length :
+        metadata.relations_metadata.multipart_monograph.length
+    } else {
+      literatureNum = 0
+    }
     const api = new InvenioSearchApi({
       invenio: {
         requestSerializer: literatureRequestSerializerCls(metadata),
@@ -58,7 +66,7 @@ export class SeriesLiteratureSearch extends React.Component {
     });
     return (
       <>
-        <Divider horizontal>Literature in this series</Divider>
+        <Divider horizontal>Literature in this series ({literatureNum})</Divider>
         <ReactSearchKit searchApi={api} history={history}>
           <Container className="series-details-search-container">
             <SearchBar renderElement={this.renderSearchBar} />

--- a/ui/src/pages/frontsite/components/Series/SeriesLiteratureSearch/SeriesLiteratureSearch.js
+++ b/ui/src/pages/frontsite/components/Series/SeriesLiteratureSearch/SeriesLiteratureSearch.js
@@ -50,9 +50,13 @@ export class SeriesLiteratureSearch extends React.Component {
 
   render() {
     const { metadata } = this.props;
-    const serialsCount = _get(metadata, 'relations_metadata.serial', []).length
-    const monographsCount = _get(metadata, 'relations_metadata.multipart_monograph', []).length
-    const documentsCount = serialsCount + monographsCount
+    const serialsCount = _get(metadata, 'relations_metadata.serial', []).length;
+    const monographsCount = _get(
+      metadata,
+      'relations_metadata.multipart_monograph',
+      []
+    ).length;
+    const documentsCount = serialsCount + monographsCount;
     const api = new InvenioSearchApi({
       invenio: {
         requestSerializer: literatureRequestSerializerCls(metadata),
@@ -62,7 +66,9 @@ export class SeriesLiteratureSearch extends React.Component {
     });
     return (
       <>
-        <Divider horizontal>Literature in this series ({documentsCount})</Divider>
+        <Divider horizontal>
+          Literature in this series ({documentsCount})
+        </Divider>
         <ReactSearchKit searchApi={api} history={history}>
           <Container className="series-details-search-container">
             <SearchBar renderElement={this.renderSearchBar} />

--- a/ui/src/pages/frontsite/components/Series/SeriesLiteratureSearch/SeriesLiteratureSearch.js
+++ b/ui/src/pages/frontsite/components/Series/SeriesLiteratureSearch/SeriesLiteratureSearch.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Divider, Loader, Responsive, Container } from 'semantic-ui-react';
+import _get from 'lodash/get';
 import {
   ReactSearchKit,
   InvenioSearchApi,
@@ -49,14 +50,9 @@ export class SeriesLiteratureSearch extends React.Component {
 
   render() {
     const { metadata } = this.props;
-    let literatureNum
-    if (metadata.relations_metadata) {
-      literatureNum = metadata.relations_metadata.serial ?
-        metadata.relations_metadata.serial.length :
-        metadata.relations_metadata.multipart_monograph.length
-    } else {
-      literatureNum = 0
-    }
+    const serialsCount = _get(metadata, 'relations_metadata.serial', []).length
+    const monographsCount = _get(metadata, 'relations_metadata.multipart_monograph', []).length
+    const documentsCount = serialsCount + monographsCount
     const api = new InvenioSearchApi({
       invenio: {
         requestSerializer: literatureRequestSerializerCls(metadata),
@@ -66,7 +62,7 @@ export class SeriesLiteratureSearch extends React.Component {
     });
     return (
       <>
-        <Divider horizontal>Literature in this series ({literatureNum})</Divider>
+        <Divider horizontal>Literature in this series ({documentsCount})</Divider>
         <ReactSearchKit searchApi={api} history={history}>
           <Container className="series-details-search-container">
             <SearchBar renderElement={this.renderSearchBar} />


### PR DESCRIPTION
On the frontsite display the number of documents in the details page of every series.
![details_frontsite](https://user-images.githubusercontent.com/33685068/76843911-cf17ee80-683c-11ea-9579-dc4b52b65a69.png)

 On the backoffice display the same in the details page and in the search page.
![details_backoffice](https://user-images.githubusercontent.com/33685068/76843967-e35beb80-683c-11ea-8ba9-8bcb8d74d5c6.png)
![search_backoffice](https://user-images.githubusercontent.com/33685068/76843973-e656dc00-683c-11ea-88fa-55de42b3262b.png)

After clicking in the link in the search page of backoffice:
![after_click_backoffice](https://user-images.githubusercontent.com/33685068/76843995-f373cb00-683c-11ea-93a7-4272751cdaab.png)

Closes #474