### PR TITLE
global: compatibility agg/sort fields with es mappings text

### DIFF
--- a/invenio_app_ils/acquisition/config.py
+++ b/invenio_app_ils/acquisition/config.py
@@ -136,7 +136,10 @@ RECORDS_REST_SORT_OPTIONS = dict(
     ),
     acq_vendors=dict(  # VendorSearch.Meta.index
         name=dict(
-            fields=["name"], title="Name", default_order="desc", order=1
+            fields=["name.keyword"],
+            title="Name",
+            default_order="desc",
+            order=1
         ),
         bestmatch=dict(
             fields=["-_score"],

--- a/invenio_app_ils/acquisition/mappings/v6/acq_vendors/vendor-v1.0.0.json
+++ b/invenio_app_ils/acquisition/mappings/v6/acq_vendors/vendor-v1.0.0.json
@@ -20,6 +20,11 @@
           "type": "text"
         },
         "name": {
+          "fields": {
+            "keyword": {
+              "type": "keyword"
+            }
+          },
           "type": "text"
         },
         "notes": {

--- a/invenio_app_ils/acquisition/mappings/v7/acq_vendors/vendor-v1.0.0.json
+++ b/invenio_app_ils/acquisition/mappings/v7/acq_vendors/vendor-v1.0.0.json
@@ -19,6 +19,11 @@
         "type": "text"
       },
       "name": {
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        },
         "type": "text"
       },
       "notes": {

--- a/invenio_app_ils/ill/config.py
+++ b/invenio_app_ils/ill/config.py
@@ -147,7 +147,10 @@ RECORDS_REST_SORT_OPTIONS = dict(
     ),
     ill_libraries=dict(  # LibrarySearch.Meta.index
         name=dict(
-            fields=["name"], title="Name", default_order="desc", order=1
+            fields=["name.keyword"],
+            title="Name",
+            default_order="desc",
+            order=1
         ),
         bestmatch=dict(
             fields=["-_score"],

--- a/invenio_app_ils/ill/mappings/v6/ill_libraries/library-v1.0.0.json
+++ b/invenio_app_ils/ill/mappings/v6/ill_libraries/library-v1.0.0.json
@@ -20,6 +20,11 @@
           "type": "text"
         },
         "name": {
+          "fields": {
+            "keyword": {
+              "type": "keyword"
+            }
+          },
           "type": "text"
         },
         "notes": {

--- a/invenio_app_ils/ill/mappings/v7/ill_libraries/library-v1.0.0.json
+++ b/invenio_app_ils/ill/mappings/v7/ill_libraries/library-v1.0.0.json
@@ -19,6 +19,11 @@
         "type": "text"
       },
       "name": {
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        },
         "type": "text"
       },
       "notes": {


### PR DESCRIPTION
@kprzerwa the following configuration will be required to enable them correctly in the moved `searchConfig.js`
```
const searchConfig = {
  ...
  acqVendors: {
    filters: [],
    sortBy: {
      onEmptyQuery: "bestmatch",
      values: [
        {
          default_order: "asc",
          field: "name.keyword",
          order: 1,
          title: "Name",
        },
        {
          default_order: "asc",
          field: "bestmatch",
          order: 2,
          title: "Best match",
        },
      ],
    },
    sortOrder: ["asc", "desc"],
  },
  ...
};
```