### PR TITLE
global: removed document.circulation from loan

### DIFF
--- a/invenio_app_ils/circulation/jsonresolvers/loan.py
+++ b/invenio_app_ils/circulation/jsonresolvers/loan.py
@@ -73,7 +73,6 @@ def document_resolver(loan_pid):
         obj = pick(
             document,
             "authors",
-            "circulation",
             "edition",
             "document_type",
             "open_access",

--- a/invenio_app_ils/config.py
+++ b/invenio_app_ils/config.py
@@ -1133,20 +1133,10 @@ RECORDS_REST_FACETS = dict(
             state=dict(terms=dict(field="state")),
             delivery=dict(terms=dict(field="delivery.method")),
             returns=overdue_agg,
-            availability=dict(
-                range=dict(
-                    field="document.circulation.has_items_for_loan",
-                    ranges=[{"key": "Available for loan", "from": 1}],
-                )
-            ),
         ),
         post_filters={
             "state": terms_filter("state"),
             "delivery": terms_filter("delivery.method"),
-            "availability": keyed_range_filter(
-                "document.circulation.has_items_for_loan",
-                {"Available for loan": {"gt": 0}},
-            ),
             "returns.end_date": overdue_loans_filter("end_date"),
             "loans_from_date": date_range_filter("start_date", "gte"),
             "loans_to_date": date_range_filter("start_date", "lte"),

--- a/invenio_app_ils/errors.py
+++ b/invenio_app_ils/errors.py
@@ -258,7 +258,7 @@ class StatsError(IlsException):
 class InvalidLoanExtendError(IlsException):
     """Raised when loan cannot be extended."""
 
-    description = "This loan cannot be extended. {}"
+    description = "{}"
 
     def __init__(self, msg, **kwargs):
         """Initialize exception."""

--- a/ui/src/config/searchConfig.js
+++ b/ui/src/config/searchConfig.js
@@ -260,11 +260,6 @@ const searchConfig = {
         field: 'delivery.method',
         aggName: 'delivery',
       },
-      {
-        title: 'Availability',
-        field: 'document.circulation.has_items_for_loan',
-        aggName: 'availability',
-      },
     ],
     sortBy: {
       onEmptyQuery: 'end_date',

--- a/ui/src/pages/backoffice/Loan/LoanSearch/LoanDates.js
+++ b/ui/src/pages/backoffice/Loan/LoanSearch/LoanDates.js
@@ -1,0 +1,47 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { invenioConfig } from '@config';
+import { Icon, List } from 'semantic-ui-react';
+
+export class LoanDates extends Component {
+  render() {
+    const { loan } = this.props;
+    const isRequest = invenioConfig.circulation.loanRequestStates.includes(
+      loan.metadata.state
+    );
+    return isRequest ? (
+      <>
+        <List.Content floated="right">
+          {loan.metadata.request_start_date}
+        </List.Content>
+        <List.Content>
+          <label> Requested on </label>
+        </List.Content>
+        <List.Content floated="right">
+          {loan.metadata.request_expire_date}
+        </List.Content>
+        <List.Content>
+          <label> Expires on </label>
+        </List.Content>
+      </>
+    ) : (
+      <>
+        <List.Content floated="right">{loan.metadata.start_date}</List.Content>
+        <List.Content>
+          <label> Start date </label>
+        </List.Content>
+        <List.Content floated="right">
+          {loan.metadata.is_overdue && <Icon name="warning" />}
+          {loan.metadata.end_date}
+        </List.Content>
+        <List.Content>
+          <label> End date </label>
+        </List.Content>
+      </>
+    );
+  }
+}
+
+LoanDates.propTypes = {
+  loan: PropTypes.object.isRequired,
+};

--- a/ui/src/pages/backoffice/Loan/LoanSearch/LoanList.js
+++ b/ui/src/pages/backoffice/Loan/LoanSearch/LoanList.js
@@ -1,172 +1,9 @@
-import { DocumentAuthors } from '@components/Document';
 import { SearchEmptyResults } from '@components/SearchControls';
-import { invenioConfig } from '@config';
-import { DocumentIcon, ItemIcon, LoanIcon } from '@pages/backoffice/components';
-import { BackOfficeRoutes } from '@routes/urls';
-import isEmpty from 'lodash/isEmpty';
+import _isEmpty from 'lodash/isEmpty';
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { Link } from 'react-router-dom';
-import { Grid, Header, Icon, Item, Label, List } from 'semantic-ui-react';
-import { LoanLinkToItem } from '../../components/Loan';
-import { OverdueLoanSendMailModal } from '../../components/OverdueLoanSendMailModal';
-
-class LoanDates extends Component {
-  render() {
-    const { loan } = this.props;
-    if (
-      invenioConfig.circulation.loanRequestStates.includes(loan.metadata.state)
-    ) {
-      return (
-        <>
-          <List.Content floated="right">
-            {loan.metadata.request_start_date}
-          </List.Content>
-          <List.Content>
-            <label> Requested on </label>
-          </List.Content>
-          <List.Content floated="right">
-            {loan.metadata.request_expire_date}
-          </List.Content>
-          <List.Content>
-            <label> Expires on </label>
-          </List.Content>
-        </>
-      );
-    } else {
-      return (
-        <>
-          <List.Content floated="right">
-            {loan.metadata.start_date}
-          </List.Content>
-          <List.Content>
-            <label> Start date </label>
-          </List.Content>
-          <List.Content floated="right">
-            {loan.metadata.is_overdue && <Icon name="warning" />}
-            {loan.metadata.end_date}
-          </List.Content>
-          <List.Content>
-            <label> End date </label>
-          </List.Content>
-        </>
-      );
-    }
-  }
-}
-
-class LoanListEntry extends Component {
-  render() {
-    const { loan } = this.props;
-
-    return (
-      <Item>
-        <Item.Content>
-          {loan.metadata.is_overdue && (
-            <Label color="red" ribbon>
-              Overdue
-            </Label>
-          )}
-          <Item.Header
-            as={Link}
-            to={BackOfficeRoutes.loanDetailsFor(loan.metadata.pid)}
-            data-test={`navigate-${loan.metadata.pid}`}
-          >
-            <LoanIcon /> Loan #{loan.metadata.pid}
-          </Item.Header>
-          <Grid columns={5}>
-            <Grid.Column computer={6} largeScreen={5}>
-              <label>Patron</label>{' '}
-              <Link
-                to={BackOfficeRoutes.patronDetailsFor(loan.metadata.patron_pid)}
-              >
-                {loan.metadata.patron.name}
-              </Link>{' '}
-              requested:
-              <Item.Meta className={'document-authors'}>
-                <Header className="loan-document-title" as="h5">
-                  {loan.metadata.document.title}
-                </Header>
-                <DocumentAuthors
-                  metadata={loan.metadata.document}
-                  prefix={'by '}
-                />
-              </Item.Meta>
-            </Grid.Column>
-            <Grid.Column computer={3} largeScreen={3}>
-              <List>
-                <List.Item>
-                  <List.Content floated="right">
-                    {loan.metadata.state}
-                  </List.Content>
-                  <List.Content>
-                    <label>State</label>
-                  </List.Content>
-                </List.Item>
-                <List.Item>
-                  <LoanDates loan={loan} />
-                </List.Item>
-                <List.Item>
-                  <List.Content floated="right">
-                    {loan.metadata.extension_count || '0'}
-                  </List.Content>
-                  <List.Content>
-                    <label> Extensions</label>
-                  </List.Content>
-                </List.Item>
-              </List>
-            </Grid.Column>
-            <Grid.Column width={2}>
-              <OverdueLoanSendMailModal loan={loan} />
-            </Grid.Column>
-            <Grid.Column computer={3} largeScreen={3}>
-              {!isEmpty(loan.metadata.item_pid) && (
-                <>
-                  <List>
-                    <List.Item>
-                      <List.Content>
-                        Item{' '}
-                        <LoanLinkToItem itemPid={loan.metadata.item_pid}>
-                          {loan.metadata.item.barcode && (
-                            <>
-                              <ItemIcon />
-                              {loan.metadata.item.barcode}
-                            </>
-                          )}
-                        </LoanLinkToItem>
-                      </List.Content>
-                      {loan.metadata.item.medium && (
-                        <List.Content>
-                          <label>medium</label> {loan.metadata.item.medium}
-                        </List.Content>
-                      )}
-                    </List.Item>
-                  </List>
-                </>
-              )}
-              {loan.metadata.circulation && (
-                <List.Content>
-                  <label>Physical copies available</label>{' '}
-                  {loan.metadata.document.circulation.has_items_for_loan}
-                </List.Content>
-              )}
-            </Grid.Column>
-            <Grid.Column computer={2} largeScreen={2} textAlign="right">
-              <Link
-                to={BackOfficeRoutes.documentDetailsFor(
-                  loan.metadata.document_pid
-                )}
-              >
-                Document <DocumentIcon />
-              </Link>
-              <br />
-            </Grid.Column>
-          </Grid>
-        </Item.Content>
-        <div className={'pid-field'}>#{loan.metadata.pid}</div>
-      </Item>
-    );
-  }
-}
+import { Item } from 'semantic-ui-react';
+import { LoanListEntry } from './LoanListEntry';
 
 export default class LoanList extends Component {
   renderListEntry = loan => {
@@ -178,15 +15,20 @@ export default class LoanList extends Component {
 
   render() {
     const { hits } = this.props;
-
-    if (!hits.length) return <SearchEmptyResults />;
-
-    return (
+    return _isEmpty(hits) ? (
+      <SearchEmptyResults />
+    ) : (
       <Item.Group divided className={'bo-loan-search'}>
-        {hits.map(hit => {
-          return this.renderListEntry(hit);
-        })}
+        {hits.map(hit => this.renderListEntry(hit))}
       </Item.Group>
     );
   }
 }
+
+LoanList.propTypes = {
+  hits: PropTypes.arrayOf(PropTypes.object),
+};
+
+LoanList.defaultProps = {
+  hits: [],
+};

--- a/ui/src/pages/backoffice/Loan/LoanSearch/LoanListEntry.js
+++ b/ui/src/pages/backoffice/Loan/LoanSearch/LoanListEntry.js
@@ -1,0 +1,121 @@
+import { DocumentAuthors } from '@components/Document';
+import { DocumentIcon, ItemIcon, LoanIcon } from '@pages/backoffice/components';
+import { BackOfficeRoutes } from '@routes/urls';
+import _isEmpty from 'lodash/isEmpty';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
+import { Grid, Header, Item, Label, List } from 'semantic-ui-react';
+import { LoanLinkToItem } from '../../components/Loan';
+import { OverdueLoanSendMailModal } from '../../components/OverdueLoanSendMailModal';
+import { LoanDates } from './LoanDates';
+
+export class LoanListEntry extends Component {
+  render() {
+    const { loan } = this.props;
+
+    return (
+      <Item>
+        <Item.Content>
+          {loan.metadata.is_overdue && (
+            <Label color="red" ribbon>
+              Overdue
+            </Label>
+          )}
+          <Item.Header
+            as={Link}
+            to={BackOfficeRoutes.loanDetailsFor(loan.metadata.pid)}
+            data-test={`navigate-${loan.metadata.pid}`}
+          >
+            <LoanIcon /> Loan #{loan.metadata.pid}
+          </Item.Header>
+          <Grid columns={5}>
+            <Grid.Column computer={6} largeScreen={5}>
+              <label>Patron</label>{' '}
+              <Link
+                to={BackOfficeRoutes.patronDetailsFor(loan.metadata.patron_pid)}
+              >
+                {loan.metadata.patron.name}
+              </Link>{' '}
+              requested:
+              <Item.Meta className={'document-authors'}>
+                <Header className="loan-document-title" as="h5">
+                  {loan.metadata.document.title}
+                </Header>
+                <DocumentAuthors
+                  metadata={loan.metadata.document}
+                  prefix={'by '}
+                />
+              </Item.Meta>
+            </Grid.Column>
+            <Grid.Column computer={3} largeScreen={3}>
+              <List>
+                <List.Item>
+                  <List.Content floated="right">
+                    {loan.metadata.state}
+                  </List.Content>
+                  <List.Content>
+                    <label>State</label>
+                  </List.Content>
+                </List.Item>
+                <List.Item>
+                  <LoanDates loan={loan} />
+                </List.Item>
+                <List.Item>
+                  <List.Content floated="right">
+                    {loan.metadata.extension_count || '0'}
+                  </List.Content>
+                  <List.Content>
+                    <label> Extensions</label>
+                  </List.Content>
+                </List.Item>
+              </List>
+            </Grid.Column>
+            <Grid.Column width={2}>
+              <OverdueLoanSendMailModal loan={loan} />
+            </Grid.Column>
+            <Grid.Column computer={3} largeScreen={3}>
+              {!_isEmpty(loan.metadata.item_pid) && (
+                <List>
+                  <List.Item>
+                    <List.Content>
+                      Item{' '}
+                      <LoanLinkToItem itemPid={loan.metadata.item_pid}>
+                        {loan.metadata.item.barcode && (
+                          <>
+                            <ItemIcon />
+                            {loan.metadata.item.barcode}
+                          </>
+                        )}
+                      </LoanLinkToItem>
+                    </List.Content>
+                    {loan.metadata.item.medium && (
+                      <List.Content>
+                        <label>medium</label> {loan.metadata.item.medium}
+                      </List.Content>
+                    )}
+                  </List.Item>
+                </List>
+              )}
+            </Grid.Column>
+            <Grid.Column computer={2} largeScreen={2} textAlign="right">
+              <Link
+                to={BackOfficeRoutes.documentDetailsFor(
+                  loan.metadata.document_pid
+                )}
+              >
+                Document <DocumentIcon />
+              </Link>
+              <br />
+            </Grid.Column>
+          </Grid>
+        </Item.Content>
+        <div className={'pid-field'}>#{loan.metadata.pid}</div>
+      </Item>
+    );
+  }
+}
+
+LoanListEntry.propTypes = {
+  loan: PropTypes.object.isRequired,
+};

--- a/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/ExtendButton/ExtendButton.js
+++ b/ui/src/pages/frontsite/PatronProfile/PatronCurrentLoans/components/ExtendButton/ExtendButton.js
@@ -50,15 +50,6 @@ export default class ExtendButton extends Component {
     );
   }
 
-  validateDocumentOverbook() {
-    const isOverbooked = _get(
-      this.props.loan,
-      'metadata.document.circulation.overbooked',
-      false
-    );
-    return !isOverbooked;
-  }
-
   validate = () => {
     if (!this.validateExtendUrl())
       return { isValid: false, msg: ExtendButton.INFO_MESSAGES.extendUrl };
@@ -76,12 +67,6 @@ export default class ExtendButton extends Component {
       return {
         isValid: false,
         msg: ExtendButton.INFO_MESSAGES.maxExtensions,
-      };
-
-    if (!this.validateDocumentOverbook())
-      return {
-        isValid: false,
-        msg: ExtendButton.INFO_MESSAGES.documentOverbook,
       };
 
     return { isValid: true, msg: '' };

--- a/ui/src/pages/frontsite/PatronProfile/PatronPendingLoans/__tests__/__snapshots__/PatronPendingLoans.js.snap
+++ b/ui/src/pages/frontsite/PatronProfile/PatronPendingLoans/__tests__/__snapshots__/PatronPendingLoans.js.snap
@@ -462,11 +462,6 @@ exports[`PatronLoans tests should render patron loans 1`] = `
                                         </Popup>
                                       </div>
                                     </ItemMeta>
-                                    <ItemDescription>
-                                      <div
-                                        className="description"
-                                      />
-                                    </ItemDescription>
                                   </div>
                                 </GridColumn>
                                 <GridColumn
@@ -786,11 +781,6 @@ exports[`PatronLoans tests should render patron loans 1`] = `
                                         </Popup>
                                       </div>
                                     </ItemMeta>
-                                    <ItemDescription>
-                                      <div
-                                        className="description"
-                                      />
-                                    </ItemDescription>
                                   </div>
                                 </GridColumn>
                                 <GridColumn

--- a/ui/src/pages/frontsite/PatronProfile/PatronPendingLoans/components/LoanRequestListEntry.js
+++ b/ui/src/pages/frontsite/PatronProfile/PatronPendingLoans/components/LoanRequestListEntry.js
@@ -1,16 +1,16 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
-import { FrontSiteRoutes } from '@routes/urls';
-import { Button, Grid, Icon, Item, Popup } from 'semantic-ui-react';
-import { DocumentAuthors, DocumentItemCover } from '@components/Document';
 import { toShortDate } from '@api/date';
-import _get from 'lodash/get';
+import { DocumentAuthors, DocumentItemCover } from '@components/Document';
+import { FrontSiteRoutes } from '@routes/urls';
 import _has from 'lodash/has';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
+import { Button, Grid, Icon, Item, Popup } from 'semantic-ui-react';
 
 export class LoanRequestListEntry extends Component {
   render() {
     const { loan } = this.props;
+
     return (
       <Item key={loan.metadata.pid} data-test={loan.metadata.pid}>
         <DocumentItemCover
@@ -44,21 +44,6 @@ export class LoanRequestListEntry extends Component {
                   trigger={<Icon name={'info'} />}
                 />
               </Item.Meta>
-              <Item.Description>
-                {_get(
-                  loan,
-                  'metadata.document.circulation.has_items_on_site',
-                  0
-                ) > 0 ? (
-                  <>
-                    You can also read it on-site only
-                    <Popup
-                      content={'Click on the cover to find the location'}
-                      trigger={<Icon name={'info'} />}
-                    />
-                  </>
-                ) : null}
-              </Item.Description>
             </Grid.Column>
             <Grid.Column
               textAlign={'right'}


### PR DESCRIPTION
- removed document.circulation from loan resolver, closes #795 
- for loan extension, document overbook validation happens on backend only
- removed "physical copies available" from LoanListEntry
- removed from FrontSite/PatronDetails/LoanRequests "You can also read it on-site only"
- removed item availability filter for loans 
- split LoanList, LoanListEntry and LoanDates to separate files