### PR TITLE
Loans: display number of available items

### DIFF
--- a/invenio_app_ils/config.py
+++ b/invenio_app_ils/config.py
@@ -1181,6 +1181,12 @@ RECORDS_REST_FACETS = dict(
             state=dict(terms=dict(field="state")),
             delivery=dict(terms=dict(field="delivery.method")),
             returns=overdue_agg,
+            availability=dict(
+                range=dict(
+                    field="document.circulation.has_items_for_loan",
+                    ranges=[{"key": "Available for loan", "from": 1}],
+                )
+            ),
         ),
         filters={
             "returns.end_date": overdue_loans_filter("end_date"),
@@ -1188,8 +1194,11 @@ RECORDS_REST_FACETS = dict(
         post_filters=dict(
             state=terms_filter("state"),
             delivery=terms_filter("delivery.method"),
-
-        )
+            availability=keyed_range_filter(
+                "document.circulation.has_items_for_loan",
+                {"Available for loan": {"gt": 0}},
+            ),
+        ),
     ),
     acq_orders=dict(  # OrderSearch.Meta.index
         aggs=dict(

--- a/ui/src/config/searchConfig.js
+++ b/ui/src/config/searchConfig.js
@@ -260,6 +260,11 @@ const searchConfig = {
         field: 'delivery.method',
         aggName: 'delivery',
       },
+      {
+        title: 'Availability',
+        field: 'document.circulation.has_items_for_loan',
+        aggName: 'availability',
+      },
     ],
     sortBy: {
       onEmptyQuery: 'end_date',

--- a/ui/src/pages/backoffice/Loan/LoanSearch/LoanList.js
+++ b/ui/src/pages/backoffice/Loan/LoanSearch/LoanList.js
@@ -143,6 +143,12 @@ class LoanListEntry extends Component {
                   </List>
                 </>
               )}
+              {loan.metadata.circulation && (
+                <List.Content>
+                  <label>Physical copies available</label>{' '}
+                  {loan.metadata.document.circulation.has_items_for_loan}
+                </List.Content>
+              )}
             </Grid.Column>
             <Grid.Column computer={2} largeScreen={2} textAlign="right">
               <Link

--- a/ui/src/pages/frontsite/components/Series/SeriesCard/SeriesCard.js
+++ b/ui/src/pages/frontsite/components/Series/SeriesCard/SeriesCard.js
@@ -59,9 +59,7 @@ export class SeriesCard extends Component {
             {data.metadata.publisher && (
               <div>Publisher {data.metadata.publisher}</div>
             )}
-            {data.metadata.relations_metadata && (
-              <div>Volumes {documentsCount}</div>
-            )}
+            {documentsCount > 0 && <div>Volumes {documentsCount}</div>}
           </Card.Meta>
         </Card.Content>
       </Card>


### PR DESCRIPTION
Closes #711 and very minor fix for #474 (volumes in frontsite).

![Selection_001](https://user-images.githubusercontent.com/33685068/77476758-75568c00-6e1b-11ea-9a0e-2daacc4e3879.png)
