### PR TITLE
Fix access badge on documents and loans

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/usr/bin/python3.6"
+}

--- a/invenio_app_ils/circulation/jsonresolvers/loan.py
+++ b/invenio_app_ils/circulation/jsonresolvers/loan.py
@@ -76,9 +76,10 @@ def document_resolver(loan_pid):
             "circulation",
             "edition",
             "document_type",
+            "open_access",
             "pid",
+            "publication_year",
             "title",
-            # TODO: add the imprint year here
         )
 
     return obj

--- a/ui/src/components/Document/DocumentItemCover.js
+++ b/ui/src/components/Document/DocumentItemCover.js
@@ -7,8 +7,8 @@ import _get from 'lodash/get';
 
 export default class DocumentItemCover extends Component {
   getLabel = metadata => {
-    const isAccessed = _get(metadata, 'open_access', false);
-    return isAccessed
+    const hasOpenAccess = _get(metadata, 'open_access', false);
+    return hasOpenAccess
       ? null
       : {
           corner: 'left',

--- a/ui/src/components/Document/DocumentItemCover.js
+++ b/ui/src/components/Document/DocumentItemCover.js
@@ -3,24 +3,23 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { Item } from 'semantic-ui-react';
-import isEmpty from 'lodash/isEmpty';
+import _get from 'lodash/get';
 
 export default class DocumentItemCover extends Component {
-  getRestrictions = document => {
-    if (
-      (!isEmpty(document) && document.open_access) ||
-      (!isEmpty(document.metadata) && document.metadata.open_access)
-    )
-      return null;
-    return {
-      corner: 'left',
-      color: 'red',
-      icon: 'lock',
-      title: `This record is restricted`,
-    };
+  getLabel = metadata => {
+    const isAccessed = _get(metadata, 'open_access', false);
+    return isAccessed
+      ? null
+      : {
+          corner: 'left',
+          color: 'red',
+          icon: 'lock',
+          title: `This record is restricted`,
+        };
   };
+
   render() {
-    const { linkTo, document, size, coverUrl, ...uiProps } = this.props;
+    const { linkTo, metadata, size, coverUrl, ...uiProps } = this.props;
     return (
       <Item.Image
         as={Link}
@@ -28,7 +27,7 @@ export default class DocumentItemCover extends Component {
         size={size}
         src={getCover(coverUrl)}
         onError={e => (e.target.style.display = 'none')}
-        label={this.getRestrictions(document)}
+        label={this.getLabel(metadata)}
         {...uiProps}
       />
     );
@@ -37,7 +36,7 @@ export default class DocumentItemCover extends Component {
 
 DocumentItemCover.propTypes = {
   linkTo: PropTypes.string.isRequired,
-  document: PropTypes.object.isRequired,
+  metadata: PropTypes.object.isRequired,
   coverUrl: PropTypes.string.isRequired,
 };
 

--- a/ui/src/components/Document/DocumentItemCover.js
+++ b/ui/src/components/Document/DocumentItemCover.js
@@ -6,8 +6,12 @@ import { Item } from 'semantic-ui-react';
 import isEmpty from 'lodash/isEmpty';
 
 export default class DocumentItemCover extends Component {
-  getRestrictions = meta => {
-    if (!isEmpty(meta) && meta.open_access) return null;
+  getRestrictions = document => {
+    if (
+      (!isEmpty(document) && document.open_access) ||
+      (!isEmpty(document.metadata) && document.metadata.open_access)
+    )
+      return null;
     return {
       corner: 'left',
       color: 'red',
@@ -24,7 +28,7 @@ export default class DocumentItemCover extends Component {
         size={size}
         src={getCover(coverUrl)}
         onError={e => (e.target.style.display = 'none')}
-        label={this.getRestrictions(document.metadata)}
+        label={this.getRestrictions(document)}
         {...uiProps}
       />
     );

--- a/ui/src/pages/backoffice/Series/SeriesDetails/__tests__/__snapshots__/SeriesDetails.test.js.snap
+++ b/ui/src/pages/backoffice/Series/SeriesDetails/__tests__/__snapshots__/SeriesDetails.test.js.snap
@@ -92,7 +92,7 @@ exports[`SeriesDetails tests should load the details component 1`] = `
                           <div
                             id="series-relations"
                           >
-                            <Memo(Connect(SeriesSiblings)) />
+                            <UNDEFINED />
                           </div>
                         </AccordionContent>,
                         "key": "series-relations",

--- a/ui/src/pages/backoffice/Stats/MostLoanedDocumentsList/__tests__/__snapshots__/MostLoanedDocumentsList.test.js.snap
+++ b/ui/src/pages/backoffice/Stats/MostLoanedDocumentsList/__tests__/__snapshots__/MostLoanedDocumentsList.test.js.snap
@@ -239,6 +239,7 @@ exports[`MostLoanedDocumentsList tests should render show a message with no docu
                                     className="field"
                                   >
                                     <Input
+                                      aria-describedby={null}
                                       autoComplete="off"
                                       data-test=""
                                       icon={true}
@@ -269,6 +270,7 @@ exports[`MostLoanedDocumentsList tests should render show a message with no docu
                                           />
                                         </Icon>
                                         <input
+                                          aria-describedby={null}
                                           autoComplete="off"
                                           key=".1"
                                           name="selectedDate"
@@ -420,6 +422,7 @@ exports[`MostLoanedDocumentsList tests should render show a message with no docu
                                     className="field"
                                   >
                                     <Input
+                                      aria-describedby={null}
                                       autoComplete="off"
                                       data-test=""
                                       icon={true}
@@ -450,6 +453,7 @@ exports[`MostLoanedDocumentsList tests should render show a message with no docu
                                           />
                                         </Icon>
                                         <input
+                                          aria-describedby={null}
                                           autoComplete="off"
                                           key=".1"
                                           name="selectedDate"

--- a/ui/src/pages/backoffice/components/Document/DocumentList/DocumentListEntry.js
+++ b/ui/src/pages/backoffice/components/Document/DocumentList/DocumentListEntry.js
@@ -98,7 +98,7 @@ export default class DocumentListEntry extends Component {
         <div className={'item-image-wrapper'}>
           <DocumentItemCover
             linkTo={BackOfficeRoutes.documentDetailsFor(document.metadata.pid)}
-            document={document}
+            metadata={document.metadata}
             coverUrl={document.metadata.edition}
           />
           <Header disabled as="h6" className={'document-type tiny ellipsis'}>

--- a/ui/src/pages/backoffice/components/Document/DocumentList/__snapshots__/DocumentListEntry.test.js.snap
+++ b/ui/src/pages/backoffice/components/Document/DocumentList/__snapshots__/DocumentListEntry.test.js.snap
@@ -7,45 +7,43 @@ exports[`DocumentCirculation tests should load the DocumentCirculation component
   >
     <DocumentItemCover
       coverUrl="1"
-      document={
+      linkTo="/backoffice/documents/docid-1"
+      metadata={
         Object {
-          "metadata": Object {
-            "$schema": "https://127.0.0.1:5000/schemas/documents/document-v1.0.0.json",
-            "abstract": "This is an abstract",
-            "authors": Array [
-              Object {
-                "full_name": "Jack E. Davis",
-              },
-            ],
-            "circulation": Object {
-              "has_items_for_loan": 2,
+          "$schema": "https://127.0.0.1:5000/schemas/documents/document-v1.0.0.json",
+          "abstract": "This is an abstract",
+          "authors": Array [
+            Object {
+              "full_name": "Jack E. Davis",
             },
-            "document_type": "BOOK",
-            "edition": "1",
-            "eitems": Object {
-              "total": 0,
-            },
-            "items": Object {
-              "total": 2,
-            },
-            "keywords": Object {
-              "source": "X",
-              "value": "Patata",
-            },
-            "languages": Array [
-              "en",
-            ],
-            "pid": "docid-1",
-            "publication_year": "1950",
-            "relations": Object {
-              "multipart_monograph": Object {},
-              "serials": Object {},
-            },
-            "title": "The Gulf: The Making of An American Sea",
+          ],
+          "circulation": Object {
+            "has_items_for_loan": 2,
           },
+          "document_type": "BOOK",
+          "edition": "1",
+          "eitems": Object {
+            "total": 0,
+          },
+          "items": Object {
+            "total": 2,
+          },
+          "keywords": Object {
+            "source": "X",
+            "value": "Patata",
+          },
+          "languages": Array [
+            "en",
+          ],
+          "pid": "docid-1",
+          "publication_year": "1950",
+          "relations": Object {
+            "multipart_monograph": Object {},
+            "serials": Object {},
+          },
+          "title": "The Gulf: The Making of An American Sea",
         }
       }
-      linkTo="/backoffice/documents/docid-1"
       size="tiny"
     />
     <Header

--- a/ui/src/pages/backoffice/components/Relations/components/RelationListEntry/RelationListEntry.js
+++ b/ui/src/pages/backoffice/components/Relations/components/RelationListEntry/RelationListEntry.js
@@ -21,7 +21,7 @@ export class RelationListEntry extends Component {
         : BackOfficeRoutes.seriesDetailsFor(record.metadata.pid);
     const cover =
       recordType === 'docid' ? (
-        <DocumentItemCover document={record} linkTo={linkTo} />
+        <DocumentItemCover metadata={record.metadata} linkTo={linkTo} />
       ) : (
         <Icon name="clone outline" size="huge" color="grey" />
       );

--- a/ui/src/pages/frontsite/DocumentRequests/DocumentRequestForm/__tests__/__snapshots__/DocumentRequestForm.test.js.snap
+++ b/ui/src/pages/frontsite/DocumentRequests/DocumentRequestForm/__tests__/__snapshots__/DocumentRequestForm.test.js.snap
@@ -330,6 +330,7 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                       Object {
                                         "dirty": false,
                                         "errors": Object {},
+                                        "getFieldHelpers": [Function],
                                         "getFieldMeta": [Function],
                                         "getFieldProps": [Function],
                                         "handleBlur": [Function],
@@ -382,23 +383,17 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                 placeholder="Title"
                                 required={true}
                               >
-                                <FastField
+                                <FormikConnect(FastFieldInner)
                                   component={[Function]}
                                   name="title"
                                 >
-                                  <Component
-                                    field={
-                                      Object {
-                                        "name": "title",
-                                        "onBlur": [Function],
-                                        "onChange": [Function],
-                                        "value": "",
-                                      }
-                                    }
-                                    form={
+                                  <FastFieldInner
+                                    component={[Function]}
+                                    formik={
                                       Object {
                                         "dirty": false,
                                         "errors": Object {},
+                                        "getFieldHelpers": [Function],
                                         "getFieldMeta": [Function],
                                         "getFieldProps": [Function],
                                         "handleBlur": [Function],
@@ -440,28 +435,72 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                         },
                                       }
                                     }
+                                    name="title"
                                   >
-                                    <FormField
-                                      inline={false}
+                                    <Component
+                                      field={
+                                        Object {
+                                          "name": "title",
+                                          "onBlur": [Function],
+                                          "onChange": [Function],
+                                          "value": "",
+                                        }
+                                      }
+                                      form={
+                                        Object {
+                                          "dirty": false,
+                                          "errors": Object {},
+                                          "getFieldHelpers": [Function],
+                                          "getFieldMeta": [Function],
+                                          "getFieldProps": [Function],
+                                          "handleBlur": [Function],
+                                          "handleChange": [Function],
+                                          "handleReset": [Function],
+                                          "handleSubmit": [Function],
+                                          "initialErrors": Object {},
+                                          "initialStatus": undefined,
+                                          "initialTouched": Object {},
+                                          "initialValues": Object {
+                                            "title": "",
+                                          },
+                                          "isSubmitting": false,
+                                          "isValid": true,
+                                          "isValidating": false,
+                                          "registerField": [Function],
+                                          "resetForm": [Function],
+                                          "setErrors": [Function],
+                                          "setFieldError": [Function],
+                                          "setFieldTouched": [Function],
+                                          "setFieldValue": [Function],
+                                          "setFormikState": [Function],
+                                          "setStatus": [Function],
+                                          "setSubmitting": [Function],
+                                          "setTouched": [Function],
+                                          "setValues": [Function],
+                                          "status": undefined,
+                                          "submitCount": 0,
+                                          "submitForm": [Function],
+                                          "touched": Object {},
+                                          "unregisterField": [Function],
+                                          "validateField": [Function],
+                                          "validateForm": [Function],
+                                          "validateOnBlur": true,
+                                          "validateOnChange": true,
+                                          "validateOnMount": false,
+                                          "values": Object {
+                                            "title": "",
+                                          },
+                                        }
+                                      }
                                     >
-                                      <div
-                                        className="field"
+                                      <FormField
+                                        inline={false}
                                       >
-                                        <FormInput
-                                          as={[Function]}
-                                          control={[Function]}
-                                          error={null}
-                                          fluid={true}
-                                          id="title"
-                                          label="Title"
-                                          name="title"
-                                          onBlur={[Function]}
-                                          onChange={[Function]}
-                                          placeholder="Title"
-                                          required={true}
-                                          value=""
+                                        <div
+                                          className="field"
                                         >
-                                          <FormField
+                                          <FormInput
+                                            as={[Function]}
                                             control={[Function]}
                                             error={null}
                                             fluid={true}
@@ -474,47 +513,65 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                             required={true}
                                             value=""
                                           >
-                                            <div
-                                              className="required field"
+                                            <FormField
+                                              control={[Function]}
+                                              error={null}
+                                              fluid={true}
+                                              id="title"
+                                              label="Title"
+                                              name="title"
+                                              onBlur={[Function]}
+                                              onChange={[Function]}
+                                              placeholder="Title"
+                                              required={true}
+                                              value=""
                                             >
-                                              <label
-                                                htmlFor="title"
+                                              <div
+                                                className="required field"
                                               >
-                                                Title
-                                              </label>
-                                              <Input
-                                                fluid={true}
-                                                id="title"
-                                                name="title"
-                                                onBlur={[Function]}
-                                                onChange={[Function]}
-                                                placeholder="Title"
-                                                required={true}
-                                                type="text"
-                                                value=""
-                                              >
-                                                <div
-                                                  className="ui fluid input"
+                                                <label
+                                                  htmlFor="title"
                                                 >
-                                                  <input
-                                                    id="title"
-                                                    name="title"
-                                                    onBlur={[Function]}
-                                                    onChange={[Function]}
-                                                    placeholder="Title"
-                                                    required={true}
-                                                    type="text"
-                                                    value=""
-                                                  />
-                                                </div>
-                                              </Input>
-                                            </div>
-                                          </FormField>
-                                        </FormInput>
-                                      </div>
-                                    </FormField>
-                                  </Component>
-                                </FastField>
+                                                  Title
+                                                </label>
+                                                <Input
+                                                  aria-describedby={null}
+                                                  aria-invalid={true}
+                                                  fluid={true}
+                                                  id="title"
+                                                  name="title"
+                                                  onBlur={[Function]}
+                                                  onChange={[Function]}
+                                                  placeholder="Title"
+                                                  required={true}
+                                                  type="text"
+                                                  value=""
+                                                >
+                                                  <div
+                                                    className="ui fluid input"
+                                                  >
+                                                    <input
+                                                      aria-describedby={null}
+                                                      aria-invalid={true}
+                                                      id="title"
+                                                      name="title"
+                                                      onBlur={[Function]}
+                                                      onChange={[Function]}
+                                                      placeholder="Title"
+                                                      required={true}
+                                                      type="text"
+                                                      value=""
+                                                    />
+                                                  </div>
+                                                </Input>
+                                              </div>
+                                            </FormField>
+                                          </FormInput>
+                                        </div>
+                                      </FormField>
+                                    </Component>
+                                  </FastFieldInner>
+                                </FormikConnect(FastFieldInner)>
                               </StringField>
                               <StringField
                                 fieldPath="journal_title"
@@ -523,23 +580,17 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                 optimized={true}
                                 placeholder="Journal title"
                               >
-                                <FastField
+                                <FormikConnect(FastFieldInner)
                                   component={[Function]}
                                   name="journal_title"
                                 >
-                                  <Component
-                                    field={
-                                      Object {
-                                        "name": "journal_title",
-                                        "onBlur": [Function],
-                                        "onChange": [Function],
-                                        "value": undefined,
-                                      }
-                                    }
-                                    form={
+                                  <FastFieldInner
+                                    component={[Function]}
+                                    formik={
                                       Object {
                                         "dirty": false,
                                         "errors": Object {},
+                                        "getFieldHelpers": [Function],
                                         "getFieldMeta": [Function],
                                         "getFieldProps": [Function],
                                         "handleBlur": [Function],
@@ -581,27 +632,72 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                         },
                                       }
                                     }
+                                    name="journal_title"
                                   >
-                                    <FormField
-                                      inline={false}
+                                    <Component
+                                      field={
+                                        Object {
+                                          "name": "journal_title",
+                                          "onBlur": [Function],
+                                          "onChange": [Function],
+                                          "value": undefined,
+                                        }
+                                      }
+                                      form={
+                                        Object {
+                                          "dirty": false,
+                                          "errors": Object {},
+                                          "getFieldHelpers": [Function],
+                                          "getFieldMeta": [Function],
+                                          "getFieldProps": [Function],
+                                          "handleBlur": [Function],
+                                          "handleChange": [Function],
+                                          "handleReset": [Function],
+                                          "handleSubmit": [Function],
+                                          "initialErrors": Object {},
+                                          "initialStatus": undefined,
+                                          "initialTouched": Object {},
+                                          "initialValues": Object {
+                                            "title": "",
+                                          },
+                                          "isSubmitting": false,
+                                          "isValid": true,
+                                          "isValidating": false,
+                                          "registerField": [Function],
+                                          "resetForm": [Function],
+                                          "setErrors": [Function],
+                                          "setFieldError": [Function],
+                                          "setFieldTouched": [Function],
+                                          "setFieldValue": [Function],
+                                          "setFormikState": [Function],
+                                          "setStatus": [Function],
+                                          "setSubmitting": [Function],
+                                          "setTouched": [Function],
+                                          "setValues": [Function],
+                                          "status": undefined,
+                                          "submitCount": 0,
+                                          "submitForm": [Function],
+                                          "touched": Object {},
+                                          "unregisterField": [Function],
+                                          "validateField": [Function],
+                                          "validateForm": [Function],
+                                          "validateOnBlur": true,
+                                          "validateOnChange": true,
+                                          "validateOnMount": false,
+                                          "values": Object {
+                                            "title": "",
+                                          },
+                                        }
+                                      }
                                     >
-                                      <div
-                                        className="field"
+                                      <FormField
+                                        inline={false}
                                       >
-                                        <FormInput
-                                          as={[Function]}
-                                          control={[Function]}
-                                          error={null}
-                                          fluid={true}
-                                          id="journal_title"
-                                          label="Journal title"
-                                          name="journal_title"
-                                          onBlur={[Function]}
-                                          onChange={[Function]}
-                                          placeholder="Journal title"
-                                          value=""
+                                        <div
+                                          className="field"
                                         >
-                                          <FormField
+                                          <FormInput
+                                            as={[Function]}
                                             control={[Function]}
                                             error={null}
                                             fluid={true}
@@ -613,45 +709,62 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                             placeholder="Journal title"
                                             value=""
                                           >
-                                            <div
-                                              className="field"
+                                            <FormField
+                                              control={[Function]}
+                                              error={null}
+                                              fluid={true}
+                                              id="journal_title"
+                                              label="Journal title"
+                                              name="journal_title"
+                                              onBlur={[Function]}
+                                              onChange={[Function]}
+                                              placeholder="Journal title"
+                                              value=""
                                             >
-                                              <label
-                                                htmlFor="journal_title"
+                                              <div
+                                                className="field"
                                               >
-                                                Journal title
-                                              </label>
-                                              <Input
-                                                fluid={true}
-                                                id="journal_title"
-                                                name="journal_title"
-                                                onBlur={[Function]}
-                                                onChange={[Function]}
-                                                placeholder="Journal title"
-                                                type="text"
-                                                value=""
-                                              >
-                                                <div
-                                                  className="ui fluid input"
+                                                <label
+                                                  htmlFor="journal_title"
                                                 >
-                                                  <input
-                                                    id="journal_title"
-                                                    name="journal_title"
-                                                    onBlur={[Function]}
-                                                    onChange={[Function]}
-                                                    placeholder="Journal title"
-                                                    type="text"
-                                                    value=""
-                                                  />
-                                                </div>
-                                              </Input>
-                                            </div>
-                                          </FormField>
-                                        </FormInput>
-                                      </div>
-                                    </FormField>
-                                  </Component>
-                                </FastField>
+                                                  Journal title
+                                                </label>
+                                                <Input
+                                                  aria-describedby={null}
+                                                  aria-invalid={true}
+                                                  fluid={true}
+                                                  id="journal_title"
+                                                  name="journal_title"
+                                                  onBlur={[Function]}
+                                                  onChange={[Function]}
+                                                  placeholder="Journal title"
+                                                  type="text"
+                                                  value=""
+                                                >
+                                                  <div
+                                                    className="ui fluid input"
+                                                  >
+                                                    <input
+                                                      aria-describedby={null}
+                                                      aria-invalid={true}
+                                                      id="journal_title"
+                                                      name="journal_title"
+                                                      onBlur={[Function]}
+                                                      onChange={[Function]}
+                                                      placeholder="Journal title"
+                                                      type="text"
+                                                      value=""
+                                                    />
+                                                  </div>
+                                                </Input>
+                                              </div>
+                                            </FormField>
+                                          </FormInput>
+                                        </div>
+                                      </FormField>
+                                    </Component>
+                                  </FastFieldInner>
+                                </FormikConnect(FastFieldInner)>
                               </StringField>
                               <StringField
                                 fieldPath="authors"
@@ -660,23 +773,17 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                 optimized={true}
                                 placeholder="Authors"
                               >
-                                <FastField
+                                <FormikConnect(FastFieldInner)
                                   component={[Function]}
                                   name="authors"
                                 >
-                                  <Component
-                                    field={
-                                      Object {
-                                        "name": "authors",
-                                        "onBlur": [Function],
-                                        "onChange": [Function],
-                                        "value": undefined,
-                                      }
-                                    }
-                                    form={
+                                  <FastFieldInner
+                                    component={[Function]}
+                                    formik={
                                       Object {
                                         "dirty": false,
                                         "errors": Object {},
+                                        "getFieldHelpers": [Function],
                                         "getFieldMeta": [Function],
                                         "getFieldProps": [Function],
                                         "handleBlur": [Function],
@@ -718,27 +825,72 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                         },
                                       }
                                     }
+                                    name="authors"
                                   >
-                                    <FormField
-                                      inline={false}
+                                    <Component
+                                      field={
+                                        Object {
+                                          "name": "authors",
+                                          "onBlur": [Function],
+                                          "onChange": [Function],
+                                          "value": undefined,
+                                        }
+                                      }
+                                      form={
+                                        Object {
+                                          "dirty": false,
+                                          "errors": Object {},
+                                          "getFieldHelpers": [Function],
+                                          "getFieldMeta": [Function],
+                                          "getFieldProps": [Function],
+                                          "handleBlur": [Function],
+                                          "handleChange": [Function],
+                                          "handleReset": [Function],
+                                          "handleSubmit": [Function],
+                                          "initialErrors": Object {},
+                                          "initialStatus": undefined,
+                                          "initialTouched": Object {},
+                                          "initialValues": Object {
+                                            "title": "",
+                                          },
+                                          "isSubmitting": false,
+                                          "isValid": true,
+                                          "isValidating": false,
+                                          "registerField": [Function],
+                                          "resetForm": [Function],
+                                          "setErrors": [Function],
+                                          "setFieldError": [Function],
+                                          "setFieldTouched": [Function],
+                                          "setFieldValue": [Function],
+                                          "setFormikState": [Function],
+                                          "setStatus": [Function],
+                                          "setSubmitting": [Function],
+                                          "setTouched": [Function],
+                                          "setValues": [Function],
+                                          "status": undefined,
+                                          "submitCount": 0,
+                                          "submitForm": [Function],
+                                          "touched": Object {},
+                                          "unregisterField": [Function],
+                                          "validateField": [Function],
+                                          "validateForm": [Function],
+                                          "validateOnBlur": true,
+                                          "validateOnChange": true,
+                                          "validateOnMount": false,
+                                          "values": Object {
+                                            "title": "",
+                                          },
+                                        }
+                                      }
                                     >
-                                      <div
-                                        className="field"
+                                      <FormField
+                                        inline={false}
                                       >
-                                        <FormInput
-                                          as={[Function]}
-                                          control={[Function]}
-                                          error={null}
-                                          fluid={true}
-                                          id="authors"
-                                          label="Authors"
-                                          name="authors"
-                                          onBlur={[Function]}
-                                          onChange={[Function]}
-                                          placeholder="Authors"
-                                          value=""
+                                        <div
+                                          className="field"
                                         >
-                                          <FormField
+                                          <FormInput
+                                            as={[Function]}
                                             control={[Function]}
                                             error={null}
                                             fluid={true}
@@ -750,45 +902,62 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                             placeholder="Authors"
                                             value=""
                                           >
-                                            <div
-                                              className="field"
+                                            <FormField
+                                              control={[Function]}
+                                              error={null}
+                                              fluid={true}
+                                              id="authors"
+                                              label="Authors"
+                                              name="authors"
+                                              onBlur={[Function]}
+                                              onChange={[Function]}
+                                              placeholder="Authors"
+                                              value=""
                                             >
-                                              <label
-                                                htmlFor="authors"
+                                              <div
+                                                className="field"
                                               >
-                                                Authors
-                                              </label>
-                                              <Input
-                                                fluid={true}
-                                                id="authors"
-                                                name="authors"
-                                                onBlur={[Function]}
-                                                onChange={[Function]}
-                                                placeholder="Authors"
-                                                type="text"
-                                                value=""
-                                              >
-                                                <div
-                                                  className="ui fluid input"
+                                                <label
+                                                  htmlFor="authors"
                                                 >
-                                                  <input
-                                                    id="authors"
-                                                    name="authors"
-                                                    onBlur={[Function]}
-                                                    onChange={[Function]}
-                                                    placeholder="Authors"
-                                                    type="text"
-                                                    value=""
-                                                  />
-                                                </div>
-                                              </Input>
-                                            </div>
-                                          </FormField>
-                                        </FormInput>
-                                      </div>
-                                    </FormField>
-                                  </Component>
-                                </FastField>
+                                                  Authors
+                                                </label>
+                                                <Input
+                                                  aria-describedby={null}
+                                                  aria-invalid={true}
+                                                  fluid={true}
+                                                  id="authors"
+                                                  name="authors"
+                                                  onBlur={[Function]}
+                                                  onChange={[Function]}
+                                                  placeholder="Authors"
+                                                  type="text"
+                                                  value=""
+                                                >
+                                                  <div
+                                                    className="ui fluid input"
+                                                  >
+                                                    <input
+                                                      aria-describedby={null}
+                                                      aria-invalid={true}
+                                                      id="authors"
+                                                      name="authors"
+                                                      onBlur={[Function]}
+                                                      onChange={[Function]}
+                                                      placeholder="Authors"
+                                                      type="text"
+                                                      value=""
+                                                    />
+                                                  </div>
+                                                </Input>
+                                              </div>
+                                            </FormField>
+                                          </FormInput>
+                                        </div>
+                                      </FormField>
+                                    </Component>
+                                  </FastFieldInner>
+                                </FormikConnect(FastFieldInner)>
                               </StringField>
                               <GroupField
                                 border={false}
@@ -812,6 +981,7 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                       Object {
                                         "dirty": false,
                                         "errors": Object {},
+                                        "getFieldHelpers": [Function],
                                         "getFieldMeta": [Function],
                                         "getFieldProps": [Function],
                                         "handleBlur": [Function],
@@ -868,23 +1038,17 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                           optimized={true}
                                           placeholder="ISBN"
                                         >
-                                          <FastField
+                                          <FormikConnect(FastFieldInner)
                                             component={[Function]}
                                             name="isbn"
                                           >
-                                            <Component
-                                              field={
-                                                Object {
-                                                  "name": "isbn",
-                                                  "onBlur": [Function],
-                                                  "onChange": [Function],
-                                                  "value": undefined,
-                                                }
-                                              }
-                                              form={
+                                            <FastFieldInner
+                                              component={[Function]}
+                                              formik={
                                                 Object {
                                                   "dirty": false,
                                                   "errors": Object {},
+                                                  "getFieldHelpers": [Function],
                                                   "getFieldMeta": [Function],
                                                   "getFieldProps": [Function],
                                                   "handleBlur": [Function],
@@ -926,27 +1090,72 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                                   },
                                                 }
                                               }
+                                              name="isbn"
                                             >
-                                              <FormField
-                                                inline={false}
+                                              <Component
+                                                field={
+                                                  Object {
+                                                    "name": "isbn",
+                                                    "onBlur": [Function],
+                                                    "onChange": [Function],
+                                                    "value": undefined,
+                                                  }
+                                                }
+                                                form={
+                                                  Object {
+                                                    "dirty": false,
+                                                    "errors": Object {},
+                                                    "getFieldHelpers": [Function],
+                                                    "getFieldMeta": [Function],
+                                                    "getFieldProps": [Function],
+                                                    "handleBlur": [Function],
+                                                    "handleChange": [Function],
+                                                    "handleReset": [Function],
+                                                    "handleSubmit": [Function],
+                                                    "initialErrors": Object {},
+                                                    "initialStatus": undefined,
+                                                    "initialTouched": Object {},
+                                                    "initialValues": Object {
+                                                      "title": "",
+                                                    },
+                                                    "isSubmitting": false,
+                                                    "isValid": true,
+                                                    "isValidating": false,
+                                                    "registerField": [Function],
+                                                    "resetForm": [Function],
+                                                    "setErrors": [Function],
+                                                    "setFieldError": [Function],
+                                                    "setFieldTouched": [Function],
+                                                    "setFieldValue": [Function],
+                                                    "setFormikState": [Function],
+                                                    "setStatus": [Function],
+                                                    "setSubmitting": [Function],
+                                                    "setTouched": [Function],
+                                                    "setValues": [Function],
+                                                    "status": undefined,
+                                                    "submitCount": 0,
+                                                    "submitForm": [Function],
+                                                    "touched": Object {},
+                                                    "unregisterField": [Function],
+                                                    "validateField": [Function],
+                                                    "validateForm": [Function],
+                                                    "validateOnBlur": true,
+                                                    "validateOnChange": true,
+                                                    "validateOnMount": false,
+                                                    "values": Object {
+                                                      "title": "",
+                                                    },
+                                                  }
+                                                }
                                               >
-                                                <div
-                                                  className="field"
+                                                <FormField
+                                                  inline={false}
                                                 >
-                                                  <FormInput
-                                                    as={[Function]}
-                                                    control={[Function]}
-                                                    error={null}
-                                                    fluid={true}
-                                                    id="isbn"
-                                                    label="ISBN"
-                                                    name="isbn"
-                                                    onBlur={[Function]}
-                                                    onChange={[Function]}
-                                                    placeholder="ISBN"
-                                                    value=""
+                                                  <div
+                                                    className="field"
                                                   >
-                                                    <FormField
+                                                    <FormInput
+                                                      as={[Function]}
                                                       control={[Function]}
                                                       error={null}
                                                       fluid={true}
@@ -958,45 +1167,62 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                                       placeholder="ISBN"
                                                       value=""
                                                     >
-                                                      <div
-                                                        className="field"
+                                                      <FormField
+                                                        control={[Function]}
+                                                        error={null}
+                                                        fluid={true}
+                                                        id="isbn"
+                                                        label="ISBN"
+                                                        name="isbn"
+                                                        onBlur={[Function]}
+                                                        onChange={[Function]}
+                                                        placeholder="ISBN"
+                                                        value=""
                                                       >
-                                                        <label
-                                                          htmlFor="isbn"
+                                                        <div
+                                                          className="field"
                                                         >
-                                                          ISBN
-                                                        </label>
-                                                        <Input
-                                                          fluid={true}
-                                                          id="isbn"
-                                                          name="isbn"
-                                                          onBlur={[Function]}
-                                                          onChange={[Function]}
-                                                          placeholder="ISBN"
-                                                          type="text"
-                                                          value=""
-                                                        >
-                                                          <div
-                                                            className="ui fluid input"
+                                                          <label
+                                                            htmlFor="isbn"
                                                           >
-                                                            <input
-                                                              id="isbn"
-                                                              name="isbn"
-                                                              onBlur={[Function]}
-                                                              onChange={[Function]}
-                                                              placeholder="ISBN"
-                                                              type="text"
-                                                              value=""
-                                                            />
-                                                          </div>
-                                                        </Input>
-                                                      </div>
-                                                    </FormField>
-                                                  </FormInput>
-                                                </div>
-                                              </FormField>
-                                            </Component>
-                                          </FastField>
+                                                            ISBN
+                                                          </label>
+                                                          <Input
+                                                            aria-describedby={null}
+                                                            aria-invalid={true}
+                                                            fluid={true}
+                                                            id="isbn"
+                                                            name="isbn"
+                                                            onBlur={[Function]}
+                                                            onChange={[Function]}
+                                                            placeholder="ISBN"
+                                                            type="text"
+                                                            value=""
+                                                          >
+                                                            <div
+                                                              className="ui fluid input"
+                                                            >
+                                                              <input
+                                                                aria-describedby={null}
+                                                                aria-invalid={true}
+                                                                id="isbn"
+                                                                name="isbn"
+                                                                onBlur={[Function]}
+                                                                onChange={[Function]}
+                                                                placeholder="ISBN"
+                                                                type="text"
+                                                                value=""
+                                                              />
+                                                            </div>
+                                                          </Input>
+                                                        </div>
+                                                      </FormField>
+                                                    </FormInput>
+                                                  </div>
+                                                </FormField>
+                                              </Component>
+                                            </FastFieldInner>
+                                          </FormikConnect(FastFieldInner)>
                                         </StringField>
                                         <StringField
                                           fieldPath="issn"
@@ -1005,23 +1231,17 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                           optimized={true}
                                           placeholder="ISSN"
                                         >
-                                          <FastField
+                                          <FormikConnect(FastFieldInner)
                                             component={[Function]}
                                             name="issn"
                                           >
-                                            <Component
-                                              field={
-                                                Object {
-                                                  "name": "issn",
-                                                  "onBlur": [Function],
-                                                  "onChange": [Function],
-                                                  "value": undefined,
-                                                }
-                                              }
-                                              form={
+                                            <FastFieldInner
+                                              component={[Function]}
+                                              formik={
                                                 Object {
                                                   "dirty": false,
                                                   "errors": Object {},
+                                                  "getFieldHelpers": [Function],
                                                   "getFieldMeta": [Function],
                                                   "getFieldProps": [Function],
                                                   "handleBlur": [Function],
@@ -1063,27 +1283,72 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                                   },
                                                 }
                                               }
+                                              name="issn"
                                             >
-                                              <FormField
-                                                inline={false}
+                                              <Component
+                                                field={
+                                                  Object {
+                                                    "name": "issn",
+                                                    "onBlur": [Function],
+                                                    "onChange": [Function],
+                                                    "value": undefined,
+                                                  }
+                                                }
+                                                form={
+                                                  Object {
+                                                    "dirty": false,
+                                                    "errors": Object {},
+                                                    "getFieldHelpers": [Function],
+                                                    "getFieldMeta": [Function],
+                                                    "getFieldProps": [Function],
+                                                    "handleBlur": [Function],
+                                                    "handleChange": [Function],
+                                                    "handleReset": [Function],
+                                                    "handleSubmit": [Function],
+                                                    "initialErrors": Object {},
+                                                    "initialStatus": undefined,
+                                                    "initialTouched": Object {},
+                                                    "initialValues": Object {
+                                                      "title": "",
+                                                    },
+                                                    "isSubmitting": false,
+                                                    "isValid": true,
+                                                    "isValidating": false,
+                                                    "registerField": [Function],
+                                                    "resetForm": [Function],
+                                                    "setErrors": [Function],
+                                                    "setFieldError": [Function],
+                                                    "setFieldTouched": [Function],
+                                                    "setFieldValue": [Function],
+                                                    "setFormikState": [Function],
+                                                    "setStatus": [Function],
+                                                    "setSubmitting": [Function],
+                                                    "setTouched": [Function],
+                                                    "setValues": [Function],
+                                                    "status": undefined,
+                                                    "submitCount": 0,
+                                                    "submitForm": [Function],
+                                                    "touched": Object {},
+                                                    "unregisterField": [Function],
+                                                    "validateField": [Function],
+                                                    "validateForm": [Function],
+                                                    "validateOnBlur": true,
+                                                    "validateOnChange": true,
+                                                    "validateOnMount": false,
+                                                    "values": Object {
+                                                      "title": "",
+                                                    },
+                                                  }
+                                                }
                                               >
-                                                <div
-                                                  className="field"
+                                                <FormField
+                                                  inline={false}
                                                 >
-                                                  <FormInput
-                                                    as={[Function]}
-                                                    control={[Function]}
-                                                    error={null}
-                                                    fluid={true}
-                                                    id="issn"
-                                                    label="ISSN"
-                                                    name="issn"
-                                                    onBlur={[Function]}
-                                                    onChange={[Function]}
-                                                    placeholder="ISSN"
-                                                    value=""
+                                                  <div
+                                                    className="field"
                                                   >
-                                                    <FormField
+                                                    <FormInput
+                                                      as={[Function]}
                                                       control={[Function]}
                                                       error={null}
                                                       fluid={true}
@@ -1095,45 +1360,62 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                                       placeholder="ISSN"
                                                       value=""
                                                     >
-                                                      <div
-                                                        className="field"
+                                                      <FormField
+                                                        control={[Function]}
+                                                        error={null}
+                                                        fluid={true}
+                                                        id="issn"
+                                                        label="ISSN"
+                                                        name="issn"
+                                                        onBlur={[Function]}
+                                                        onChange={[Function]}
+                                                        placeholder="ISSN"
+                                                        value=""
                                                       >
-                                                        <label
-                                                          htmlFor="issn"
+                                                        <div
+                                                          className="field"
                                                         >
-                                                          ISSN
-                                                        </label>
-                                                        <Input
-                                                          fluid={true}
-                                                          id="issn"
-                                                          name="issn"
-                                                          onBlur={[Function]}
-                                                          onChange={[Function]}
-                                                          placeholder="ISSN"
-                                                          type="text"
-                                                          value=""
-                                                        >
-                                                          <div
-                                                            className="ui fluid input"
+                                                          <label
+                                                            htmlFor="issn"
                                                           >
-                                                            <input
-                                                              id="issn"
-                                                              name="issn"
-                                                              onBlur={[Function]}
-                                                              onChange={[Function]}
-                                                              placeholder="ISSN"
-                                                              type="text"
-                                                              value=""
-                                                            />
-                                                          </div>
-                                                        </Input>
-                                                      </div>
-                                                    </FormField>
-                                                  </FormInput>
-                                                </div>
-                                              </FormField>
-                                            </Component>
-                                          </FastField>
+                                                            ISSN
+                                                          </label>
+                                                          <Input
+                                                            aria-describedby={null}
+                                                            aria-invalid={true}
+                                                            fluid={true}
+                                                            id="issn"
+                                                            name="issn"
+                                                            onBlur={[Function]}
+                                                            onChange={[Function]}
+                                                            placeholder="ISSN"
+                                                            type="text"
+                                                            value=""
+                                                          >
+                                                            <div
+                                                              className="ui fluid input"
+                                                            >
+                                                              <input
+                                                                aria-describedby={null}
+                                                                aria-invalid={true}
+                                                                id="issn"
+                                                                name="issn"
+                                                                onBlur={[Function]}
+                                                                onChange={[Function]}
+                                                                placeholder="ISSN"
+                                                                type="text"
+                                                                value=""
+                                                              />
+                                                            </div>
+                                                          </Input>
+                                                        </div>
+                                                      </FormField>
+                                                    </FormInput>
+                                                  </div>
+                                                </FormField>
+                                              </Component>
+                                            </FastFieldInner>
+                                          </FormikConnect(FastFieldInner)>
                                         </StringField>
                                       </div>
                                     </FormGroup>
@@ -1162,6 +1444,7 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                       Object {
                                         "dirty": false,
                                         "errors": Object {},
+                                        "getFieldHelpers": [Function],
                                         "getFieldMeta": [Function],
                                         "getFieldProps": [Function],
                                         "handleBlur": [Function],
@@ -1218,23 +1501,17 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                           optimized={true}
                                           placeholder="Edition number"
                                         >
-                                          <FastField
+                                          <FormikConnect(FastFieldInner)
                                             component={[Function]}
                                             name="edition"
                                           >
-                                            <Component
-                                              field={
-                                                Object {
-                                                  "name": "edition",
-                                                  "onBlur": [Function],
-                                                  "onChange": [Function],
-                                                  "value": undefined,
-                                                }
-                                              }
-                                              form={
+                                            <FastFieldInner
+                                              component={[Function]}
+                                              formik={
                                                 Object {
                                                   "dirty": false,
                                                   "errors": Object {},
+                                                  "getFieldHelpers": [Function],
                                                   "getFieldMeta": [Function],
                                                   "getFieldProps": [Function],
                                                   "handleBlur": [Function],
@@ -1276,27 +1553,72 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                                   },
                                                 }
                                               }
+                                              name="edition"
                                             >
-                                              <FormField
-                                                inline={false}
+                                              <Component
+                                                field={
+                                                  Object {
+                                                    "name": "edition",
+                                                    "onBlur": [Function],
+                                                    "onChange": [Function],
+                                                    "value": undefined,
+                                                  }
+                                                }
+                                                form={
+                                                  Object {
+                                                    "dirty": false,
+                                                    "errors": Object {},
+                                                    "getFieldHelpers": [Function],
+                                                    "getFieldMeta": [Function],
+                                                    "getFieldProps": [Function],
+                                                    "handleBlur": [Function],
+                                                    "handleChange": [Function],
+                                                    "handleReset": [Function],
+                                                    "handleSubmit": [Function],
+                                                    "initialErrors": Object {},
+                                                    "initialStatus": undefined,
+                                                    "initialTouched": Object {},
+                                                    "initialValues": Object {
+                                                      "title": "",
+                                                    },
+                                                    "isSubmitting": false,
+                                                    "isValid": true,
+                                                    "isValidating": false,
+                                                    "registerField": [Function],
+                                                    "resetForm": [Function],
+                                                    "setErrors": [Function],
+                                                    "setFieldError": [Function],
+                                                    "setFieldTouched": [Function],
+                                                    "setFieldValue": [Function],
+                                                    "setFormikState": [Function],
+                                                    "setStatus": [Function],
+                                                    "setSubmitting": [Function],
+                                                    "setTouched": [Function],
+                                                    "setValues": [Function],
+                                                    "status": undefined,
+                                                    "submitCount": 0,
+                                                    "submitForm": [Function],
+                                                    "touched": Object {},
+                                                    "unregisterField": [Function],
+                                                    "validateField": [Function],
+                                                    "validateForm": [Function],
+                                                    "validateOnBlur": true,
+                                                    "validateOnChange": true,
+                                                    "validateOnMount": false,
+                                                    "values": Object {
+                                                      "title": "",
+                                                    },
+                                                  }
+                                                }
                                               >
-                                                <div
-                                                  className="field"
+                                                <FormField
+                                                  inline={false}
                                                 >
-                                                  <FormInput
-                                                    as={[Function]}
-                                                    control={[Function]}
-                                                    error={null}
-                                                    fluid={true}
-                                                    id="edition"
-                                                    label="Edition"
-                                                    name="edition"
-                                                    onBlur={[Function]}
-                                                    onChange={[Function]}
-                                                    placeholder="Edition number"
-                                                    value=""
+                                                  <div
+                                                    className="field"
                                                   >
-                                                    <FormField
+                                                    <FormInput
+                                                      as={[Function]}
                                                       control={[Function]}
                                                       error={null}
                                                       fluid={true}
@@ -1308,45 +1630,62 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                                       placeholder="Edition number"
                                                       value=""
                                                     >
-                                                      <div
-                                                        className="field"
+                                                      <FormField
+                                                        control={[Function]}
+                                                        error={null}
+                                                        fluid={true}
+                                                        id="edition"
+                                                        label="Edition"
+                                                        name="edition"
+                                                        onBlur={[Function]}
+                                                        onChange={[Function]}
+                                                        placeholder="Edition number"
+                                                        value=""
                                                       >
-                                                        <label
-                                                          htmlFor="edition"
+                                                        <div
+                                                          className="field"
                                                         >
-                                                          Edition
-                                                        </label>
-                                                        <Input
-                                                          fluid={true}
-                                                          id="edition"
-                                                          name="edition"
-                                                          onBlur={[Function]}
-                                                          onChange={[Function]}
-                                                          placeholder="Edition number"
-                                                          type="text"
-                                                          value=""
-                                                        >
-                                                          <div
-                                                            className="ui fluid input"
+                                                          <label
+                                                            htmlFor="edition"
                                                           >
-                                                            <input
-                                                              id="edition"
-                                                              name="edition"
-                                                              onBlur={[Function]}
-                                                              onChange={[Function]}
-                                                              placeholder="Edition number"
-                                                              type="text"
-                                                              value=""
-                                                            />
-                                                          </div>
-                                                        </Input>
-                                                      </div>
-                                                    </FormField>
-                                                  </FormInput>
-                                                </div>
-                                              </FormField>
-                                            </Component>
-                                          </FastField>
+                                                            Edition
+                                                          </label>
+                                                          <Input
+                                                            aria-describedby={null}
+                                                            aria-invalid={true}
+                                                            fluid={true}
+                                                            id="edition"
+                                                            name="edition"
+                                                            onBlur={[Function]}
+                                                            onChange={[Function]}
+                                                            placeholder="Edition number"
+                                                            type="text"
+                                                            value=""
+                                                          >
+                                                            <div
+                                                              className="ui fluid input"
+                                                            >
+                                                              <input
+                                                                aria-describedby={null}
+                                                                aria-invalid={true}
+                                                                id="edition"
+                                                                name="edition"
+                                                                onBlur={[Function]}
+                                                                onChange={[Function]}
+                                                                placeholder="Edition number"
+                                                                type="text"
+                                                                value=""
+                                                              />
+                                                            </div>
+                                                          </Input>
+                                                        </div>
+                                                      </FormField>
+                                                    </FormInput>
+                                                  </div>
+                                                </FormField>
+                                              </Component>
+                                            </FastFieldInner>
+                                          </FormikConnect(FastFieldInner)>
                                         </StringField>
                                         <StringField
                                           fieldPath="volume"
@@ -1355,23 +1694,17 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                           optimized={true}
                                           placeholder="Volume number"
                                         >
-                                          <FastField
+                                          <FormikConnect(FastFieldInner)
                                             component={[Function]}
                                             name="volume"
                                           >
-                                            <Component
-                                              field={
-                                                Object {
-                                                  "name": "volume",
-                                                  "onBlur": [Function],
-                                                  "onChange": [Function],
-                                                  "value": undefined,
-                                                }
-                                              }
-                                              form={
+                                            <FastFieldInner
+                                              component={[Function]}
+                                              formik={
                                                 Object {
                                                   "dirty": false,
                                                   "errors": Object {},
+                                                  "getFieldHelpers": [Function],
                                                   "getFieldMeta": [Function],
                                                   "getFieldProps": [Function],
                                                   "handleBlur": [Function],
@@ -1413,27 +1746,72 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                                   },
                                                 }
                                               }
+                                              name="volume"
                                             >
-                                              <FormField
-                                                inline={false}
+                                              <Component
+                                                field={
+                                                  Object {
+                                                    "name": "volume",
+                                                    "onBlur": [Function],
+                                                    "onChange": [Function],
+                                                    "value": undefined,
+                                                  }
+                                                }
+                                                form={
+                                                  Object {
+                                                    "dirty": false,
+                                                    "errors": Object {},
+                                                    "getFieldHelpers": [Function],
+                                                    "getFieldMeta": [Function],
+                                                    "getFieldProps": [Function],
+                                                    "handleBlur": [Function],
+                                                    "handleChange": [Function],
+                                                    "handleReset": [Function],
+                                                    "handleSubmit": [Function],
+                                                    "initialErrors": Object {},
+                                                    "initialStatus": undefined,
+                                                    "initialTouched": Object {},
+                                                    "initialValues": Object {
+                                                      "title": "",
+                                                    },
+                                                    "isSubmitting": false,
+                                                    "isValid": true,
+                                                    "isValidating": false,
+                                                    "registerField": [Function],
+                                                    "resetForm": [Function],
+                                                    "setErrors": [Function],
+                                                    "setFieldError": [Function],
+                                                    "setFieldTouched": [Function],
+                                                    "setFieldValue": [Function],
+                                                    "setFormikState": [Function],
+                                                    "setStatus": [Function],
+                                                    "setSubmitting": [Function],
+                                                    "setTouched": [Function],
+                                                    "setValues": [Function],
+                                                    "status": undefined,
+                                                    "submitCount": 0,
+                                                    "submitForm": [Function],
+                                                    "touched": Object {},
+                                                    "unregisterField": [Function],
+                                                    "validateField": [Function],
+                                                    "validateForm": [Function],
+                                                    "validateOnBlur": true,
+                                                    "validateOnChange": true,
+                                                    "validateOnMount": false,
+                                                    "values": Object {
+                                                      "title": "",
+                                                    },
+                                                  }
+                                                }
                                               >
-                                                <div
-                                                  className="field"
+                                                <FormField
+                                                  inline={false}
                                                 >
-                                                  <FormInput
-                                                    as={[Function]}
-                                                    control={[Function]}
-                                                    error={null}
-                                                    fluid={true}
-                                                    id="volume"
-                                                    label="Volume"
-                                                    name="volume"
-                                                    onBlur={[Function]}
-                                                    onChange={[Function]}
-                                                    placeholder="Volume number"
-                                                    value=""
+                                                  <div
+                                                    className="field"
                                                   >
-                                                    <FormField
+                                                    <FormInput
+                                                      as={[Function]}
                                                       control={[Function]}
                                                       error={null}
                                                       fluid={true}
@@ -1445,45 +1823,62 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                                       placeholder="Volume number"
                                                       value=""
                                                     >
-                                                      <div
-                                                        className="field"
+                                                      <FormField
+                                                        control={[Function]}
+                                                        error={null}
+                                                        fluid={true}
+                                                        id="volume"
+                                                        label="Volume"
+                                                        name="volume"
+                                                        onBlur={[Function]}
+                                                        onChange={[Function]}
+                                                        placeholder="Volume number"
+                                                        value=""
                                                       >
-                                                        <label
-                                                          htmlFor="volume"
+                                                        <div
+                                                          className="field"
                                                         >
-                                                          Volume
-                                                        </label>
-                                                        <Input
-                                                          fluid={true}
-                                                          id="volume"
-                                                          name="volume"
-                                                          onBlur={[Function]}
-                                                          onChange={[Function]}
-                                                          placeholder="Volume number"
-                                                          type="text"
-                                                          value=""
-                                                        >
-                                                          <div
-                                                            className="ui fluid input"
+                                                          <label
+                                                            htmlFor="volume"
                                                           >
-                                                            <input
-                                                              id="volume"
-                                                              name="volume"
-                                                              onBlur={[Function]}
-                                                              onChange={[Function]}
-                                                              placeholder="Volume number"
-                                                              type="text"
-                                                              value=""
-                                                            />
-                                                          </div>
-                                                        </Input>
-                                                      </div>
-                                                    </FormField>
-                                                  </FormInput>
-                                                </div>
-                                              </FormField>
-                                            </Component>
-                                          </FastField>
+                                                            Volume
+                                                          </label>
+                                                          <Input
+                                                            aria-describedby={null}
+                                                            aria-invalid={true}
+                                                            fluid={true}
+                                                            id="volume"
+                                                            name="volume"
+                                                            onBlur={[Function]}
+                                                            onChange={[Function]}
+                                                            placeholder="Volume number"
+                                                            type="text"
+                                                            value=""
+                                                          >
+                                                            <div
+                                                              className="ui fluid input"
+                                                            >
+                                                              <input
+                                                                aria-describedby={null}
+                                                                aria-invalid={true}
+                                                                id="volume"
+                                                                name="volume"
+                                                                onBlur={[Function]}
+                                                                onChange={[Function]}
+                                                                placeholder="Volume number"
+                                                                type="text"
+                                                                value=""
+                                                              />
+                                                            </div>
+                                                          </Input>
+                                                        </div>
+                                                      </FormField>
+                                                    </FormInput>
+                                                  </div>
+                                                </FormField>
+                                              </Component>
+                                            </FastFieldInner>
+                                          </FormikConnect(FastFieldInner)>
                                         </StringField>
                                         <StringField
                                           fieldPath="issue"
@@ -1492,23 +1887,17 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                           optimized={true}
                                           placeholder="Issue number"
                                         >
-                                          <FastField
+                                          <FormikConnect(FastFieldInner)
                                             component={[Function]}
                                             name="issue"
                                           >
-                                            <Component
-                                              field={
-                                                Object {
-                                                  "name": "issue",
-                                                  "onBlur": [Function],
-                                                  "onChange": [Function],
-                                                  "value": undefined,
-                                                }
-                                              }
-                                              form={
+                                            <FastFieldInner
+                                              component={[Function]}
+                                              formik={
                                                 Object {
                                                   "dirty": false,
                                                   "errors": Object {},
+                                                  "getFieldHelpers": [Function],
                                                   "getFieldMeta": [Function],
                                                   "getFieldProps": [Function],
                                                   "handleBlur": [Function],
@@ -1550,27 +1939,72 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                                   },
                                                 }
                                               }
+                                              name="issue"
                                             >
-                                              <FormField
-                                                inline={false}
+                                              <Component
+                                                field={
+                                                  Object {
+                                                    "name": "issue",
+                                                    "onBlur": [Function],
+                                                    "onChange": [Function],
+                                                    "value": undefined,
+                                                  }
+                                                }
+                                                form={
+                                                  Object {
+                                                    "dirty": false,
+                                                    "errors": Object {},
+                                                    "getFieldHelpers": [Function],
+                                                    "getFieldMeta": [Function],
+                                                    "getFieldProps": [Function],
+                                                    "handleBlur": [Function],
+                                                    "handleChange": [Function],
+                                                    "handleReset": [Function],
+                                                    "handleSubmit": [Function],
+                                                    "initialErrors": Object {},
+                                                    "initialStatus": undefined,
+                                                    "initialTouched": Object {},
+                                                    "initialValues": Object {
+                                                      "title": "",
+                                                    },
+                                                    "isSubmitting": false,
+                                                    "isValid": true,
+                                                    "isValidating": false,
+                                                    "registerField": [Function],
+                                                    "resetForm": [Function],
+                                                    "setErrors": [Function],
+                                                    "setFieldError": [Function],
+                                                    "setFieldTouched": [Function],
+                                                    "setFieldValue": [Function],
+                                                    "setFormikState": [Function],
+                                                    "setStatus": [Function],
+                                                    "setSubmitting": [Function],
+                                                    "setTouched": [Function],
+                                                    "setValues": [Function],
+                                                    "status": undefined,
+                                                    "submitCount": 0,
+                                                    "submitForm": [Function],
+                                                    "touched": Object {},
+                                                    "unregisterField": [Function],
+                                                    "validateField": [Function],
+                                                    "validateForm": [Function],
+                                                    "validateOnBlur": true,
+                                                    "validateOnChange": true,
+                                                    "validateOnMount": false,
+                                                    "values": Object {
+                                                      "title": "",
+                                                    },
+                                                  }
+                                                }
                                               >
-                                                <div
-                                                  className="field"
+                                                <FormField
+                                                  inline={false}
                                                 >
-                                                  <FormInput
-                                                    as={[Function]}
-                                                    control={[Function]}
-                                                    error={null}
-                                                    fluid={true}
-                                                    id="issue"
-                                                    label="Issue"
-                                                    name="issue"
-                                                    onBlur={[Function]}
-                                                    onChange={[Function]}
-                                                    placeholder="Issue number"
-                                                    value=""
+                                                  <div
+                                                    className="field"
                                                   >
-                                                    <FormField
+                                                    <FormInput
+                                                      as={[Function]}
                                                       control={[Function]}
                                                       error={null}
                                                       fluid={true}
@@ -1582,45 +2016,62 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                                       placeholder="Issue number"
                                                       value=""
                                                     >
-                                                      <div
-                                                        className="field"
+                                                      <FormField
+                                                        control={[Function]}
+                                                        error={null}
+                                                        fluid={true}
+                                                        id="issue"
+                                                        label="Issue"
+                                                        name="issue"
+                                                        onBlur={[Function]}
+                                                        onChange={[Function]}
+                                                        placeholder="Issue number"
+                                                        value=""
                                                       >
-                                                        <label
-                                                          htmlFor="issue"
+                                                        <div
+                                                          className="field"
                                                         >
-                                                          Issue
-                                                        </label>
-                                                        <Input
-                                                          fluid={true}
-                                                          id="issue"
-                                                          name="issue"
-                                                          onBlur={[Function]}
-                                                          onChange={[Function]}
-                                                          placeholder="Issue number"
-                                                          type="text"
-                                                          value=""
-                                                        >
-                                                          <div
-                                                            className="ui fluid input"
+                                                          <label
+                                                            htmlFor="issue"
                                                           >
-                                                            <input
-                                                              id="issue"
-                                                              name="issue"
-                                                              onBlur={[Function]}
-                                                              onChange={[Function]}
-                                                              placeholder="Issue number"
-                                                              type="text"
-                                                              value=""
-                                                            />
-                                                          </div>
-                                                        </Input>
-                                                      </div>
-                                                    </FormField>
-                                                  </FormInput>
-                                                </div>
-                                              </FormField>
-                                            </Component>
-                                          </FastField>
+                                                            Issue
+                                                          </label>
+                                                          <Input
+                                                            aria-describedby={null}
+                                                            aria-invalid={true}
+                                                            fluid={true}
+                                                            id="issue"
+                                                            name="issue"
+                                                            onBlur={[Function]}
+                                                            onChange={[Function]}
+                                                            placeholder="Issue number"
+                                                            type="text"
+                                                            value=""
+                                                          >
+                                                            <div
+                                                              className="ui fluid input"
+                                                            >
+                                                              <input
+                                                                aria-describedby={null}
+                                                                aria-invalid={true}
+                                                                id="issue"
+                                                                name="issue"
+                                                                onBlur={[Function]}
+                                                                onChange={[Function]}
+                                                                placeholder="Issue number"
+                                                                type="text"
+                                                                value=""
+                                                              />
+                                                            </div>
+                                                          </Input>
+                                                        </div>
+                                                      </FormField>
+                                                    </FormInput>
+                                                  </div>
+                                                </FormField>
+                                              </Component>
+                                            </FastFieldInner>
+                                          </FormikConnect(FastFieldInner)>
                                         </StringField>
                                         <StringField
                                           fieldPath="standard_number"
@@ -1629,23 +2080,17 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                           optimized={true}
                                           placeholder="Standard number"
                                         >
-                                          <FastField
+                                          <FormikConnect(FastFieldInner)
                                             component={[Function]}
                                             name="standard_number"
                                           >
-                                            <Component
-                                              field={
-                                                Object {
-                                                  "name": "standard_number",
-                                                  "onBlur": [Function],
-                                                  "onChange": [Function],
-                                                  "value": undefined,
-                                                }
-                                              }
-                                              form={
+                                            <FastFieldInner
+                                              component={[Function]}
+                                              formik={
                                                 Object {
                                                   "dirty": false,
                                                   "errors": Object {},
+                                                  "getFieldHelpers": [Function],
                                                   "getFieldMeta": [Function],
                                                   "getFieldProps": [Function],
                                                   "handleBlur": [Function],
@@ -1687,27 +2132,72 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                                   },
                                                 }
                                               }
+                                              name="standard_number"
                                             >
-                                              <FormField
-                                                inline={false}
+                                              <Component
+                                                field={
+                                                  Object {
+                                                    "name": "standard_number",
+                                                    "onBlur": [Function],
+                                                    "onChange": [Function],
+                                                    "value": undefined,
+                                                  }
+                                                }
+                                                form={
+                                                  Object {
+                                                    "dirty": false,
+                                                    "errors": Object {},
+                                                    "getFieldHelpers": [Function],
+                                                    "getFieldMeta": [Function],
+                                                    "getFieldProps": [Function],
+                                                    "handleBlur": [Function],
+                                                    "handleChange": [Function],
+                                                    "handleReset": [Function],
+                                                    "handleSubmit": [Function],
+                                                    "initialErrors": Object {},
+                                                    "initialStatus": undefined,
+                                                    "initialTouched": Object {},
+                                                    "initialValues": Object {
+                                                      "title": "",
+                                                    },
+                                                    "isSubmitting": false,
+                                                    "isValid": true,
+                                                    "isValidating": false,
+                                                    "registerField": [Function],
+                                                    "resetForm": [Function],
+                                                    "setErrors": [Function],
+                                                    "setFieldError": [Function],
+                                                    "setFieldTouched": [Function],
+                                                    "setFieldValue": [Function],
+                                                    "setFormikState": [Function],
+                                                    "setStatus": [Function],
+                                                    "setSubmitting": [Function],
+                                                    "setTouched": [Function],
+                                                    "setValues": [Function],
+                                                    "status": undefined,
+                                                    "submitCount": 0,
+                                                    "submitForm": [Function],
+                                                    "touched": Object {},
+                                                    "unregisterField": [Function],
+                                                    "validateField": [Function],
+                                                    "validateForm": [Function],
+                                                    "validateOnBlur": true,
+                                                    "validateOnChange": true,
+                                                    "validateOnMount": false,
+                                                    "values": Object {
+                                                      "title": "",
+                                                    },
+                                                  }
+                                                }
                                               >
-                                                <div
-                                                  className="field"
+                                                <FormField
+                                                  inline={false}
                                                 >
-                                                  <FormInput
-                                                    as={[Function]}
-                                                    control={[Function]}
-                                                    error={null}
-                                                    fluid={true}
-                                                    id="standard_number"
-                                                    label="Standard number"
-                                                    name="standard_number"
-                                                    onBlur={[Function]}
-                                                    onChange={[Function]}
-                                                    placeholder="Standard number"
-                                                    value=""
+                                                  <div
+                                                    className="field"
                                                   >
-                                                    <FormField
+                                                    <FormInput
+                                                      as={[Function]}
                                                       control={[Function]}
                                                       error={null}
                                                       fluid={true}
@@ -1719,45 +2209,62 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                                       placeholder="Standard number"
                                                       value=""
                                                     >
-                                                      <div
-                                                        className="field"
+                                                      <FormField
+                                                        control={[Function]}
+                                                        error={null}
+                                                        fluid={true}
+                                                        id="standard_number"
+                                                        label="Standard number"
+                                                        name="standard_number"
+                                                        onBlur={[Function]}
+                                                        onChange={[Function]}
+                                                        placeholder="Standard number"
+                                                        value=""
                                                       >
-                                                        <label
-                                                          htmlFor="standard_number"
+                                                        <div
+                                                          className="field"
                                                         >
-                                                          Standard number
-                                                        </label>
-                                                        <Input
-                                                          fluid={true}
-                                                          id="standard_number"
-                                                          name="standard_number"
-                                                          onBlur={[Function]}
-                                                          onChange={[Function]}
-                                                          placeholder="Standard number"
-                                                          type="text"
-                                                          value=""
-                                                        >
-                                                          <div
-                                                            className="ui fluid input"
+                                                          <label
+                                                            htmlFor="standard_number"
                                                           >
-                                                            <input
-                                                              id="standard_number"
-                                                              name="standard_number"
-                                                              onBlur={[Function]}
-                                                              onChange={[Function]}
-                                                              placeholder="Standard number"
-                                                              type="text"
-                                                              value=""
-                                                            />
-                                                          </div>
-                                                        </Input>
-                                                      </div>
-                                                    </FormField>
-                                                  </FormInput>
-                                                </div>
-                                              </FormField>
-                                            </Component>
-                                          </FastField>
+                                                            Standard number
+                                                          </label>
+                                                          <Input
+                                                            aria-describedby={null}
+                                                            aria-invalid={true}
+                                                            fluid={true}
+                                                            id="standard_number"
+                                                            name="standard_number"
+                                                            onBlur={[Function]}
+                                                            onChange={[Function]}
+                                                            placeholder="Standard number"
+                                                            type="text"
+                                                            value=""
+                                                          >
+                                                            <div
+                                                              className="ui fluid input"
+                                                            >
+                                                              <input
+                                                                aria-describedby={null}
+                                                                aria-invalid={true}
+                                                                id="standard_number"
+                                                                name="standard_number"
+                                                                onBlur={[Function]}
+                                                                onChange={[Function]}
+                                                                placeholder="Standard number"
+                                                                type="text"
+                                                                value=""
+                                                              />
+                                                            </div>
+                                                          </Input>
+                                                        </div>
+                                                      </FormField>
+                                                    </FormInput>
+                                                  </div>
+                                                </FormField>
+                                              </Component>
+                                            </FastFieldInner>
+                                          </FormikConnect(FastFieldInner)>
                                         </StringField>
                                       </div>
                                     </FormGroup>
@@ -1786,6 +2293,7 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                       Object {
                                         "dirty": false,
                                         "errors": Object {},
+                                        "getFieldHelpers": [Function],
                                         "getFieldMeta": [Function],
                                         "getFieldProps": [Function],
                                         "handleBlur": [Function],
@@ -1842,23 +2350,17 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                           optimized={true}
                                           placeholder="Page number"
                                         >
-                                          <FastField
+                                          <FormikConnect(FastFieldInner)
                                             component={[Function]}
                                             name="page"
                                           >
-                                            <Component
-                                              field={
-                                                Object {
-                                                  "name": "page",
-                                                  "onBlur": [Function],
-                                                  "onChange": [Function],
-                                                  "value": undefined,
-                                                }
-                                              }
-                                              form={
+                                            <FastFieldInner
+                                              component={[Function]}
+                                              formik={
                                                 Object {
                                                   "dirty": false,
                                                   "errors": Object {},
+                                                  "getFieldHelpers": [Function],
                                                   "getFieldMeta": [Function],
                                                   "getFieldProps": [Function],
                                                   "handleBlur": [Function],
@@ -1900,27 +2402,72 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                                   },
                                                 }
                                               }
+                                              name="page"
                                             >
-                                              <FormField
-                                                inline={false}
+                                              <Component
+                                                field={
+                                                  Object {
+                                                    "name": "page",
+                                                    "onBlur": [Function],
+                                                    "onChange": [Function],
+                                                    "value": undefined,
+                                                  }
+                                                }
+                                                form={
+                                                  Object {
+                                                    "dirty": false,
+                                                    "errors": Object {},
+                                                    "getFieldHelpers": [Function],
+                                                    "getFieldMeta": [Function],
+                                                    "getFieldProps": [Function],
+                                                    "handleBlur": [Function],
+                                                    "handleChange": [Function],
+                                                    "handleReset": [Function],
+                                                    "handleSubmit": [Function],
+                                                    "initialErrors": Object {},
+                                                    "initialStatus": undefined,
+                                                    "initialTouched": Object {},
+                                                    "initialValues": Object {
+                                                      "title": "",
+                                                    },
+                                                    "isSubmitting": false,
+                                                    "isValid": true,
+                                                    "isValidating": false,
+                                                    "registerField": [Function],
+                                                    "resetForm": [Function],
+                                                    "setErrors": [Function],
+                                                    "setFieldError": [Function],
+                                                    "setFieldTouched": [Function],
+                                                    "setFieldValue": [Function],
+                                                    "setFormikState": [Function],
+                                                    "setStatus": [Function],
+                                                    "setSubmitting": [Function],
+                                                    "setTouched": [Function],
+                                                    "setValues": [Function],
+                                                    "status": undefined,
+                                                    "submitCount": 0,
+                                                    "submitForm": [Function],
+                                                    "touched": Object {},
+                                                    "unregisterField": [Function],
+                                                    "validateField": [Function],
+                                                    "validateForm": [Function],
+                                                    "validateOnBlur": true,
+                                                    "validateOnChange": true,
+                                                    "validateOnMount": false,
+                                                    "values": Object {
+                                                      "title": "",
+                                                    },
+                                                  }
+                                                }
                                               >
-                                                <div
-                                                  className="field"
+                                                <FormField
+                                                  inline={false}
                                                 >
-                                                  <FormInput
-                                                    as={[Function]}
-                                                    control={[Function]}
-                                                    error={null}
-                                                    fluid={true}
-                                                    id="page"
-                                                    label="Page"
-                                                    name="page"
-                                                    onBlur={[Function]}
-                                                    onChange={[Function]}
-                                                    placeholder="Page number"
-                                                    value=""
+                                                  <div
+                                                    className="field"
                                                   >
-                                                    <FormField
+                                                    <FormInput
+                                                      as={[Function]}
                                                       control={[Function]}
                                                       error={null}
                                                       fluid={true}
@@ -1932,45 +2479,62 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                                       placeholder="Page number"
                                                       value=""
                                                     >
-                                                      <div
-                                                        className="field"
+                                                      <FormField
+                                                        control={[Function]}
+                                                        error={null}
+                                                        fluid={true}
+                                                        id="page"
+                                                        label="Page"
+                                                        name="page"
+                                                        onBlur={[Function]}
+                                                        onChange={[Function]}
+                                                        placeholder="Page number"
+                                                        value=""
                                                       >
-                                                        <label
-                                                          htmlFor="page"
+                                                        <div
+                                                          className="field"
                                                         >
-                                                          Page
-                                                        </label>
-                                                        <Input
-                                                          fluid={true}
-                                                          id="page"
-                                                          name="page"
-                                                          onBlur={[Function]}
-                                                          onChange={[Function]}
-                                                          placeholder="Page number"
-                                                          type="text"
-                                                          value=""
-                                                        >
-                                                          <div
-                                                            className="ui fluid input"
+                                                          <label
+                                                            htmlFor="page"
                                                           >
-                                                            <input
-                                                              id="page"
-                                                              name="page"
-                                                              onBlur={[Function]}
-                                                              onChange={[Function]}
-                                                              placeholder="Page number"
-                                                              type="text"
-                                                              value=""
-                                                            />
-                                                          </div>
-                                                        </Input>
-                                                      </div>
-                                                    </FormField>
-                                                  </FormInput>
-                                                </div>
-                                              </FormField>
-                                            </Component>
-                                          </FastField>
+                                                            Page
+                                                          </label>
+                                                          <Input
+                                                            aria-describedby={null}
+                                                            aria-invalid={true}
+                                                            fluid={true}
+                                                            id="page"
+                                                            name="page"
+                                                            onBlur={[Function]}
+                                                            onChange={[Function]}
+                                                            placeholder="Page number"
+                                                            type="text"
+                                                            value=""
+                                                          >
+                                                            <div
+                                                              className="ui fluid input"
+                                                            >
+                                                              <input
+                                                                aria-describedby={null}
+                                                                aria-invalid={true}
+                                                                id="page"
+                                                                name="page"
+                                                                onBlur={[Function]}
+                                                                onChange={[Function]}
+                                                                placeholder="Page number"
+                                                                type="text"
+                                                                value=""
+                                                              />
+                                                            </div>
+                                                          </Input>
+                                                        </div>
+                                                      </FormField>
+                                                    </FormInput>
+                                                  </div>
+                                                </FormField>
+                                              </Component>
+                                            </FastFieldInner>
+                                          </FormikConnect(FastFieldInner)>
                                         </StringField>
                                         <YearInputField
                                           fieldPath="publication_year"
@@ -1999,6 +2563,7 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                                   Object {
                                                     "dirty": false,
                                                     "errors": Object {},
+                                                    "getFieldHelpers": [Function],
                                                     "getFieldMeta": [Function],
                                                     "getFieldProps": [Function],
                                                     "handleBlur": [Function],
@@ -2159,6 +2724,8 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                                                   className="field"
                                                                 >
                                                                   <Input
+                                                                    aria-describedby={null}
+                                                                    aria-invalid={true}
                                                                     autoComplete="off"
                                                                     data-test=""
                                                                     icon={true}
@@ -2190,6 +2757,8 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                                                         />
                                                                       </Icon>
                                                                       <input
+                                                                        aria-describedby={null}
+                                                                        aria-invalid={true}
                                                                         autoComplete="off"
                                                                         id="publication_year"
                                                                         key=".1"
@@ -2257,6 +2826,7 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                       Object {
                                         "dirty": false,
                                         "errors": Object {},
+                                        "getFieldHelpers": [Function],
                                         "getFieldMeta": [Function],
                                         "getFieldProps": [Function],
                                         "handleBlur": [Function],
@@ -2337,6 +2907,8 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                                 Note
                                               </label>
                                               <TextArea
+                                                aria-describedby={null}
+                                                aria-invalid={true}
                                                 as="textarea"
                                                 id="note"
                                                 name="note"
@@ -2350,6 +2922,7 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                                   innerRef={
                                                     Object {
                                                       "current": <textarea
+                                                        aria-invalid="true"
                                                         id="note"
                                                         name="note"
                                                         placeholder="Notes for the library"
@@ -2362,6 +2935,7 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                                     innerRef={
                                                       Object {
                                                         "current": <textarea
+                                                          aria-invalid="true"
                                                           id="note"
                                                           name="note"
                                                           placeholder="Notes for the library"
@@ -2371,6 +2945,8 @@ exports[`DocumentRequestForm tests should render the document request form corre
                                                     }
                                                   >
                                                     <textarea
+                                                      aria-describedby={null}
+                                                      aria-invalid={true}
                                                       id="note"
                                                       name="note"
                                                       onBlur={[Function]}

--- a/ui/src/pages/frontsite/Documents/DocumentsDetails/LoanRequestForm/__tests__/__snapshots__/LoanRequestForm.test.js.snap
+++ b/ui/src/pages/frontsite/Documents/DocumentsDetails/LoanRequestForm/__tests__/__snapshots__/LoanRequestForm.test.js.snap
@@ -341,6 +341,7 @@ exports[`DocumentMetadata tests should render the loan request form correctly 1`
                           className="field"
                         >
                           <Input
+                            aria-describedby={null}
                             autoComplete="off"
                             data-test=""
                             icon={true}
@@ -371,6 +372,7 @@ exports[`DocumentMetadata tests should render the loan request form correctly 1`
                                 />
                               </Icon>
                               <input
+                                aria-describedby={null}
                                 autoComplete="off"
                                 key=".1"
                                 name="selectedDate"
@@ -421,6 +423,7 @@ exports[`DocumentMetadata tests should render the loan request form correctly 1`
               className="field"
             >
               <Button
+                aria-describedby={null}
                 as="button"
                 fluid={true}
                 onClick={[Function]}
@@ -449,6 +452,7 @@ exports[`DocumentMetadata tests should render the loan request form correctly 1`
                     }
                   >
                     <button
+                      aria-describedby={null}
                       className="ui fluid primary button"
                       onClick={[Function]}
                     >

--- a/ui/src/pages/frontsite/Documents/DocumentsSearch/DocumentListEntry/DocumentListEntry.js
+++ b/ui/src/pages/frontsite/Documents/DocumentsSearch/DocumentListEntry/DocumentListEntry.js
@@ -67,7 +67,7 @@ export default class DocumentListEntry extends Component {
       <DocumentItemCover
         size="mini"
         coverUrl={this.metadata.edition}
-        document={this.metadata}
+        metadata={this.metadata}
         disabled
         linkTo={FrontSiteRoutes.documentDetailsFor(this.metadata.pid)}
       />

--- a/ui/src/pages/frontsite/Documents/DocumentsSearch/DocumentListEntry/__tests__/__snapshots__/DocumentListEntry.test.js.snap
+++ b/ui/src/pages/frontsite/Documents/DocumentsSearch/DocumentListEntry/__tests__/__snapshots__/DocumentListEntry.test.js.snap
@@ -5,7 +5,8 @@ exports[`should render correctly 1`] = `
   <DocumentItemCover
     coverUrl="1"
     disabled={true}
-    document={
+    linkTo="/literature/13"
+    metadata={
       Object {
         "$schema": "https://127.0.0.1:5000/schemas/documents/document-v1.0.0.json",
         "abstract": "This is an abstract",
@@ -35,7 +36,6 @@ exports[`should render correctly 1`] = `
         "title": "The Gulf: The Making of An American Sea",
       }
     }
-    linkTo="/literature/13"
     size="mini"
   />
   <ItemContent>

--- a/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/LoanListEntry/LoanListEntry.js
+++ b/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/LoanListEntry/LoanListEntry.js
@@ -31,7 +31,7 @@ export class LoanListEntry extends Component {
         <DocumentItemCover
           size="mini"
           src={loan.metadata.document.edition}
-          document={loan.metadata.document}
+          metadata={loan.metadata.document}
           disabled
           linkTo={FrontSiteRoutes.documentDetailsFor(
             loan.metadata.document_pid

--- a/ui/src/pages/frontsite/PatronProfile/PatronPastLoans/PatronPastLoans.js
+++ b/ui/src/pages/frontsite/PatronProfile/PatronPastLoans/PatronPastLoans.js
@@ -19,7 +19,7 @@ class PastLoanListEntry extends Component {
         <DocumentItemCover
           size="mini"
           src={loan.metadata.document.edition}
-          document={loan.metadata.document}
+          metadata={loan.metadata.document}
           disabled
           linkTo={FrontSiteRoutes.documentDetailsFor(
             loan.metadata.document_pid

--- a/ui/src/pages/frontsite/PatronProfile/PatronPendingLoans/__tests__/__snapshots__/PatronPendingLoans.js.snap
+++ b/ui/src/pages/frontsite/PatronProfile/PatronPendingLoans/__tests__/__snapshots__/PatronPendingLoans.js.snap
@@ -217,7 +217,8 @@ exports[`PatronLoans tests should render patron loans 1`] = `
                         <DocumentItemCover
                           coverUrl="42"
                           disabled={true}
-                          document={
+                          linkTo="/literature/docid-1"
+                          metadata={
                             Object {
                               "circulation": Object {
                                 "has_items_on_site": 0,
@@ -227,7 +228,6 @@ exports[`PatronLoans tests should render patron loans 1`] = `
                               "title": "Test",
                             }
                           }
-                          linkTo="/literature/docid-1"
                           size="mini"
                         >
                           <ItemImage
@@ -578,7 +578,8 @@ exports[`PatronLoans tests should render patron loans 1`] = `
                         <DocumentItemCover
                           coverUrl="42"
                           disabled={true}
-                          document={
+                          linkTo="/literature/docid-1"
+                          metadata={
                             Object {
                               "circulation": Object {
                                 "has_items_on_site": 0,
@@ -588,7 +589,6 @@ exports[`PatronLoans tests should render patron loans 1`] = `
                               "title": "Test 2",
                             }
                           }
-                          linkTo="/literature/docid-1"
                           size="mini"
                         >
                           <ItemImage

--- a/ui/src/pages/frontsite/PatronProfile/PatronPendingLoans/components/LoanRequestListEntry.js
+++ b/ui/src/pages/frontsite/PatronProfile/PatronPendingLoans/components/LoanRequestListEntry.js
@@ -15,7 +15,7 @@ export class LoanRequestListEntry extends Component {
       <Item key={loan.metadata.pid} data-test={loan.metadata.pid}>
         <DocumentItemCover
           size="mini"
-          document={loan.metadata.document}
+          metadata={loan.metadata.document}
           disabled
           linkTo={FrontSiteRoutes.documentDetailsFor(
             loan.metadata.document_pid


### PR DESCRIPTION
Fix the restricted access badge that appeared in all documents in loans (in patron's profile).

Before:
![Selection_002](https://user-images.githubusercontent.com/33685068/77667523-9e456100-6f82-11ea-9f36-ca852d996769.png)

After:
![Selection_001](https://user-images.githubusercontent.com/33685068/77666991-f62f9800-6f81-11ea-8e01-45f7dcc9ff25.png)


Closes #776