### PR TITLE
loan: patron extend loan

### DIFF
--- a/invenio_app_ils/circulation/utils.py
+++ b/invenio_app_ils/circulation/utils.py
@@ -70,7 +70,7 @@ def circulation_default_extension_duration(loan):
 
 def circulation_default_extension_max_count(loan):
     """Return a default extensions max count."""
-    return float("inf")
+    return 3
 
 
 def circulation_is_loan_duration_valid(loan):
@@ -94,7 +94,7 @@ def circulation_overdue_loan_days(loan):
 def circulation_upcoming_return_range():
     """Return a default upcoming return range."""
     return arrow.utcnow() + timedelta(
-        days=current_app.config["ILS_UPCOMING_RETURN_RANGE"])
+        days=current_app.config["ILS_LOAN_OVERDUE_DAYS_UPFRONT_NOTIFICATION"])
 
 
 def circulation_transaction_location_validator(transaction_location_pid):

--- a/invenio_app_ils/circulation/utils.py
+++ b/invenio_app_ils/circulation/utils.py
@@ -91,10 +91,10 @@ def circulation_overdue_loan_days(loan):
     return (arrow.get().utcnow() - end_date).days
 
 
-def circulation_upcoming_return_range():
+def circulation_loan_will_expire_days():
     """Return a default upcoming return range."""
     return arrow.utcnow() + timedelta(
-        days=current_app.config["ILS_LOAN_OVERDUE_DAYS_UPFRONT_NOTIFICATION"])
+        days=current_app.config["ILS_LOAN_WILL_EXPIRE_DAYS"])
 
 
 def circulation_transaction_location_validator(transaction_location_pid):

--- a/invenio_app_ils/config.py
+++ b/invenio_app_ils/config.py
@@ -96,8 +96,8 @@ from .circulation.utils import (  # isort:skip
 from .permissions import (  # isort:skip
     authenticated_user_permission,
     backoffice_permission,
+    loan_extend_circulation_permission,
     DocumentRequestOwnerPermission,
-    LoanExtendPermission,
     LoanOwnerPermission,
     views_permissions_factory,
 )
@@ -837,7 +837,7 @@ CIRCULATION_LOAN_TRANSITIONS = {
             dest="ITEM_ON_LOAN",
             transition=ItemOnLoanToItemOnLoan,
             trigger="extend",
-            permission_factory=LoanExtendPermission,
+            permission_factory=loan_extend_circulation_permission,
         ),
         dict(
             dest="CANCELLED",

--- a/invenio_app_ils/config.py
+++ b/invenio_app_ils/config.py
@@ -90,13 +90,14 @@ from .circulation.utils import (  # isort:skip
     circulation_build_item_ref,
     circulation_build_patron_ref,
     circulation_can_be_requested,
-    circulation_build_document_ref, circulation_upcoming_return_range,
+    circulation_build_document_ref, circulation_loan_will_expire_days,
     circulation_transaction_location_validator,
     circulation_transaction_user_validator)
 from .permissions import (  # isort:skip
     authenticated_user_permission,
     backoffice_permission,
     DocumentRequestOwnerPermission,
+    LoanExtendPermission,
     LoanOwnerPermission,
     views_permissions_factory,
 )
@@ -227,8 +228,8 @@ ILS_MAIL_LOAN_MSG_LOADER = (
 #: Notification email for overdue loan sent automatically every X days
 ILS_MAIL_LOAN_OVERDUE_REMINDER_INTERVAL = 3
 
-# Upcoming return date range in days
-ILS_LOAN_OVERDUE_DAYS_UPFRONT_NOTIFICATION = 7
+#: Period of time in days, before loans expire, for notifications etc.
+ILS_LOAN_WILL_EXPIRE_DAYS = 7
 
 # Assets
 # ======
@@ -767,7 +768,7 @@ CIRCULATION_POLICIES = dict(
         max_count=circulation_default_extension_max_count,
     ),
     request=dict(can_be_requested=circulation_can_be_requested),
-    upcoming_return_range=circulation_upcoming_return_range
+    upcoming_return_range=circulation_loan_will_expire_days
 )
 
 CIRCULATION_ITEM_REF_BUILDER = circulation_build_item_ref
@@ -836,7 +837,7 @@ CIRCULATION_LOAN_TRANSITIONS = {
             dest="ITEM_ON_LOAN",
             transition=ItemOnLoanToItemOnLoan,
             trigger="extend",
-            permission_factory=LoanOwnerPermission,
+            permission_factory=LoanExtendPermission,
         ),
         dict(
             dest="CANCELLED",

--- a/invenio_app_ils/config.py
+++ b/invenio_app_ils/config.py
@@ -228,7 +228,7 @@ ILS_MAIL_LOAN_MSG_LOADER = (
 ILS_MAIL_LOAN_OVERDUE_REMINDER_INTERVAL = 3
 
 # Upcoming return date range in days
-ILS_UPCOMING_RETURN_RANGE = 7
+ILS_LOAN_OVERDUE_DAYS_UPFRONT_NOTIFICATION = 7
 
 # Assets
 # ======
@@ -836,7 +836,7 @@ CIRCULATION_LOAN_TRANSITIONS = {
             dest="ITEM_ON_LOAN",
             transition=ItemOnLoanToItemOnLoan,
             trigger="extend",
-            permission_factory=backoffice_permission,
+            permission_factory=LoanOwnerPermission,
         ),
         dict(
             dest="CANCELLED",

--- a/invenio_app_ils/errors.py
+++ b/invenio_app_ils/errors.py
@@ -253,3 +253,14 @@ class StatsError(IlsException):
     def __init__(self, description):
         """Initialize exception."""
         super().__init__(description=description)
+
+
+class InvalidLoanExtendError(IlsException):
+    """Raised when loan cannot be extended."""
+
+    description = "This loan cannot be extended. {}"
+
+    def __init__(self, msg, **kwargs):
+        """Initialize exception."""
+        super().__init__(**kwargs)
+        self.description = self.description.format(msg)

--- a/invenio_app_ils/permissions.py
+++ b/invenio_app_ils/permissions.py
@@ -11,22 +11,15 @@ from __future__ import absolute_import, print_function
 
 from functools import wraps
 
-import arrow
 from flask import abort, current_app
 from flask_login import current_user
 from flask_principal import UserNeed
 from invenio_access import action_factory
 from invenio_access.permissions import Permission, authenticated_user
-from invenio_circulation.proxies import current_circulation
 from invenio_records_rest.utils import allow_all, deny_all
 
 from invenio_app_ils.errors import InvalidLoanExtendError
 from invenio_app_ils.proxies import current_app_ils
-
-from invenio_app_ils.circulation.utils import (  # isort:skip
-    circulation_default_extension_max_count,
-    circulation_overdue_loan_days
-)
 
 backoffice_access_action = action_factory("ils-backoffice-access")
 
@@ -60,9 +53,19 @@ def check_permission(permission):
         abort(403)
 
 
+def authenticated_user_permission(*args, **kwargs):
+    """Return an object that evaluates if the current user is authenticated."""
+    return Permission(authenticated_user)
+
+
 def backoffice_permission(*args, **kwargs):
     """Return permission to allow only librarians and admins."""
     return Permission(backoffice_access_action)
+
+
+def circulation_permission(patron_pid):
+    """Return circulation status permission for a patron."""
+    return Permission(UserNeed(int(patron_pid)), backoffice_access_action)
 
 
 def file_download_permission(obj):
@@ -87,6 +90,19 @@ def files_permission(obj, action=None):
     return backoffice_permission()
 
 
+def loan_extend_circulation_permission(loan):
+    """Return permission to allow only owner and librarians to extend loan."""
+    if not current_user or not current_user.id:
+        abort(401)
+
+    if current_user.id == int(loan["patron_pid"]):
+        loan = loan.replace_refs()
+        if loan.get("document").get("circulation").get("overbooked"):
+            raise InvalidLoanExtendError("This document is overbooked!")
+
+    return LoanOwnerPermission(loan)
+
+
 class LoanOwnerPermission(Permission):
     """Return Permission to evaluate if the current user owns the loan."""
 
@@ -97,73 +113,6 @@ class LoanOwnerPermission(Permission):
         )
 
 
-class LoanExtendPermission(Permission):
-    """Return Permission to evaluate if the user can extend the loan."""
-
-    def __init__(self, record):
-        """Constructor."""
-        self.record = record
-
-        # NOTE: extra validation if the user is not librarian or admin
-        if current_user.id == int(record["patron_pid"]):
-            self.validate()
-
-        super().__init__(
-            UserNeed(int(record["patron_pid"])), backoffice_access_action
-        )
-
-    def validate(self):
-        """Validate if the loan can be extended."""
-        if not self.validate_extend_enabled():
-            raise InvalidLoanExtendError(
-                "You can extend this loan {} days before it "
-                "expires!".format(
-                    current_app.config["ILS_LOAN_WILL_EXPIRE_DAYS"])
-            )
-
-        if not self.validate_max_extensions():
-            raise InvalidLoanExtendError(
-                "You have reached the max number of extensions for THIS loan!"
-            )
-
-        if not self.validate_pending_loans():
-            raise InvalidLoanExtendError(
-                "There is a high demand for this literature!"
-            )
-
-        if self.validate_is_overdue():
-            raise InvalidLoanExtendError(
-                "This loan is overdue, its end date has passed!"
-            )
-
-    def validate_extend_enabled(self):
-        """Validate loan is in the period that can be extended."""
-        end_date = arrow.get(self.record["end_date"])
-        return (
-            (arrow.get().utcnow() - end_date).days <=
-            current_app.config["ILS_LOAN_WILL_EXPIRE_DAYS"]
-        )
-
-    def validate_max_extensions(self):
-        """Validate if we have reached the max extension count."""
-        return (
-            self.record["extension_count"] <=
-            circulation_default_extension_max_count(self.record)
-        )
-
-    def validate_pending_loans(self):
-        """Validate the loaned document has no pending loan requests."""
-        loan_search = current_circulation.loan_search_cls()
-        pending_loans_count = loan_search.get_pending_loans_by_doc_pid(
-            self.record["document_pid"]
-        ).count()
-        return pending_loans_count == 0
-
-    def validate_is_overdue(self):
-        """Validate if the loan is overdue."""
-        return circulation_overdue_loan_days(self.record) > 0
-
-
 class DocumentRequestOwnerPermission(Permission):
     """Return Permission to evaluate if the current user owns the request."""
 
@@ -172,11 +121,6 @@ class DocumentRequestOwnerPermission(Permission):
         super(DocumentRequestOwnerPermission, self).__init__(
             UserNeed(int(record["patron_pid"])), backoffice_access_action
         )
-
-
-def authenticated_user_permission(*args, **kwargs):
-    """Return an object that evaluates if the current user is authenticated."""
-    return Permission(authenticated_user)
 
 
 def views_permissions_factory(action):
@@ -201,10 +145,4 @@ def views_permissions_factory(action):
         return backoffice_permission()
     elif action == "ill-create-loan":
         return backoffice_permission()
-    else:
-        return deny_all()
-
-
-def circulation_permission(patron_pid):
-    """Return circulation status permission for a patron."""
-    return Permission(UserNeed(int(patron_pid)), backoffice_access_action)
+    return deny_all()

--- a/tests/api/circulation/test_loan_extend.py
+++ b/tests/api/circulation/test_loan_extend.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019-2020 CERN.
+#
+# invenio-app-ils is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Test loan extend."""
+
+import json
+
+import pytest
+from flask import url_for
+from flask_security import login_user
+from invenio_circulation.api import Loan
+from invenio_circulation.proxies import current_circulation
+
+from ..helpers import user_login
+
+
+@pytest.mark.parametrize(
+    "user,expected_resp_code",
+    [
+        ("admin", 202),
+        ("librarian", 202),
+        ("patron1", 202),
+        ("patron3", 403),
+    ],
+)
+def test_loan_extend_permissions(
+    app, client, json_headers, users, testdata, app_config, loan_params,
+    user, expected_resp_code
+):
+    """Test loan can be extended."""
+    # Create a Loan for patron with pid 1
+    login_user(users["librarian"])
+    loan_data = testdata["loans"][0]
+    loan = Loan.get_record_by_pid(loan_data["pid"])
+
+    current_circulation.circulation.trigger(
+        loan, **dict(loan_params, trigger="checkout")
+    )
+
+    user_login(client, "librarian", users)
+    resp = client.get(
+        url_for("invenio_records_rest.loanid_item", pid_value=loan["pid"]),
+        headers=json_headers
+    )
+    loan = resp.get_json()
+
+    # Remove payload params that break the request
+    del loan_params["item_pid"]
+    del loan_params["transaction_date"]
+    extend_url = loan.get("links").get("actions").get("extend")
+
+    user_login(client, user, users)
+    extend_res = client.post(
+        extend_url, headers=json_headers, data=json.dumps(loan_params))
+    assert extend_res.status_code == expected_resp_code

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -11473,9 +11473,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
       "version": "3.1.1",

--- a/ui/src/config/__mocks__/invenioConfig.js
+++ b/ui/src/config/__mocks__/invenioConfig.js
@@ -10,7 +10,7 @@ export const invenioConfig = {
     loanCancelledStates: ['CANCELLED'],
     deliveryMethods: { DELIVERY: '', 'PICK UP': '' },
     requestDuration: 60,
-    loanOverdueDaysUpfrontNotification: 7,
+    loanWillExpireDays: 7,
   },
   documentRequests: {
     physicalItemProviders: {

--- a/ui/src/config/__mocks__/invenioConfig.js
+++ b/ui/src/config/__mocks__/invenioConfig.js
@@ -3,12 +3,14 @@ export const invenioConfig = {
     canCirculateStatuses: ['CAN_CIRCULATE'],
   },
   circulation: {
+    extensionsMaxCount: 3,
     loanRequestStates: ['PENDING'],
     loanActiveStates: ['ITEM_ON_LOAN'],
     loanCompletedStates: ['ITEM_RETURNED'],
     loanCancelledStates: ['CANCELLED'],
     deliveryMethods: { DELIVERY: '', 'PICK UP': '' },
     requestDuration: 60,
+    loanOverdueDaysUpfrontNotification: 7,
   },
   documentRequests: {
     physicalItemProviders: {

--- a/ui/src/config/invenioConfig.js
+++ b/ui/src/config/invenioConfig.js
@@ -9,6 +9,8 @@ export const invenioConfig = {
       PICKUP: 'Pick it up at the library desk',
       DELIVERY: 'Have it delivered to my office',
     },
+    extensionsMaxCount: 3,
+    loanOverdueDaysUpfrontNotification: 7,
     loanActiveStates: [
       'ITEM_AT_DESK',
       'ITEM_ON_LOAN',
@@ -72,9 +74,6 @@ export const invenioConfig = {
     ],
     canCirculateStatuses: ['CAN_CIRCULATE'],
     referenceStatuses: ['FOR_REFERENCE_ONLY'],
-  },
-  loans: {
-    maxExtensionsCount: 3,
   },
   max_results_window: 10000,
   orders: {

--- a/ui/src/config/invenioConfig.js
+++ b/ui/src/config/invenioConfig.js
@@ -10,7 +10,7 @@ export const invenioConfig = {
       DELIVERY: 'Have it delivered to my office',
     },
     extensionsMaxCount: 3,
-    loanOverdueDaysUpfrontNotification: 7,
+    loanWillExpireDays: 7,
     loanActiveStates: [
       'ITEM_AT_DESK',
       'ITEM_ON_LOAN',

--- a/ui/src/pages/backoffice/Series/SeriesDetails/__tests__/__snapshots__/SeriesDetails.test.js.snap
+++ b/ui/src/pages/backoffice/Series/SeriesDetails/__tests__/__snapshots__/SeriesDetails.test.js.snap
@@ -72,7 +72,7 @@ exports[`SeriesDetails tests should load the details component 1`] = `
                           </div>
                         </AccordionContent>,
                         "key": "series-documents",
-                        "title": "Literature in this series",
+                        "title": "Literature in this series (0)",
                       },
                       Object {
                         "content": <AccordionContent>

--- a/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/PatronCurrentLoans.js
+++ b/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/PatronCurrentLoans.js
@@ -2,16 +2,17 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Loader, Error, Pagination } from '@components';
 import { Container, Header, Item } from 'semantic-ui-react';
-import _isEmpty from 'lodash/isEmpty';
 import { ILSItemPlaceholder } from '@components/ILSPlaceholder/ILSPlaceholder';
 import { NoResultsMessage } from '../../components/NoResultsMessage';
-import { LoanListEntry } from './components/LoanListEntry';
+import { LoanListEntry } from './components';
+import _isEmpty from 'lodash/isEmpty';
 
 const PAGE_SIZE = 5;
 
 export default class PatronCurrentLoans extends Component {
   constructor(props) {
     super(props);
+    this.extendLoan = this.props.extendLoan;
     this.fetchPatronCurrentLoans = this.props.fetchPatronCurrentLoans;
     this.patronPid = this.props.patronPid;
     this.state = { activePage: 1 };
@@ -48,7 +49,18 @@ export default class PatronCurrentLoans extends Component {
         <>
           <Item.Group divided>
             {data.hits.map(entry => (
-              <LoanListEntry key={entry.metadata.pid} loan={entry} />
+              <LoanListEntry
+                key={entry.metadata.pid}
+                loan={entry}
+                extendLoan={this.extendLoan}
+                onExtendSuccess={() => {
+                  this.fetchPatronCurrentLoans(
+                    this.patronPid,
+                    this.state.activePage,
+                    PAGE_SIZE
+                  );
+                }}
+              />
             ))}
           </Item.Group>
           <Container textAlign={'center'}>

--- a/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/ExtendButton/ExtendButton.js
+++ b/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/ExtendButton/ExtendButton.js
@@ -1,0 +1,130 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { DateTime } from 'luxon';
+import { Button, Icon, Popup } from 'semantic-ui-react';
+import { invenioConfig, ES_DELAY } from '@config';
+import _get from 'lodash/get';
+import _has from 'lodash/has';
+
+export const INFO_MESSAGES = {
+  hasMaxExtensions: 'You have reached the max number of extensions for a loan!',
+  hasExtendAction:
+    'Manually extending this loan, is not currently an available action!',
+  hasPendingLoans:
+    'Other users requested that book, therefore you cannot extend your loan.',
+  isOverdue: 'You loan is overdue, therefore you cannot extend the loan!',
+  isOwner: 'You are not the owner of this loan, so you cannot extend it!',
+};
+
+export default class ExtendButton extends Component {
+  state = {
+    hasExtendAction: false,
+    hasMaxExtensions: false,
+    hasPendingLoans: false,
+    infoMessage: '',
+    isOverdue: false,
+    isOwner: false,
+  };
+
+  componentDidMount = () => {
+    this.checkMaxExtensions();
+    this.checkPendingLoans();
+    this.checkIsOverdue();
+    this.checkHasExtendAction();
+    this.checkIsOwner();
+  };
+
+  checkMaxExtensions = () => {
+    const { extension_count: extensionCount } = this.props.loan.metadata;
+    const hasMaxExtensions =
+      invenioConfig.circulation.extensionsMaxCount <= extensionCount;
+    this.setState({ hasMaxExtensions: hasMaxExtensions });
+    if (hasMaxExtensions)
+      this.setState({ infoMessage: INFO_MESSAGES.hasMaxExtensions });
+  };
+
+  checkPendingLoans = () => {
+    const { document } = this.props.loan.metadata;
+    const hasPendingLoans = _get(document, 'circulation.pending_loans', 0) > 0;
+    this.setState({ hasPendingLoans: hasPendingLoans });
+    if (hasPendingLoans)
+      this.setState({ infoMessage: INFO_MESSAGES.hasPendingLoans });
+  };
+
+  checkIsOverdue = () => {
+    const { is_overdue: isOverdue } = this.props.loan.metadata;
+    this.setState({ isOverdue: isOverdue });
+    if (isOverdue) this.setState({ infoMessage: INFO_MESSAGES.isOverdue });
+  };
+
+  checkHasExtendAction = () => {
+    const hasExtendAction = _has(this.props.loan, 'availableActions.extend');
+    this.setState({ hasExtendAction: hasExtendAction });
+    if (!hasExtendAction)
+      this.setState({ infoMessage: INFO_MESSAGES.hasExtendAction });
+  };
+
+  checkIsOwner = () => {
+    const { id: userId } = this.props.user;
+    const { patron_pid: patronPid } = this.props.loan.metadata;
+
+    const isOwner = userId === patronPid;
+    this.setState({ isOwner: isOwner });
+    if (!isOwner) this.setState({ infoMessage: INFO_MESSAGES.isOwner });
+  };
+
+  get isDisabled() {
+    return (
+      this.state.hasMaxExtensions ||
+      this.state.hasPendingLoans ||
+      this.state.isOverdue ||
+      !this.state.hasExtendAction ||
+      !this.state.isOwner
+    );
+  }
+
+  handleExtendRequest = async () => {
+    const { loan, onExtendSuccess } = this.props;
+    const { document, patron_pid: patronPid } = loan.metadata;
+    const extendUrl = _get(loan, 'availableActions.extend');
+
+    await this.props.extendLoan(extendUrl, document.pid, patronPid);
+    setTimeout(() => {
+      onExtendSuccess();
+    }, ES_DELAY);
+  };
+
+  render() {
+    const { loan } = this.props;
+    const showExtendButton =
+      DateTime.fromISO(loan.metadata.end_date).diffNow('days').days <=
+      invenioConfig.circulation.loanOverdueDaysUpfrontNotification;
+
+    return (
+      showExtendButton && (
+        <>
+          <Button
+            color="purple"
+            size="mini"
+            content="extend loan"
+            disabled={this.isDisabled}
+            onClick={this.handleExtendRequest}
+          />
+          {this.isDisabled && (
+            <Popup
+              content={this.state.infoMessage}
+              trigger={<Icon name={'info'} />}
+              position={'top left'}
+            />
+          )}
+        </>
+      )
+    );
+  }
+}
+
+ExtendButton.propTypes = {
+  loan: PropTypes.object.isRequired,
+  extendLoan: PropTypes.func.isRequired,
+  onExtendSuccess: PropTypes.func.isRequired,
+};

--- a/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/ExtendButton/__tests__/ExtendButton.test.js
+++ b/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/ExtendButton/__tests__/ExtendButton.test.js
@@ -1,8 +1,7 @@
 import React from 'react';
-import { DateTime } from 'luxon';
-import { mount } from 'enzyme';
-import ExtendButton, { INFO_MESSAGES } from '../ExtendButton';
 import { fromISO } from '@api/date';
+import { mount } from 'enzyme';
+import ExtendButton from '../ExtendButton';
 import testData from '@testData/loans.json';
 
 jest.mock('@config/invenioConfig');
@@ -24,6 +23,7 @@ describe('Extend loan button tests', () => {
       availableActions: { extend: 'url/extend' },
       metadata: {
         ...testData[0],
+        end_date: fromISO(testData.end_date),
         extension_count: 0,
       },
     };
@@ -44,6 +44,7 @@ describe('Extend loan button tests', () => {
       availableActions: { extend: 'url/extend' },
       metadata: {
         ...testData[0],
+        end_date: fromISO(testData.end_date),
         extension_count: 0,
         document: { circulation: { pending_loans: 2 } },
       },
@@ -57,9 +58,6 @@ describe('Extend loan button tests', () => {
         user={user}
       />
     );
-    expect(component.state().infoMessage).toEqual(
-      'Other users requested that book, therefore you cannot extend your loan.'
-    );
     const btn = component.find('Button');
     expect(btn.props().disabled).toBe(true);
   });
@@ -69,6 +67,7 @@ describe('Extend loan button tests', () => {
       availableActions: { extend: 'url/extend' },
       metadata: {
         ...testData[0],
+        end_date: fromISO(testData.end_date),
         extension_count: 0,
         is_overdue: true,
       },
@@ -82,7 +81,6 @@ describe('Extend loan button tests', () => {
         user={user}
       />
     );
-    expect(component.state().infoMessage).toEqual(INFO_MESSAGES.isOverdue);
     const btn = component.find('Button');
     expect(btn.props().disabled).toBe(true);
   });
@@ -92,6 +90,7 @@ describe('Extend loan button tests', () => {
       availableActions: { extend: 'url/extend' },
       metadata: {
         ...testData[0],
+        end_date: fromISO(testData.end_date),
         extension_count: 3,
       },
     };
@@ -104,41 +103,16 @@ describe('Extend loan button tests', () => {
         user={user}
       />
     );
-    expect(component.state().infoMessage).toEqual(
-      INFO_MESSAGES.hasMaxExtensions
-    );
     const btn = component.find('Button');
     expect(btn.props().disabled).toBe(true);
   });
 
-  it('should be disabled if patron is not the owner', () => {
-    const loan = {
-      availableActions: { extend: 'url/extend' },
-      metadata: {
-        ...testData[0],
-        extension_count: 3,
-      },
-    };
-    const otherUser = { id: 2 };
-
-    const component = mount(
-      <ExtendButton
-        extendLoan={() => {}}
-        onExtendSuccess={() => {}}
-        loan={loan}
-        user={otherUser}
-      />
-    );
-    expect(component.state().infoMessage).toEqual(INFO_MESSAGES.isOwner);
-    const btn = component.find('Button');
-    expect(btn.props().disabled).toBe(true);
-  });
-
-  it('should be disabled if extend action is in available actions', () => {
+  it('should be disabled if extend action is not in available actions', () => {
     const loan = {
       availableActions: {},
       metadata: {
         ...testData[0],
+        end_date: fromISO(testData.end_date),
         extension_count: 0,
       },
     };
@@ -151,9 +125,7 @@ describe('Extend loan button tests', () => {
         user={user}
       />
     );
-    expect(component.state().infoMessage).toEqual(
-      INFO_MESSAGES.hasExtendAction
-    );
+
     const btn = component.find('Button');
     expect(btn.props().disabled).toBe(true);
   });

--- a/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/ExtendButton/__tests__/ExtendButton.test.js
+++ b/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/ExtendButton/__tests__/ExtendButton.test.js
@@ -3,9 +3,11 @@ import { fromISO } from '@api/date';
 import { mount } from 'enzyme';
 import ExtendButton from '../ExtendButton';
 import testData from '@testData/loans.json';
+import { DateTime } from 'luxon';
 
 jest.mock('@config/invenioConfig');
 
+const end_date = DateTime.local(2032, 12, 13, 12, 13);
 const user = {
   id: testData[0].patron_pid,
 };
@@ -23,7 +25,7 @@ describe('Extend loan button tests', () => {
       availableActions: { extend: 'url/extend' },
       metadata: {
         ...testData[0],
-        end_date: fromISO(testData.end_date),
+        end_date: end_date,
         extension_count: 0,
       },
     };
@@ -39,37 +41,14 @@ describe('Extend loan button tests', () => {
     expect(component).toMatchSnapshot();
   });
 
-  it('should be disabled if it document has pending loans', () => {
+  it('should be disabled if the document is overbooked', () => {
     const loan = {
       availableActions: { extend: 'url/extend' },
       metadata: {
         ...testData[0],
-        end_date: fromISO(testData.end_date),
+        end_date: end_date,
         extension_count: 0,
-        document: { circulation: { pending_loans: 2 } },
-      },
-    };
-
-    const component = mount(
-      <ExtendButton
-        extendLoan={() => {}}
-        onExtendSuccess={() => {}}
-        loan={loan}
-        user={user}
-      />
-    );
-    const btn = component.find('Button');
-    expect(btn.props().disabled).toBe(true);
-  });
-
-  it('should be disabled if the loan is overdue', () => {
-    const loan = {
-      availableActions: { extend: 'url/extend' },
-      metadata: {
-        ...testData[0],
-        end_date: fromISO(testData.end_date),
-        extension_count: 0,
-        is_overdue: true,
+        document: { circulation: { overbooked: true } },
       },
     };
 
@@ -90,7 +69,7 @@ describe('Extend loan button tests', () => {
       availableActions: { extend: 'url/extend' },
       metadata: {
         ...testData[0],
-        end_date: fromISO(testData.end_date),
+        end_date: end_date,
         extension_count: 3,
       },
     };
@@ -112,7 +91,7 @@ describe('Extend loan button tests', () => {
       availableActions: {},
       metadata: {
         ...testData[0],
-        end_date: fromISO(testData.end_date),
+        end_date: end_date,
         extension_count: 0,
       },
     };

--- a/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/ExtendButton/__tests__/ExtendButton.test.js
+++ b/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/ExtendButton/__tests__/ExtendButton.test.js
@@ -1,0 +1,160 @@
+import React from 'react';
+import { DateTime } from 'luxon';
+import { mount } from 'enzyme';
+import ExtendButton, { INFO_MESSAGES } from '../ExtendButton';
+import { fromISO } from '@api/date';
+import testData from '@testData/loans.json';
+
+jest.mock('@config/invenioConfig');
+
+const user = {
+  id: testData[0].patron_pid,
+};
+
+describe('Extend loan button tests', () => {
+  let component;
+  afterEach(() => {
+    if (component) {
+      component.unmount();
+    }
+  });
+
+  it('should match snapshot', () => {
+    const loan = {
+      availableActions: { extend: 'url/extend' },
+      metadata: {
+        ...testData[0],
+        extension_count: 0,
+      },
+    };
+
+    const component = mount(
+      <ExtendButton
+        extendLoan={() => {}}
+        onExtendSuccess={() => {}}
+        loan={loan}
+        user={user}
+      />
+    );
+    expect(component).toMatchSnapshot();
+  });
+
+  it('should be disabled if it document has pending loans', () => {
+    const loan = {
+      availableActions: { extend: 'url/extend' },
+      metadata: {
+        ...testData[0],
+        extension_count: 0,
+        document: { circulation: { pending_loans: 2 } },
+      },
+    };
+
+    const component = mount(
+      <ExtendButton
+        extendLoan={() => {}}
+        onExtendSuccess={() => {}}
+        loan={loan}
+        user={user}
+      />
+    );
+    expect(component.state().infoMessage).toEqual(
+      'Other users requested that book, therefore you cannot extend your loan.'
+    );
+    const btn = component.find('Button');
+    expect(btn.props().disabled).toBe(true);
+  });
+
+  it('should be disabled if the loan is overdue', () => {
+    const loan = {
+      availableActions: { extend: 'url/extend' },
+      metadata: {
+        ...testData[0],
+        extension_count: 0,
+        is_overdue: true,
+      },
+    };
+
+    const component = mount(
+      <ExtendButton
+        extendLoan={() => {}}
+        onExtendSuccess={() => {}}
+        loan={loan}
+        user={user}
+      />
+    );
+    expect(component.state().infoMessage).toEqual(INFO_MESSAGES.isOverdue);
+    const btn = component.find('Button');
+    expect(btn.props().disabled).toBe(true);
+  });
+
+  it('should be disabled if patron has reached maximum extensions', () => {
+    const loan = {
+      availableActions: { extend: 'url/extend' },
+      metadata: {
+        ...testData[0],
+        extension_count: 3,
+      },
+    };
+
+    const component = mount(
+      <ExtendButton
+        extendLoan={() => {}}
+        onExtendSuccess={() => {}}
+        loan={loan}
+        user={user}
+      />
+    );
+    expect(component.state().infoMessage).toEqual(
+      INFO_MESSAGES.hasMaxExtensions
+    );
+    const btn = component.find('Button');
+    expect(btn.props().disabled).toBe(true);
+  });
+
+  it('should be disabled if patron is not the owner', () => {
+    const loan = {
+      availableActions: { extend: 'url/extend' },
+      metadata: {
+        ...testData[0],
+        extension_count: 3,
+      },
+    };
+    const otherUser = { id: 2 };
+
+    const component = mount(
+      <ExtendButton
+        extendLoan={() => {}}
+        onExtendSuccess={() => {}}
+        loan={loan}
+        user={otherUser}
+      />
+    );
+    expect(component.state().infoMessage).toEqual(INFO_MESSAGES.isOwner);
+    const btn = component.find('Button');
+    expect(btn.props().disabled).toBe(true);
+  });
+
+  it('should be disabled if extend action is in available actions', () => {
+    const loan = {
+      availableActions: {},
+      metadata: {
+        ...testData[0],
+        extension_count: 0,
+      },
+    };
+
+    const component = mount(
+      <ExtendButton
+        extendLoan={() => {}}
+        onExtendSuccess={() => {}}
+        loan={loan}
+        user={user}
+      />
+    );
+    expect(component.state().infoMessage).toEqual(
+      INFO_MESSAGES.hasExtendAction
+    );
+    const btn = component.find('Button');
+    expect(btn.props().disabled).toBe(true);
+  });
+});

--- a/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/ExtendButton/__tests__/__snapshots__/ExtendButton.test.js.snap
+++ b/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/ExtendButton/__tests__/__snapshots__/ExtendButton.test.js.snap
@@ -10,7 +10,7 @@ exports[`Extend loan button tests should match snapshot 1`] = `
       },
       "metadata": Object {
         "document_pid": "docid-1",
-        "end_date": null,
+        "end_date": "2032-12-13T12:13:00.000+01:00",
         "extension_count": 0,
         "item_pid": Object {},
         "patron": Object {
@@ -38,7 +38,7 @@ exports[`Extend loan button tests should match snapshot 1`] = `
   <Button
     as="button"
     color="purple"
-    content="extend loan"
+    content="Request extension"
     disabled={true}
     onClick={[Function]}
     size="mini"
@@ -51,7 +51,7 @@ exports[`Extend loan button tests should match snapshot 1`] = `
             disabled=""
             tabindex="-1"
           >
-            extend loan
+            Request extension
           </button>,
         }
       }
@@ -64,7 +64,7 @@ exports[`Extend loan button tests should match snapshot 1`] = `
               disabled=""
               tabindex="-1"
             >
-              extend loan
+              Request extension
             </button>,
           }
         }
@@ -75,13 +75,14 @@ exports[`Extend loan button tests should match snapshot 1`] = `
           onClick={[Function]}
           tabIndex={-1}
         >
-          extend loan
+          Request extension
         </button>
       </RefFindNode>
     </Ref>
   </Button>
   <Popup
-    content="You can extend this loan 7 days before it expires!"
+    content="It is too early for extending the loan. You can request an extension from
+      December 6"
     disabled={false}
     eventsEnabled={true}
     offset={0}
@@ -92,7 +93,7 @@ exports[`Extend loan button tests should match snapshot 1`] = `
       ]
     }
     pinned={false}
-    position="top left"
+    position="top right"
     trigger={
       <Icon
         as="i"

--- a/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/ExtendButton/__tests__/__snapshots__/ExtendButton.test.js.snap
+++ b/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/ExtendButton/__tests__/__snapshots__/ExtendButton.test.js.snap
@@ -1,0 +1,78 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Extend loan button tests should match snapshot 1`] = `
+<ExtendButton
+  extendLoan={[Function]}
+  loan={
+    Object {
+      "availableActions": Object {
+        "extend": "url/extend",
+      },
+      "metadata": Object {
+        "document_pid": "docid-1",
+        "end_date": "2018-07-28",
+        "extension_count": 0,
+        "item_pid": Object {},
+        "patron": Object {
+          "email": "patron1@test.ch",
+        },
+        "patron_pid": "1",
+        "pickup_location_pid": "1",
+        "pid": "loanid-1",
+        "request_expire_date": "2019-06-28",
+        "request_start_date": "2018-06-28",
+        "start_date": "2018-06-28",
+        "state": "PENDING",
+        "transaction_date": "2018-06-29",
+        "transaction_location_pid": "1",
+      },
+    }
+  }
+  onExtendSuccess={[Function]}
+  user={
+    Object {
+      "id": "1",
+    }
+  }
+>
+  <Button
+    as="button"
+    color="purple"
+    content="extend loan"
+    disabled={false}
+    onClick={[Function]}
+    size="mini"
+  >
+    <Ref
+      innerRef={
+        Object {
+          "current": <button
+            class="ui purple mini button"
+          >
+            extend loan
+          </button>,
+        }
+      }
+    >
+      <RefFindNode
+        innerRef={
+          Object {
+            "current": <button
+              class="ui purple mini button"
+            >
+              extend loan
+            </button>,
+          }
+        }
+      >
+        <button
+          className="ui purple mini button"
+          onClick={[Function]}
+        >
+          extend loan
+        </button>
+      </RefFindNode>
+    </Ref>
+  </Button>
+</ExtendButton>
+`;

--- a/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/ExtendButton/__tests__/__snapshots__/ExtendButton.test.js.snap
+++ b/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/ExtendButton/__tests__/__snapshots__/ExtendButton.test.js.snap
@@ -10,7 +10,7 @@ exports[`Extend loan button tests should match snapshot 1`] = `
       },
       "metadata": Object {
         "document_pid": "docid-1",
-        "end_date": "2018-07-28",
+        "end_date": null,
         "extension_count": 0,
         "item_pid": Object {},
         "patron": Object {
@@ -39,7 +39,7 @@ exports[`Extend loan button tests should match snapshot 1`] = `
     as="button"
     color="purple"
     content="extend loan"
-    disabled={false}
+    disabled={true}
     onClick={[Function]}
     size="mini"
   >
@@ -47,7 +47,9 @@ exports[`Extend loan button tests should match snapshot 1`] = `
       innerRef={
         Object {
           "current": <button
-            class="ui purple mini button"
+            class="ui purple mini disabled button"
+            disabled=""
+            tabindex="-1"
           >
             extend loan
           </button>,
@@ -58,7 +60,9 @@ exports[`Extend loan button tests should match snapshot 1`] = `
         innerRef={
           Object {
             "current": <button
-              class="ui purple mini button"
+              class="ui purple mini disabled button"
+              disabled=""
+              tabindex="-1"
             >
               extend loan
             </button>,
@@ -66,13 +70,93 @@ exports[`Extend loan button tests should match snapshot 1`] = `
         }
       >
         <button
-          className="ui purple mini button"
+          className="ui purple mini disabled button"
+          disabled={true}
           onClick={[Function]}
+          tabIndex={-1}
         >
           extend loan
         </button>
       </RefFindNode>
     </Ref>
   </Button>
+  <Popup
+    content="You can extend this loan 7 days before it expires!"
+    disabled={false}
+    eventsEnabled={true}
+    offset={0}
+    on={
+      Array [
+        "click",
+        "hover",
+      ]
+    }
+    pinned={false}
+    position="top left"
+    trigger={
+      <Icon
+        as="i"
+        name="info"
+      />
+    }
+  >
+    <Portal
+      closeOnDocumentClick={true}
+      closeOnEscape={true}
+      closeOnTriggerClick={true}
+      closeOnTriggerMouseLeave={true}
+      eventPool="default"
+      mouseEnterDelay={50}
+      mouseLeaveDelay={70}
+      onClose={[Function]}
+      onMount={[Function]}
+      onOpen={[Function]}
+      onUnmount={[Function]}
+      openOnTriggerClick={true}
+      openOnTriggerMouseEnter={true}
+      trigger={
+        <Icon
+          as="i"
+          name="info"
+        />
+      }
+      triggerRef={
+        Object {
+          "current": <i
+            aria-hidden="true"
+            class="info icon"
+          />,
+        }
+      }
+    >
+      <Ref
+        innerRef={[Function]}
+      >
+        <RefFindNode
+          innerRef={[Function]}
+        >
+          <Icon
+            as="i"
+            name="info"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            <i
+              aria-hidden="true"
+              className="info icon"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+            />
+          </Icon>
+        </RefFindNode>
+      </Ref>
+    </Portal>
+  </Popup>
 </ExtendButton>
 `;

--- a/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/ExtendButton/index.js
+++ b/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/ExtendButton/index.js
@@ -1,0 +1,19 @@
+import { connect } from 'react-redux';
+import { performLoanAction } from '@pages/backoffice/Loan/LoanDetails/state/actions';
+import ExtendButtonComponent from './ExtendButton';
+
+const mapStateToProps = state => ({
+  user: state.authenticationManagement.data,
+});
+
+const mapDispatchToProps = dispatch => ({
+  extendLoan: (url, documentPid, patronPid, itemPid) =>
+    dispatch(
+      performLoanAction(url, documentPid, patronPid, { itemPid: itemPid })
+    ),
+});
+
+export const ExtendButton = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ExtendButtonComponent);

--- a/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/ExtendButton/index.js
+++ b/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/ExtendButton/index.js
@@ -2,10 +2,6 @@ import { connect } from 'react-redux';
 import { performLoanAction } from '@pages/backoffice/Loan/LoanDetails/state/actions';
 import ExtendButtonComponent from './ExtendButton';
 
-const mapStateToProps = state => ({
-  user: state.authenticationManagement.data,
-});
-
 const mapDispatchToProps = dispatch => ({
   extendLoan: (url, documentPid, patronPid, itemPid) =>
     dispatch(
@@ -14,6 +10,6 @@ const mapDispatchToProps = dispatch => ({
 });
 
 export const ExtendButton = connect(
-  mapStateToProps,
+  null,
   mapDispatchToProps
 )(ExtendButtonComponent);

--- a/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/LoanListEntry/LoanListEntry.js
+++ b/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/LoanListEntry/LoanListEntry.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { Grid, Item, Label } from 'semantic-ui-react';
 import { toShortDate } from '@api/date';
-import { invenioConfig } from '@config';
 import { FrontSiteRoutes } from '@routes/urls';
 import { DocumentAuthors, DocumentItemCover } from '@components/Document';
 import { ExtendButton } from '../';
@@ -22,6 +21,13 @@ const ReturnLabel = ({ endDate }) => {
     </h4>
   );
 };
+
+const ExtensionCount = ({ count }) =>
+  count > 0 && (
+    <Item.Description>
+      You have extended this loan {count} times
+    </Item.Description>
+  );
 
 export class LoanListEntry extends Component {
   render() {
@@ -55,10 +61,7 @@ export class LoanListEntry extends Component {
                 <DocumentAuthors metadata={loan.metadata.document} />
                 Loaned on {toShortDate(loan.metadata.start_date)}
               </Item.Meta>
-              <Item.Description>
-                You have extended this loan {loan.metadata.extension_count} of{' '}
-                {invenioConfig.circulation.extensionsMaxCount} times
-              </Item.Description>
+              <ExtensionCount count={loan.metadata.extension_count} />
             </Grid.Column>
             <Grid.Column
               textAlign={'right'}

--- a/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/LoanListEntry/LoanListEntry.js
+++ b/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/LoanListEntry/LoanListEntry.js
@@ -5,29 +5,19 @@ import { Grid, Item, Label } from 'semantic-ui-react';
 import { toShortDate } from '@api/date';
 import { FrontSiteRoutes } from '@routes/urls';
 import { DocumentAuthors, DocumentItemCover } from '@components/Document';
+import { ExtensionCount } from '@pages/frontsite/components/Loan';
 import { ExtendButton } from '../';
 
-const OverdueLabel = () => {
-  return (
-    <h4>Your loan is overdue. Please return the book as soon as possible!</h4>
-  );
-};
+const OverdueLabel = () => (
+  <h4>Your loan is overdue. Please return the book as soon as possible!</h4>
+);
 
-const ReturnLabel = ({ endDate }) => {
-  return (
-    <h4>
-      Please return the literature before date{' '}
-      <Label className={'bkg-primary'}>{toShortDate(endDate)}</Label>
-    </h4>
-  );
-};
-
-const ExtensionCount = ({ count }) =>
-  count > 0 && (
-    <Item.Description>
-      You have extended this loan {count} times
-    </Item.Description>
-  );
+const ReturnLabel = ({ endDate }) => (
+  <h4>
+    Please return the literature before date{' '}
+    <Label className={'bkg-primary'}>{toShortDate(endDate)}</Label>
+  </h4>
+);
 
 export class LoanListEntry extends Component {
   render() {

--- a/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/LoanListEntry/LoanListEntry.js
+++ b/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/LoanListEntry/LoanListEntry.js
@@ -1,14 +1,31 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { Grid, Item, Label } from 'semantic-ui-react';
 import { toShortDate } from '@api/date';
 import { invenioConfig } from '@config';
 import { FrontSiteRoutes } from '@routes/urls';
 import { DocumentAuthors, DocumentItemCover } from '@components/Document';
+import { ExtendButton } from '../';
+
+const OverdueLabel = () => {
+  return (
+    <h4>Your loan is overdue. Please return the book as soon as possible!</h4>
+  );
+};
+
+const ReturnLabel = ({ endDate }) => {
+  return (
+    <h4>
+      Please return the literature before date{' '}
+      <Label className={'bkg-primary'}>{toShortDate(endDate)}</Label>
+    </h4>
+  );
+};
 
 export class LoanListEntry extends Component {
   render() {
-    const { loan } = this.props;
+    const { loan, extendLoan, onExtendSuccess } = this.props;
     const isLoanOverdue = loan.metadata.is_overdue;
     return (
       <Item
@@ -39,10 +56,8 @@ export class LoanListEntry extends Component {
                 Loaned on {toShortDate(loan.metadata.start_date)}
               </Item.Meta>
               <Item.Description>
-                {}
-                You have extended this loan {
-                  loan.metadata.extension_count
-                } of {invenioConfig.loans.maxExtensionsCount} times
+                You have extended this loan {loan.metadata.extension_count} of{' '}
+                {invenioConfig.circulation.extensionsMaxCount} times
               </Item.Description>
             </Grid.Column>
             <Grid.Column
@@ -52,15 +67,17 @@ export class LoanListEntry extends Component {
               computer={8}
             >
               <Item.Description>
-                Please return the literature before date{' '}
-                <Label className={'bkg-primary'}>
-                  {toShortDate(loan.metadata.end_date)}
-                </Label>
+                {isLoanOverdue ? (
+                  <OverdueLabel />
+                ) : (
+                  <ReturnLabel endDate={loan.metadata.end_date}></ReturnLabel>
+                )}
                 <br />
-                {isLoanOverdue
-                  ? 'Your loan is overdue. Please return the book ' +
-                    'as soon as possible'
-                  : null}
+                <ExtendButton
+                  loan={loan}
+                  extendLoan={extendLoan}
+                  onExtendSuccess={onExtendSuccess}
+                ></ExtendButton>
               </Item.Description>
             </Grid.Column>
           </Grid>
@@ -69,3 +86,9 @@ export class LoanListEntry extends Component {
     );
   }
 }
+
+LoanListEntry.propTypes = {
+  loan: PropTypes.object.isRequired,
+  extendLoan: PropTypes.func,
+  onExtendSuccess: PropTypes.func,
+};

--- a/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/LoanListEntry/index.js
+++ b/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/LoanListEntry/index.js
@@ -1,0 +1,1 @@
+export { LoanListEntry } from './LoanListEntry';

--- a/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/index.js
+++ b/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/index.js
@@ -1,0 +1,2 @@
+export { ExtendButton } from './ExtendButton/index';
+export { LoanListEntry } from './LoanListEntry';

--- a/ui/src/pages/frontsite/PatronProfile/PatronPastLoans/PatronPastLoans.js
+++ b/ui/src/pages/frontsite/PatronProfile/PatronPastLoans/PatronPastLoans.js
@@ -2,14 +2,14 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Loader, Error, Pagination } from '@components';
 import { toShortDate } from '@api/date';
-import { invenioConfig } from '@config';
 import { Container, Grid, Header, Item, Label } from 'semantic-ui-react';
 import { Link } from 'react-router-dom';
 import { FrontSiteRoutes } from '@routes/urls';
 import { DocumentAuthors, DocumentItemCover } from '@components/Document';
+import { ExtensionCount } from '@pages/frontsite/components/Loan';
 import { ILSItemPlaceholder } from '@components/ILSPlaceholder/ILSPlaceholder';
-import isEmpty from 'lodash/isEmpty';
 import { NoResultsMessage } from '../../components/NoResultsMessage';
+import isEmpty from 'lodash/isEmpty';
 
 class PastLoanListEntry extends Component {
   render() {
@@ -39,10 +39,7 @@ class PastLoanListEntry extends Component {
                 <DocumentAuthors metadata={loan.metadata.document} />
                 Loaned on {toShortDate(loan.metadata.start_date)}
               </Item.Meta>
-              <Item.Description>
-                You have extended this loan {loan.metadata.extension_count} of{' '}
-                {invenioConfig.circulation.extensionsMaxCount} times
-              </Item.Description>
+              <ExtensionCount count={loan.metadata.extension_count} />
             </Grid.Column>
             <Grid.Column
               textAlign={'right'}

--- a/ui/src/pages/frontsite/PatronProfile/PatronPastLoans/PatronPastLoans.js
+++ b/ui/src/pages/frontsite/PatronProfile/PatronPastLoans/PatronPastLoans.js
@@ -40,10 +40,8 @@ class PastLoanListEntry extends Component {
                 Loaned on {toShortDate(loan.metadata.start_date)}
               </Item.Meta>
               <Item.Description>
-                {}
-                You have extended this loan {
-                  loan.metadata.extension_count
-                } of {invenioConfig.loans.maxExtensionsCount} times
+                You have extended this loan {loan.metadata.extension_count} of{' '}
+                {invenioConfig.circulation.extensionsMaxCount} times
               </Item.Description>
             </Grid.Column>
             <Grid.Column

--- a/ui/src/pages/frontsite/components/Loan/ExtensionCount.js
+++ b/ui/src/pages/frontsite/components/Loan/ExtensionCount.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { Item } from 'semantic-ui-react';
+
+export const ExtensionCount = ({ count }) =>
+  count > 0 && (
+    <Item.Description>
+      You have extended this loan {count} time{count > 1 ? 's' : ''}
+    </Item.Description>
+  );

--- a/ui/src/pages/frontsite/components/Loan/index.js
+++ b/ui/src/pages/frontsite/components/Loan/index.js
@@ -1,0 +1,1 @@
+export { ExtensionCount } from './ExtensionCount';

--- a/ui/src/pages/frontsite/components/Series/SeriesLiteratureSearch/__tests__/__snapshots__/SeriesLiteratureSearch.test.js.snap
+++ b/ui/src/pages/frontsite/components/Series/SeriesLiteratureSearch/__tests__/__snapshots__/SeriesLiteratureSearch.test.js.snap
@@ -5,7 +5,9 @@ exports[`SeriesLiteratureSearch tests should load the SeriesLiteratureSearch com
   <Divider
     horizontal={true}
   >
-    Literature in this series
+    Literature in this series (
+    0
+    )
   </Divider>
   <ReactSearchKit
     defaultSortByOnEmptyQuery={null}


### PR DESCRIPTION
**[UPDATED]**
- introduced extend loan permission
- frontend checks for extend button
- refetch current loans after extend
- validation if document is overbooked
- validation max extensions
- validation default duration before request allowed
- the user is the owner of the loan or admin or librarian
- an extend action is available (frontend only)
- closes #520, #261