### PR TITLE
ui: configurable static pages

### DIFF
--- a/invenio_app_ils/templates/static_pages/about.html
+++ b/invenio_app_ils/templates/static_pages/about.html
@@ -1,0 +1,1 @@
+InvenioILS

--- a/invenio_app_ils/templates/static_pages/contact.html
+++ b/invenio_app_ils/templates/static_pages/contact.html
@@ -1,0 +1,2 @@
+You can contact InvenioILS developers on
+<a href="https://gitter.im/inveniosoftware/invenio">our chatroom</a>

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,7 @@ install_requires = [
     # --- extra deps of ILS -----------------------------------------------
     "invenio-circulation>=1.0.0a21,<1.1.0",
     "invenio-stats>=1.0.0a17",
+    "invenio-pages>=1.0.0a5",
     "invenio-pidrelations>=1.0.0a6,<1.1.0",
     "invenio-opendefinition>=1.0.0a9,<1.1.0",
     "sentry-sdk>=0.10.2",
@@ -154,6 +155,7 @@ setup(
             "setup = invenio_app_ils.cli:setup",
             'stats = invenio_stats.cli:stats',
             "vocabulary = invenio_app_ils.vocabularies.cli:vocabulary",
+            "fixtures = invenio_app_ils.cli:fixtures",
         ],
         "invenio_base.apps": [
             "ils_ui = invenio_app_ils.ext:InvenioAppIlsUI",

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -6,7 +6,6 @@ import { Login, ConfirmEmail } from '@authentication/pages';
 import { FrontSite, BackOffice } from '@routes/components';
 import { AuthenticationRoutes, BackOfficeRoutes } from '@routes/urls';
 import history from './history';
-import { NotFound } from '@components';
 import { AuthenticationGuard, UnAuthorized } from '@authentication/components';
 import PropTypes from 'prop-types';
 
@@ -47,7 +46,6 @@ export default class App extends Component {
               roles={['admin', 'librarian']}
             />
             <FrontSite {...this.props} />
-            <Route component={NotFound} />
           </Switch>
         </Router>
       </SetUserInfo>

--- a/ui/src/__tests__/App.test.js
+++ b/ui/src/__tests__/App.test.js
@@ -29,7 +29,6 @@ beforeEach(() => {
 it('should render backoffice application', () => {
   const div = document.createElement('div');
   ReactDOM.render(
-
     <Provider store={store}>
       <App />
     </Provider>,

--- a/ui/src/api/index.js
+++ b/ui/src/api/index.js
@@ -14,3 +14,4 @@ export { stats, circulationStats } from './stats';
 export { vocabulary } from './vocabularies/vocabulary';
 export { acqOrder, acqVendor } from './acquisition';
 export { illBorrowingRequest, illLibrary } from './ill';
+export { page } from './staticPages';

--- a/ui/src/api/staticPages/index.js
+++ b/ui/src/api/staticPages/index.js
@@ -1,0 +1,1 @@
+export {page} from './page';

--- a/ui/src/api/staticPages/page.js
+++ b/ui/src/api/staticPages/page.js
@@ -1,0 +1,20 @@
+import { http } from '../base';
+
+const pageURL = '/pages/';
+
+/**
+ * GET the static page by providing ID
+ *
+ * page is not a record type (read more in https://github.com/inveniosoftware/invenio-pages)
+ *
+ * @param pageID id of the static page
+ * @returns {Promise<AxiosResponse<T>>} page object
+ */
+const get = async pageID => {
+  return http.get(`${pageURL}${pageID}`);
+};
+
+export const page = {
+  get: get,
+  url: pageURL,
+};

--- a/ui/src/components/ILSPlaceholder/ILSPlaceholder.js
+++ b/ui/src/components/ILSPlaceholder/ILSPlaceholder.js
@@ -1,14 +1,16 @@
 import React, { Component } from 'react';
 import { Item, Placeholder } from 'semantic-ui-react';
+import {random} from 'lodash/number';
 
 export class ILSParagraphPlaceholder extends Component {
   renderLines = () => {
     const lines = [];
+    const lineLengths = ['full', 'very long', 'long', 'medium', 'short', 'very short'];
     for (let i = 0; i < this.props.linesNumber; i++) {
       lines.push(
         <Placeholder.Line
           key={i}
-          length={this.props.lineLength ? this.props.lineLength : 'full'}
+          length={this.props.lineLength ? this.props.lineLength : lineLengths[random(lineLengths.length-1)]}
         />
       );
     }
@@ -43,7 +45,7 @@ export class ILSHeaderPlaceholder extends Component {
     const { isLoading, image, renderElement, ...restParams } = this.props;
     return isLoading ? (
       <Placeholder {...restParams}>
-        <Placeholder.Header image>
+        <Placeholder.Header>
           <Placeholder.Line />
           <Placeholder.Line />
         </Placeholder.Header>

--- a/ui/src/config/uiConfig.js
+++ b/ui/src/config/uiConfig.js
@@ -1,0 +1,19 @@
+import _find from 'lodash/find';
+import _map from 'lodash/map';
+
+export const staticPages = [
+  { name: 'about', route: '/about', apiURL: '1' },
+  { name: 'contact', route: '/contact', apiURL: '2' },
+];
+
+export const getStaticPagesRoutes = () => {
+  return _map(staticPages, 'route');
+};
+
+export const getStaticPageByRoute = path => {
+  return _find(staticPages, ['route', path]);
+};
+
+export const getStaticPageByName = name => {
+  return _find(staticPages, ['name', name]);
+};

--- a/ui/src/pages/backoffice/components/Sidebar/AdminMenu.js
+++ b/ui/src/pages/backoffice/components/Sidebar/AdminMenu.js
@@ -1,0 +1,21 @@
+import { adminRoutes } from '@routes/urls';
+import React, { Component } from 'react';
+import { Divider, Menu } from 'semantic-ui-react';
+
+export default class AdminMenu extends Component {
+  render() {
+    return (
+      <>
+        <Divider horizontal>Admin menu</Divider>
+        <Menu text vertical className="bo-menu">
+          <Menu.Item as={'a'} href={adminRoutes.admin}>
+            Admin panel
+          </Menu.Item>
+          <Menu.Item as={'a'} href={adminRoutes.staticPages}>
+            Static pages
+          </Menu.Item>
+        </Menu>
+      </>
+    );
+  }
+}

--- a/ui/src/pages/backoffice/components/Sidebar/Sidebar.js
+++ b/ui/src/pages/backoffice/components/Sidebar/Sidebar.js
@@ -1,3 +1,5 @@
+import { AuthenticationGuard } from '@authentication/components';
+import AdminMenu from './AdminMenu';
 import React, { Component } from 'react';
 import { withRouter } from 'react-router';
 import { Link } from 'react-router-dom';
@@ -179,12 +181,18 @@ class Sidebar extends Component {
             </Menu.Menu>
           </Menu.Item>
         </Menu>
-        <Divider />
+        <Divider horizontal>Other</Divider>
         <Menu text vertical className="bo-menu">
           <Menu.Item as={Link} to={FrontSiteRoutes.home}>
             Go to Home Page
           </Menu.Item>
         </Menu>
+        <AuthenticationGuard
+          silent={true}
+          authorizedComponent={() => <AdminMenu />}
+          roles={['admin']}
+          loginComponent={() => <></>}
+        />
       </>
     );
   }

--- a/ui/src/pages/frontsite/StaticPage/StaticPage.js
+++ b/ui/src/pages/frontsite/StaticPage/StaticPage.js
@@ -1,0 +1,49 @@
+import { Error } from '@components';
+import {
+  ILSHeaderPlaceholder,
+  ILSParagraphPlaceholder,
+} from '@components/ILSPlaceholder';
+import { getStaticPageByRoute } from '@config/uiConfig';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Container, Header } from 'semantic-ui-react';
+import _isEmpty from 'lodash/isEmpty';
+
+export default class StaticPage extends Component {
+  componentDidMount() {
+    const staticPage = getStaticPageByRoute(this.props.match.path);
+    const staticPageID = staticPage['apiURL'];
+    this.props.fetchStaticPageDetails(staticPageID);
+  }
+
+  parseStaticPageContent = () => {
+    const { data } = this.props;
+    if (!_isEmpty(data)) {
+      return (
+        <div dangerouslySetInnerHTML={{ __html: data.content }} />
+      );
+    }
+    return null;
+  };
+
+  render() {
+    const { isLoading, error, data } = this.props;
+
+    return (
+      <Error boundary error={error}>
+        <Container className="spaced">
+          <ILSHeaderPlaceholder fluid isLoading={isLoading} image="false">
+            <Header as="h1">{data.title}</Header>
+          </ILSHeaderPlaceholder>
+          <ILSParagraphPlaceholder fluid isLoading={isLoading} linesNumber={30}>
+            {this.parseStaticPageContent(data.content)}
+          </ILSParagraphPlaceholder>
+        </Container>
+      </Error>
+    );
+  }
+}
+
+StaticPage.propTypes = {
+  fetchStaticPageDetails: PropTypes.func.isRequired,
+};

--- a/ui/src/pages/frontsite/StaticPage/index.js
+++ b/ui/src/pages/frontsite/StaticPage/index.js
@@ -1,0 +1,18 @@
+import { connect } from 'react-redux';
+import { fetchStaticPageDetails } from './state/actions';
+import StaticPageComponent from './StaticPage';
+
+const mapDispatchToProps = dispatch => ({
+  fetchStaticPageDetails: pageID => dispatch(fetchStaticPageDetails(pageID)),
+});
+
+const mapStateToProps = state => ({
+  isLoading: state.staticPage.isLoading,
+  data: state.staticPage.data,
+  hasError: state.staticPage.hasError,
+});
+
+export const StaticPage = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(StaticPageComponent);

--- a/ui/src/pages/frontsite/StaticPage/reducer.js
+++ b/ui/src/pages/frontsite/StaticPage/reducer.js
@@ -1,0 +1,1 @@
+export {default as staticPageReducer} from './state/reducer';

--- a/ui/src/pages/frontsite/StaticPage/state/actions.js
+++ b/ui/src/pages/frontsite/StaticPage/state/actions.js
@@ -1,0 +1,23 @@
+import { IS_LOADING, SUCCESS, HAS_ERROR } from './types';
+import { page as pageApi } from '@api';
+
+export const fetchStaticPageDetails = pageID => {
+  return async dispatch => {
+    dispatch({
+      type: IS_LOADING,
+    });
+
+    try {
+      const response = await pageApi.get(pageID);
+      dispatch({
+        type: SUCCESS,
+        payload: response.data,
+      });
+    } catch (error) {
+      dispatch({
+        type: HAS_ERROR,
+        payload: error,
+      });
+    }
+  };
+};

--- a/ui/src/pages/frontsite/StaticPage/state/reducer.js
+++ b/ui/src/pages/frontsite/StaticPage/state/reducer.js
@@ -1,0 +1,31 @@
+import { IS_LOADING, SUCCESS, HAS_ERROR} from './types';
+
+export const initialState = {
+  isLoading: true,
+  hasError: false,
+  data: { },
+};
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case IS_LOADING:
+      return { ...state, isLoading: true };
+    case SUCCESS:
+      return {
+        ...state,
+        isLoading: false,
+        data: action.payload,
+        error: {},
+        hasError: false,
+      };
+    case HAS_ERROR:
+      return {
+        ...state,
+        isLoading: false,
+        error: action.payload,
+        hasError: true,
+      };
+    default:
+      return state;
+  }
+};

--- a/ui/src/pages/frontsite/StaticPage/state/types.js
+++ b/ui/src/pages/frontsite/StaticPage/state/types.js
@@ -1,0 +1,3 @@
+export const IS_LOADING = 'fetchStaticPage/IS_LOADING';
+export const SUCCESS = 'fetchStaticPage/SUCCESS';
+export const HAS_ERROR = 'fetchStaticPage/HAS_ERROR';

--- a/ui/src/pages/frontsite/components/Footer/Footer.js
+++ b/ui/src/pages/frontsite/components/Footer/Footer.js
@@ -1,42 +1,66 @@
+import { getStaticPageByName } from '@config/uiConfig';
 import React, { Component } from 'react';
-import { Container, Grid, Header } from 'semantic-ui-react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { Container, Grid, Header, List } from 'semantic-ui-react';
 
 export default class Footer extends Component {
   render() {
     return (
       <footer>
-        <Container fluid className="footer-upper">
-          <Container>
-            <Grid columns={3} stackable>
-              <Grid.Column>
-                <Header as="h4" content={'Address'} />
-                <p>
-                  Library
-                  <br />
-                  Address line 1 <br />
-                  Address line 2 <br />
-                  Phone: +41 00 000 000
-                </p>
-              </Grid.Column>
-              <Grid.Column>
-                <Header as="h4" content={'Opening hours'} />
-                <p>
-                  Open 24 hours a day, every day of the year <br />
-                  Staffed from 8.30 to 19.00, Monday-Friday
-                </p>
-              </Grid.Column>
-            </Grid>
-          </Container>
-        </Container>
-        <Container fluid className="footer-lower">
-          <Container>
-            <Header as="h4" textAlign={'center'}>
-              <Header.Content>Integrated Library System</Header.Content>
-              <Header.Subheader>Powered by INVENIO</Header.Subheader>
-            </Header>
-          </Container>
-        </Container>
+        {this.props.renderElement ? (
+          this.props.renderElement()
+        ) : (
+          <>
+            <Container fluid className="footer-upper">
+              <Container>
+                <Grid columns={2} stackable>
+                  <Grid.Column>
+                    <Header as="h4" content={'More information'} />
+                    <List>
+                      <List.Item>
+                        <Link to={getStaticPageByName('about').route}>
+                          About
+                        </Link>
+                      </List.Item>
+                      <List.Item>
+                        <Link to={getStaticPageByName('contact').route}>
+                          Contact
+                        </Link>
+                      </List.Item>
+                    </List>
+                  </Grid.Column>
+                  <Grid.Column>
+                    <Header as="h4" content={'Invenio'} />
+                    <p>
+                      Read more about us on: <br />
+                      <a
+                        href="https://inveniosoftware.org/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        https://inveniosoftware.org/
+                      </a>
+                    </p>
+                  </Grid.Column>
+                </Grid>
+              </Container>
+            </Container>
+            <Container fluid className="footer-lower">
+              <Container>
+                <Header as="h4" textAlign={'center'}>
+                  <Header.Content>Integrated Library System</Header.Content>
+                  <Header.Subheader>Powered by INVENIO</Header.Subheader>
+                </Header>
+              </Container>
+            </Container>
+          </>
+        )}
       </footer>
     );
   }
 }
+
+Footer.propTypes = {
+  renderElement: PropTypes.func,
+};

--- a/ui/src/routes/components/BackOffice/BackOfficeRoutesSwitch.js
+++ b/ui/src/routes/components/BackOffice/BackOfficeRoutesSwitch.js
@@ -1,3 +1,4 @@
+import { NotFound } from '@components';
 import React, { Component } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import { BackOfficeRoutes, AcquisitionRoutes, ILLRoutes } from '@routes/urls';
@@ -248,6 +249,9 @@ export default class extends Component {
           component={BorrowingRequestDetails}
         />
         <Route exact path={BackOfficeRoutes.stats.home} component={Stats} />
+        <Route>
+          <NotFound />
+        </Route>
       </Switch>
     );
   }

--- a/ui/src/routes/components/FrontSite/FrontSite.js
+++ b/ui/src/routes/components/FrontSite/FrontSite.js
@@ -1,6 +1,9 @@
+import { NotFound } from '@components';
+import { getStaticPagesRoutes } from '@config/uiConfig';
+import { StaticPage } from '@pages/frontsite/StaticPage';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Route } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
 import { FrontSiteRoutes } from '../../urls';
 import { Footer, ILSMenu, Home, PatronProfile } from '@pages/frontsite';
 import { Container } from 'semantic-ui-react';
@@ -16,42 +19,55 @@ import { DocumentRequestForm } from '@pages/frontsite/DocumentRequests';
 import { SeriesDetailsContainer } from '@pages/frontsite/Series';
 
 export default class FrontSite extends Component {
+  renderCustomStaticPages = () =>
+    this.props.customStaticPages ? this.props.customStaticPages() : null;
+
   render() {
+    const staticPagesRoutes = getStaticPagesRoutes();
     return (
       <div className="frontsite">
         <ILSMenu />
         <Notifications className="compact" />
         <Container fluid className="fs-content">
-          <Route
-            exact
-            path={FrontSiteRoutes.home}
-            render={props => <Home {...props} {...this.props} />}
-          />
-          <Route
-            exact
-            path={FrontSiteRoutes.documentsList}
-            component={DocumentsSearch}
-          />
-          <Route
-            exact
-            path={FrontSiteRoutes.patronProfile}
-            component={PatronProfile}
-          />
-          <Route
-            exact
-            path={FrontSiteRoutes.documentRequestForm}
-            component={DocumentRequestForm}
-          />
-          <Route
-            exact
-            path={FrontSiteRoutes.seriesDetails}
-            component={SeriesDetailsContainer}
-          />
-          <Route
-            exact
-            path={FrontSiteRoutes.documentDetails}
-            component={DocumentsDetailsContainer}
-          />
+          <Switch>
+            <Route
+              exact
+              path={FrontSiteRoutes.home}
+              render={props => <Home {...props} {...this.props} />}
+            />
+            <Route
+              exact
+              path={FrontSiteRoutes.documentsList}
+              component={DocumentsSearch}
+            />
+            <Route
+              exact
+              path={FrontSiteRoutes.patronProfile}
+              component={PatronProfile}
+            />
+            <Route
+              exact
+              path={FrontSiteRoutes.documentRequestForm}
+              component={DocumentRequestForm}
+            />
+            <Route
+              exact
+              path={FrontSiteRoutes.seriesDetails}
+              component={SeriesDetailsContainer}
+            />
+            <Route
+              exact
+              path={FrontSiteRoutes.documentDetails}
+              component={DocumentsDetailsContainer}
+            />
+            {staticPagesRoutes.map(route => (
+              <Route key={route} exact path={route} component={StaticPage} />
+            ))}
+            {this.renderCustomStaticPages()}
+            <Route>
+              <NotFound />
+            </Route>
+          </Switch>
         </Container>
         <Footer />
       </div>
@@ -63,4 +79,5 @@ FrontSite.propTypes = {
   headline: PropTypes.func,
   headlineImage: PropTypes.string,
   sections: PropTypes.array,
+  customStaticPages: PropTypes.func,
 };

--- a/ui/src/routes/urls.js
+++ b/ui/src/routes/urls.js
@@ -1,5 +1,12 @@
 import { generatePath } from 'react-router-dom';
 
+const adminConfig = {
+  baseURL:
+    process.env.NODE_ENV === 'production'
+      ? '/admin'
+      : `${process.env.REACT_APP_BACKEND_DEV_BASE_URL}/admin`,
+};
+
 const AuthenticationBase = '/';
 
 const AuthenticationRoutesList = {
@@ -205,6 +212,11 @@ const ILLRoutesGenerators = {
 export const ILLRoutes = {
   ...ILLRoutesList,
   ...ILLRoutesGenerators,
+};
+
+export const adminRoutes = {
+  admin: adminConfig.baseURL,
+  staticPages: `${adminConfig.baseURL}/pages`,
 };
 
 export const DetailsRouteByPidTypeFor = pidType => {

--- a/ui/src/store.js
+++ b/ui/src/store.js
@@ -1,5 +1,6 @@
 import { recordRelationsReducer } from '@pages/backoffice/components/Relations/reducer';
 import { relationSelectorReducer } from '@pages/backoffice/components/Relations/reducer';
+import {staticPageReducer} from "@pages/frontsite/StaticPage/reducer";
 import { createStore, applyMiddleware, combineReducers } from 'redux';
 import { composeWithDevTools } from 'redux-devtools-extension';
 import thunk from 'redux-thunk';
@@ -120,6 +121,7 @@ const rootReducer = combineReducers({
   seriesDocuments: seriesDocumentsReducer,
   seriesMultipartMonographs: seriesMultipartMonographsReducer,
   seriesRelations: seriesRelationsReducer,
+  staticPage: staticPageReducer,
   statsMostLoanedDocuments: mostLoanedDocumentsReducer,
   vendorDetails: vendorDetailsReducer,
 });


### PR DESCRIPTION
* closes #772

* footer is fully overridable, IMO its very custom so it does not make sense to override parts of it - it is overridable in the same way as react-searchkit


Decisions taken
----------
1. decided not to overwrite the individual pages as react components - every time changing the content of such a page would require a deployment of react app. Instead the pages will be fetched from invenio-pages, where static page can be easily edited, with a simple formatting editor included
2. overridable component will be the footer of the frontsite
3. custom pages (from any overlay) will be added as a param to the routing 
4. override was implemented like in the react-searchkit. I think we should discuss in detail the id approach proposed by indico first.


Loading:
<img width="1717" alt="Screenshot 2020-04-09 at 14 33 18" src="https://user-images.githubusercontent.com/38131488/78895547-54bf4080-7a6f-11ea-8803-a246d43b203a.png">
Loaded:
<img width="1722" alt="Screenshot 2020-04-09 at 14 33 31" src="https://user-images.githubusercontent.com/38131488/78895554-5852c780-7a6f-11ea-9c5d-1f70efefb4d4.png">
