### PR TITLE
global: add identifiers tab in documents frontsite and display isbn in backoffice

### DIFF
--- a/invenio_app_ils/vocabularies/data/alternative_identifier_schemes.json
+++ b/invenio_app_ils/vocabularies/data/alternative_identifier_schemes.json
@@ -11,11 +11,6 @@
   },
   {
     "type": "alternative_identifier_scheme",
-    "key": "ISBN",
-    "text": "International Standard Book Number (ISBN)"
-  },
-  {
-    "type": "alternative_identifier_scheme",
     "key": "HDL",
     "text": "Handle.Net (HDL)"
   },

--- a/invenio_app_ils/vocabularies/data/identifier_schemes.json
+++ b/invenio_app_ils/vocabularies/data/identifier_schemes.json
@@ -8,5 +8,10 @@
     "type": "identifier_scheme",
     "key": "URN",
     "text": "Uniform Resource Name (URN)"
+  },
+  {
+    "type": "identifier_scheme",
+    "key": "ISBN",
+    "text": "International Standard Book Number (ISBN)"
   }
 ]

--- a/ui/src/pages/backoffice/Document/DocumentDetails/components/DocumentMetadata/DocumentIdentifiers.js
+++ b/ui/src/pages/backoffice/Document/DocumentDetails/components/DocumentMetadata/DocumentIdentifiers.js
@@ -6,10 +6,12 @@ import PropTypes from 'prop-types';
 export class DocumentIdentifiers extends Component {
   render() {
     const { document } = this.props;
+    const identifiers = groupedSchemeValueList(document.metadata.identifiers);
+    const alternative_identifiers = groupedSchemeValueList(
+      document.metadata.alternative_identifiers
+    );
     return document.metadata.identifiers ? (
-      <MetadataTable
-        rows={groupedSchemeValueList(document.metadata.identifiers)}
-      />
+      <MetadataTable rows={identifiers.concat(alternative_identifiers)} />
     ) : (
       <InfoMessage
         header={'No stored identifiers.'}

--- a/ui/src/pages/frontsite/components/Document/DocumentInfo.js
+++ b/ui/src/pages/frontsite/components/Document/DocumentInfo.js
@@ -3,6 +3,7 @@ import { Divider, Table } from 'semantic-ui-react';
 import PropTypes from 'prop-types';
 import { DocumentAuthors } from '@components/Document';
 import isEmpty from 'lodash/isEmpty';
+import { IdentifierRows } from '../Identifiers';
 
 export class DocumentInfo extends Component {
   constructor(props) {
@@ -24,45 +25,15 @@ export class DocumentInfo extends Component {
     return null;
   }
 
-  renderISBN() {
-    const identifiersISBN = this.metadata.alternative_identifiers
-      ? this.metadata.alternative_identifiers.filter(
-          identifier => identifier.scheme === 'ISBN'
-        )
-      : null;
-
-    if (!isEmpty(identifiersISBN)) {
-      return (
-        <Table.Row>
-          <Table.Cell>ISBN</Table.Cell>
-          <Table.Cell>
-            {identifiersISBN.map(isbn => `${isbn.value}, `)}
-          </Table.Cell>
-        </Table.Row>
-      );
-    }
-    return null;
-  }
-
-  renderDOI() {
-    const identifiersDOI = this.metadata.identifiers
+  renderSpecificIdentifiers(scheme) {
+    const identifiers = this.metadata.identifiers
       ? this.metadata.identifiers.filter(
-          identifier => identifier.scheme === 'DOI'
+          identifier => identifier.scheme === scheme
         )
       : null;
 
-    if (!isEmpty(identifiersDOI)) {
-      return (
-        <Table.Row>
-          <Table.Cell>DOI</Table.Cell>
-          <Table.Cell>
-            {identifiersDOI.map(
-              doi =>
-                `${doi.value}${!isEmpty(doi.material) && ` (${doi.value})`}, `
-            )}
-          </Table.Cell>
-        </Table.Row>
-      );
+    if (!isEmpty(identifiers)) {
+      return <IdentifierRows identifiers={identifiers} />;
     }
     return null;
   }
@@ -94,8 +65,8 @@ export class DocumentInfo extends Component {
                 {this.metadata.keywords.value} ({this.metadata.keywords.source})
               </Table.Cell>
             </Table.Row>
-            {this.renderISBN()}
-            {this.renderDOI()}
+            {this.renderSpecificIdentifiers('ISBN')}
+            {this.renderSpecificIdentifiers('DOI')}
           </Table.Body>
         </Table>
       </>

--- a/ui/src/pages/frontsite/components/Document/DocumentInfo.js
+++ b/ui/src/pages/frontsite/components/Document/DocumentInfo.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { Divider, Table } from 'semantic-ui-react';
 import PropTypes from 'prop-types';
 import { DocumentAuthors } from '@components/Document';
+import isEmpty from 'lodash/isEmpty';
 
 export class DocumentInfo extends Component {
   constructor(props) {
@@ -16,6 +17,49 @@ export class DocumentInfo extends Component {
           <Table.Cell>Languages</Table.Cell>
           <Table.Cell>
             {this.metadata.languages.map(lang => lang + ', ')}
+          </Table.Cell>
+        </Table.Row>
+      );
+    }
+    return null;
+  }
+
+  renderISBN() {
+    const identifiersISBN = this.metadata.alternative_identifiers
+      ? this.metadata.alternative_identifiers.filter(
+          identifier => identifier.scheme === 'ISBN'
+        )
+      : null;
+
+    if (!isEmpty(identifiersISBN)) {
+      return (
+        <Table.Row>
+          <Table.Cell>ISBN</Table.Cell>
+          <Table.Cell>
+            {identifiersISBN.map(isbn => `${isbn.value}, `)}
+          </Table.Cell>
+        </Table.Row>
+      );
+    }
+    return null;
+  }
+
+  renderDOI() {
+    const identifiersDOI = this.metadata.identifiers
+      ? this.metadata.identifiers.filter(
+          identifier => identifier.scheme === 'DOI'
+        )
+      : null;
+
+    if (!isEmpty(identifiersDOI)) {
+      return (
+        <Table.Row>
+          <Table.Cell>DOI</Table.Cell>
+          <Table.Cell>
+            {identifiersDOI.map(
+              doi =>
+                `${doi.value}${!isEmpty(doi.material) && ` (${doi.value})`}, `
+            )}
           </Table.Cell>
         </Table.Row>
       );
@@ -50,6 +94,8 @@ export class DocumentInfo extends Component {
                 {this.metadata.keywords.value} ({this.metadata.keywords.source})
               </Table.Cell>
             </Table.Row>
+            {this.renderISBN()}
+            {this.renderDOI()}
           </Table.Body>
         </Table>
       </>

--- a/ui/src/pages/frontsite/components/Document/DocumentMetadataTabs.js
+++ b/ui/src/pages/frontsite/components/Document/DocumentMetadataTabs.js
@@ -7,6 +7,7 @@ import { DocumentConference } from './DocumentConference';
 import { DocumentLinks } from './DocumentLinks';
 import { Notes } from '../Notes';
 import _get from 'lodash/get';
+import { Identifiers } from '../Identifiers';
 
 export class DocumentMetadataTabs extends Component {
   constructor(props) {
@@ -25,6 +26,18 @@ export class DocumentMetadataTabs extends Component {
               documentType={this.document.document_type}
             />
             <DocumentInfo metadata={this.document} />
+          </Tab.Pane>
+        ),
+      },
+      {
+        menuItem: 'Identifiers',
+        render: () => (
+          <Tab.Pane attached={false}>
+            <Identifiers
+              identifiers={this.document.identifiers.concat(
+                this.document.alternative_identifiers
+              )}
+            />
           </Tab.Pane>
         ),
       },

--- a/ui/src/pages/frontsite/components/Document/DocumentMetadataTabs.js
+++ b/ui/src/pages/frontsite/components/Document/DocumentMetadataTabs.js
@@ -7,6 +7,7 @@ import { DocumentConference } from './DocumentConference';
 import { DocumentLinks } from './DocumentLinks';
 import { Notes } from '../Notes';
 import _get from 'lodash/get';
+import isEmpty from 'lodash/isEmpty';
 import { Identifiers } from '../Identifiers';
 
 export class DocumentMetadataTabs extends Component {
@@ -34,9 +35,13 @@ export class DocumentMetadataTabs extends Component {
         render: () => (
           <Tab.Pane attached={false}>
             <Identifiers
-              identifiers={this.document.identifiers.concat(
-                this.document.alternative_identifiers
-              )}
+              identifiers={
+                isEmpty(this.document.identifiers)
+                  ? this.document.alternative_identifiers
+                  : this.document.identifiers.concat(
+                      this.document.alternative_identifiers
+                    )
+              }
             />
           </Tab.Pane>
         ),

--- a/ui/src/pages/frontsite/components/Document/DocumentRelations.js
+++ b/ui/src/pages/frontsite/components/Document/DocumentRelations.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Divider } from 'semantic-ui-react';
 import { Link } from 'react-router-dom';
 import { FrontSiteRoutes } from '@routes/urls';
+import isEmpty from 'lodash/isEmpty';
 
 export class DocumentRelations extends Component {
   constructor(props) {
@@ -87,10 +88,16 @@ export class DocumentRelations extends Component {
       return (
         <>
           <Divider horizontal>Related</Divider>
-          {this.renderMultiparts()}
-          {this.renderSerials()}
-          {this.renderLanguages()}
-          {this.renderEditions()}
+          {isEmpty(this.relations) ? (
+            <> No related documents </>
+          ) : (
+            <>
+              {this.renderMultiparts()}
+              {this.renderSerials()}
+              {this.renderLanguages()}
+              {this.renderEditions()}
+            </>
+          )}
         </>
       );
     } else {

--- a/ui/src/pages/frontsite/components/Document/DocumentRelations.js
+++ b/ui/src/pages/frontsite/components/Document/DocumentRelations.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { Divider } from 'semantic-ui-react';
 import { Link } from 'react-router-dom';
 import { FrontSiteRoutes } from '@routes/urls';
-import isEmpty from 'lodash/isEmpty';
 
 export class DocumentRelations extends Component {
   constructor(props) {
@@ -88,15 +87,10 @@ export class DocumentRelations extends Component {
       return (
         <>
           <Divider horizontal>Related</Divider>
-          {isEmpty(this.relations) ? (
-            <> No related documents </>
-          ) : (
-            <>
-              {this.renderMultiparts()}
-              {this.renderSerials()}
-              {this.renderLanguages()}
-              {this.renderEditions()}
-            </>
+          {this.renderMultiparts()}
+          {this.renderSerials()}
+          {this.renderLanguages()}
+          {this.renderEditions()}
           )}
         </>
       );

--- a/ui/src/pages/frontsite/components/Identifiers/Identifiers.js
+++ b/ui/src/pages/frontsite/components/Identifiers/Identifiers.js
@@ -31,7 +31,7 @@ export const IdentifierRows = ({ includeSchemes, identifiers }) => {
     // Only include whitelisted schemes if includeSchemes is set
     if (!includeSchemes || includeSchemes.includes(id.scheme)) {
       const value = { value: id.value, material: id.material };
-      if (id.scheme in identifiers) {
+      if (id.scheme in idsByScheme) {
         idsByScheme[id.scheme].push(value);
       } else {
         idsByScheme[id.scheme] = [value];


### PR DESCRIPTION
* Add message "No related documents" in document details tab on frontsite, closes #722
* Add ISBN, DOI in document details tab on frontsite
* Add identifiers tab in document details page on frontsite
* Display alternative identifiers in document details page on backoffice
* Fix error in series identifiers tab in details page on frontsite (not all identifiers were displayed)

Closes #723

Document backoffice details page:
![document_back_details](https://user-images.githubusercontent.com/33685068/78271637-ab2afd00-750c-11ea-80d5-fd0a641fd599.png)

Document frontsite details page:
![document_front_details](https://user-images.githubusercontent.com/33685068/78271672-b716bf00-750c-11ea-92a5-8f73b3b10b40.png)
![Selection_001](https://user-images.githubusercontent.com/33685068/78271914-0fe65780-750d-11ea-8099-15ad4b809425.png)


Series backoffice details page:
![series_back_details](https://user-images.githubusercontent.com/33685068/78271684-c0079080-750c-11ea-8bcf-2045e56738b9.png)

Series frontsite details page:
![series_front_details](https://user-images.githubusercontent.com/33685068/78271729-cbf35280-750c-11ea-8da3-b082197a8103.png)




 