### PR TITLE
global: extensions customized RDM solution

### DIFF
--- a/invenio_app_ils/cli.py
+++ b/invenio_app_ils/cli.py
@@ -345,6 +345,13 @@ class DocumentGenerator(Generator):
         obj = {
             "pid": self.create_pid(),
             "title": lorem.sentence(),
+            "extensions": {
+                "accelerator_experiments:accelerator": "LHCb",
+                "accelerator_experiments:institution": "CERN",
+                "accelerator_experiments:project": "Myon energy detection",
+                "standard_status:CERN_applicability": "applicable",
+                "standard_status:standard_validity": "published"
+            },
             "cover_metadata": {"ISBN": random.choice(self.ISBNS), "urls": {}},
             "authors": random.sample(self.AUTHORS, randint(1, 3)),
             "abstract": "{}".format(lorem.text()),

--- a/invenio_app_ils/cli.py
+++ b/invenio_app_ils/cli.py
@@ -345,13 +345,6 @@ class DocumentGenerator(Generator):
         obj = {
             "pid": self.create_pid(),
             "title": lorem.sentence(),
-            "extensions": {
-                "accelerator_experiments:accelerator": "LHCb",
-                "accelerator_experiments:institution": "CERN",
-                "accelerator_experiments:project": "Myon energy detection",
-                "standard_status:CERN_applicability": "applicable",
-                "standard_status:standard_validity": "published"
-            },
             "cover_metadata": {"ISBN": random.choice(self.ISBNS), "urls": {}},
             "authors": random.sample(self.AUTHORS, randint(1, 3)),
             "abstract": "{}".format(lorem.text()),

--- a/invenio_app_ils/config.py
+++ b/invenio_app_ils/config.py
@@ -15,14 +15,12 @@ You overwrite and set instance-specific configuration by either:
 
 from __future__ import absolute_import, print_function
 
-from collections import namedtuple
 from datetime import timedelta
 
 from invenio_accounts.config import \
     ACCOUNTS_REST_AUTH_VIEWS as _ACCOUNTS_REST_AUTH_VIEWS
 from invenio_app.config import APP_DEFAULT_SECURE_HEADERS
 from invenio_oauthclient.contrib import cern
-from invenio_pidrelations.config import RelationType
 from invenio_records_rest.facets import terms_filter
 from invenio_records_rest.schemas.fields import SanitizedUnicode
 from invenio_records_rest.utils import allow_all, deny_all
@@ -1036,67 +1034,8 @@ ILS_DEFAULT_LOCATION_PID = "1"
 ILS_LITERATURE_COVER_URLS_BUILDER = build_ils_demo_cover_urls
 """Default implementation for building cover urls in document serializer."""
 
-# Namespaces for fields *added* to the metadata schema.
-ILS_RECORDS_METADATA_NAMESPACES = {
-    "series": {
-        "serial": {
-            "@context": "https://example.com/serial/terms"
-        },
-    },
-    "document": {
-        "accelerator_experiments": {
-            "@context": "https://example.com/accelerator_experiments/terms"
-        },
-        "standard_status": {
-            "@context": "https://example.com/standard_status/terms"
-        },
-    }
-}
+# Namespaces for fields added to the metadata schema
+ILS_RECORDS_METADATA_NAMESPACES = {}
 
 # Fields added to the metadata schema.
-ILS_RECORDS_METADATA_EXTENSIONS = {
-    "series": {
-        "serial:number": {
-            "elasticsearch": "keyword",
-            "marshmallow": SanitizedUnicode()
-        },
-    },
-    "document": {
-        "accelerator_experiments:accelerator": {
-            "elasticsearch": "keyword",
-            "marshmallow": SanitizedUnicode()
-        },
-        "accelerator_experiments:curated_relation": {
-            "elasticsearch": "boolean",
-            "marshmallow": Bool()
-        },
-        "accelerator_experiments:experiment": {
-            "elasticsearch": "keyword",
-            "marshmallow": SanitizedUnicode()
-        },
-        "accelerator_experiments:institution": {
-            "elasticsearch": "keyword",
-            "marshmallow": SanitizedUnicode()
-        },
-        "accelerator_experiments:legacy_name": {
-            "elasticsearch": "keyword",
-            "marshmallow": SanitizedUnicode()
-        },
-        "accelerator_experiments:project": {
-            "elasticsearch": "keyword",
-            "marshmallow": SanitizedUnicode()
-        },
-        "accelerator_experiments:study": {
-            "elasticsearch": "keyword",
-            "marshmallow": SanitizedUnicode()
-        },
-        "standard_status:CERN_applicability": {
-            "elasticsearch": "keyword",
-            "marshmallow": SanitizedUnicode()
-        },
-        "standard_status:standard_validity": {
-            "elasticsearch": "keyword",
-            "marshmallow": SanitizedUnicode(required=True)
-        },
-    }
-}
+ILS_RECORDS_METADATA_EXTENSIONS = {}

--- a/invenio_app_ils/config.py
+++ b/invenio_app_ils/config.py
@@ -24,10 +24,12 @@ from invenio_app.config import APP_DEFAULT_SECURE_HEADERS
 from invenio_oauthclient.contrib import cern
 from invenio_pidrelations.config import RelationType
 from invenio_records_rest.facets import terms_filter
+from invenio_records_rest.schemas.fields import SanitizedUnicode
 from invenio_records_rest.utils import allow_all, deny_all
 from invenio_stats.aggregations import StatAggregator
 from invenio_stats.processors import EventsIndexer
 from invenio_stats.queries import ESTermsQuery
+from marshmallow.fields import Bool
 
 from invenio_app_ils.document_requests.indexer import DocumentRequestIndexer
 from invenio_app_ils.documents.indexer import DocumentIndexer
@@ -1033,3 +1035,68 @@ ILS_DEFAULT_LOCATION_PID = "1"
 
 ILS_LITERATURE_COVER_URLS_BUILDER = build_ils_demo_cover_urls
 """Default implementation for building cover urls in document serializer."""
+
+# Namespaces for fields *added* to the metadata schema.
+ILS_RECORDS_METADATA_NAMESPACES = {
+    "series": {
+        "serial": {
+            "@context": "https://example.com/serial/terms"
+        },
+    },
+    "document": {
+        "accelerator_experiments": {
+            "@context": "https://example.com/accelerator_experiments/terms"
+        },
+        "standard_status": {
+            "@context": "https://example.com/standard_status/terms"
+        },
+    }
+}
+
+# Fields added to the metadata schema.
+ILS_RECORDS_METADATA_EXTENSIONS = {
+    "series": {
+        "serial:number": {
+            "elasticsearch": "keyword",
+            "marshmallow": SanitizedUnicode()
+        },
+    },
+    "document": {
+        "accelerator_experiments:accelerator": {
+            "elasticsearch": "keyword",
+            "marshmallow": SanitizedUnicode()
+        },
+        "accelerator_experiments:curated_relation": {
+            "elasticsearch": "boolean",
+            "marshmallow": Bool()
+        },
+        "accelerator_experiments:experiment": {
+            "elasticsearch": "keyword",
+            "marshmallow": SanitizedUnicode()
+        },
+        "accelerator_experiments:institution": {
+            "elasticsearch": "keyword",
+            "marshmallow": SanitizedUnicode()
+        },
+        "accelerator_experiments:legacy_name": {
+            "elasticsearch": "keyword",
+            "marshmallow": SanitizedUnicode()
+        },
+        "accelerator_experiments:project": {
+            "elasticsearch": "keyword",
+            "marshmallow": SanitizedUnicode()
+        },
+        "accelerator_experiments:study": {
+            "elasticsearch": "keyword",
+            "marshmallow": SanitizedUnicode()
+        },
+        "standard_status:CERN_applicability": {
+            "elasticsearch": "keyword",
+            "marshmallow": SanitizedUnicode()
+        },
+        "standard_status:standard_validity": {
+            "elasticsearch": "keyword",
+            "marshmallow": SanitizedUnicode(required=True)
+        },
+    }
+}

--- a/invenio_app_ils/documents/loaders/jsonschemas/document.py
+++ b/invenio_app_ils/documents/loaders/jsonschemas/document.py
@@ -231,7 +231,9 @@ class DocumentSchemaV1(RecordMetadataSchemaJSONV1):
 
         :params obj: content of the object's 'extensions' field
         """
-        ExtensionSchema = current_app.document_metadata_extensions.to_schema()
+        ExtensionSchema = current_app.extensions["invenio-app-ils"] \
+                                     .document_metadata_extensions \
+                                     .to_schema()
         return ExtensionSchema().dump(obj)
 
     def load_extensions(self, value):
@@ -239,7 +241,9 @@ class DocumentSchemaV1(RecordMetadataSchemaJSONV1):
 
         :params value: content of the input's 'extensions' field
         """
-        ExtensionSchema = current_app.document_metadata_extensions.to_schema()
+        ExtensionSchema = current_app.extensions["invenio-app-ils"] \
+                                     .document_metadata_extensions \
+                                     .to_schema()
         return ExtensionSchema().load(value)
 
     @pre_load

--- a/invenio_app_ils/documents/loaders/jsonschemas/document.py
+++ b/invenio_app_ils/documents/loaders/jsonschemas/document.py
@@ -7,6 +7,7 @@
 
 """Document schema for marshmallow loader."""
 
+from flask import current_app
 from invenio_records_rest.schemas import RecordMetadataSchemaJSONV1
 from marshmallow import EXCLUDE, Schema, fields, pre_load
 
@@ -204,6 +205,7 @@ class DocumentSchemaV1(RecordMetadataSchemaJSONV1):
     curated = fields.Bool()
     document_type = fields.Str()
     edition = fields.Str()
+    extensions = fields.Method('dump_extensions', 'load_extensions')
     identifiers = fields.List(fields.Nested(IdentifierSchema))
     imprint = fields.Nested(ImprintSchema)
     internal_notes = fields.List(fields.Nested(InternalNoteSchema))
@@ -223,6 +225,22 @@ class DocumentSchemaV1(RecordMetadataSchemaJSONV1):
     title = fields.Str(required=True)
     updated_by = fields.Nested(ChangedBySchema)
     urls = fields.List(fields.Nested(UrlSchema))
+
+    def dump_extensions(self, obj):
+        """Dumps the extensions value.
+
+        :params obj: content of the object's 'extensions' field
+        """
+        ExtensionSchema = current_app.document_metadata_extensions.to_schema()
+        return ExtensionSchema().dump(obj)
+
+    def load_extensions(self, value):
+        """Loads the 'extensions' field.
+
+        :params value: content of the input's 'extensions' field
+        """
+        ExtensionSchema = current_app.document_metadata_extensions.to_schema()
+        return ExtensionSchema().load(value)
 
     @pre_load
     def preload_fields(self, data, **kwargs):

--- a/invenio_app_ils/documents/mappings/v6/documents/document-v1.0.0.json
+++ b/invenio_app_ils/documents/mappings/v6/documents/document-v1.0.0.json
@@ -128,6 +128,46 @@
           },
           "type": "object"
         },
+        "extensions": {
+          "type": "object",
+          "dynamic": false,
+          "enabled": false
+        },
+        "extensions_keywords": {
+          "type": "object",
+          "properties": {
+            "key": { "type": "keyword" },
+            "value": { "type": "keyword" }
+          }
+        },
+        "extensions_texts": {
+          "type": "object",
+          "properties": {
+            "key": { "type": "keyword" },
+            "value": { "type": "text" }
+          }
+        },
+        "extensions_longs": {
+          "type": "object",
+          "properties": {
+            "key": { "type": "keyword" },
+            "value": { "type": "long" }
+          }
+        },
+        "extensions_dates": {
+          "type": "object",
+          "properties": {
+            "key": { "type": "keyword" },
+            "value": { "type": "date" }
+          }
+        },
+        "extensions_booleans": {
+          "type": "object",
+          "properties": {
+            "key": { "type": "keyword" },
+            "value": { "type": "boolean" }
+          }
+        },
         "items": {
           "properties": {
             "hits": {

--- a/invenio_app_ils/documents/mappings/v7/documents/document-v1.0.0.json
+++ b/invenio_app_ils/documents/mappings/v7/documents/document-v1.0.0.json
@@ -127,6 +127,46 @@
         },
         "type": "object"
       },
+      "extensions": {
+        "type": "object",
+        "dynamic": false,
+        "enabled": false
+      },
+      "extensions_keywords": {
+        "type": "object",
+        "properties": {
+          "key": { "type": "keyword" },
+          "value": { "type": "keyword" }
+        }
+      },
+      "extensions_texts": {
+        "type": "object",
+        "properties": {
+          "key": { "type": "keyword" },
+          "value": { "type": "text" }
+        }
+      },
+      "extensions_longs": {
+        "type": "object",
+        "properties": {
+          "key": { "type": "keyword" },
+          "value": { "type": "long" }
+        }
+      },
+      "extensions_dates": {
+        "type": "object",
+        "properties": {
+          "key": { "type": "keyword" },
+          "value": { "type": "date" }
+        }
+      },
+      "extensions_booleans": {
+        "type": "object",
+        "properties": {
+          "key": { "type": "keyword" },
+          "value": { "type": "boolean" }
+        }
+      },
       "items": {
         "properties": {
           "hits": {

--- a/invenio_app_ils/documents/schemas/documents/document-v1.0.0.json
+++ b/invenio_app_ils/documents/schemas/documents/document-v1.0.0.json
@@ -298,6 +298,23 @@
       },
       "type": "object"
     },
+    "extensions": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "array",
+            "items": {
+              "type": ["boolean", "number", "string"]
+            }
+          },
+          { "type": "boolean" },
+          { "type": "number" },
+          { "type": "string" }
+        ]
+      },
+      "description": "Configured additional metadata",
+      "type": "object"
+    },
     "extra_data": {
       "type": "object"
     },

--- a/invenio_app_ils/ext.py
+++ b/invenio_app_ils/ext.py
@@ -19,7 +19,6 @@ from werkzeug.utils import cached_property
 from invenio_app_ils.records.metadata_extensions import MetadataExtensions, \
     add_es_metadata_extensions
 
-from . import config
 from .circulation import config as circulation_config
 from .circulation.receivers import register_circulation_signals
 from .document_requests.api import DOCUMENT_REQUEST_PID_TYPE
@@ -166,19 +165,6 @@ class _InvenioAppIlsState(object):
         return self.indexer_by_pid_type(SERIES_PID_TYPE)
 
 
-def before_record_index_hook(
-        sender, json=None, record=None, index=None, **kwargs):
-    """Hook to transform Deposits before indexing in ES.
-
-    :param sender: The entity sending the signal.
-    :param json: The dumped Record dict which will be indexed.
-    :param record: The correspondng Record object.
-    :param index: The index in which the json will be indexed.
-    :param kwargs: Any other parameters.
-    """
-    add_es_metadata_extensions(json, kwargs["record_type"])  # mutates json
-
-
 class InvenioAppIls(object):
     """Invenio App ILS UI app."""
 
@@ -206,23 +192,19 @@ class InvenioAppIls(object):
 
     def init_metadata_extensions(self, app):
         """Metadata extensions initialization."""
-        allowed_types = ["document", "series"]
-
-        for rec_type in allowed_types:
+        for rec_type in app.config['ILS_RECORDS_METADATA_EXTENSIONS'].keys():
             namespaces = \
                 app.config['ILS_RECORDS_METADATA_NAMESPACES'].get(rec_type, {})
             extensions = \
                 app.config['ILS_RECORDS_METADATA_EXTENSIONS'].get(rec_type, {})
-
             setattr(
-                self,
+                app.extensions["invenio-app-ils"],
                 "{}_metadata_extensions".format(rec_type),
                 MetadataExtensions(namespaces, extensions)
             )
-
             before_record_index.dynamic_connect(
                 before_record_index_hook, sender=app, weak=False,
-                index="{0}s-{0}-v1.0.0".format(rec_type), record_type=rec_type
+                index="{0}s-{0}-v1.0.0".format(rec_type)
             )
 
     def update_config_records_rest(self, app):
@@ -250,3 +232,16 @@ class InvenioAppIlsREST(InvenioAppIls):
         """Register signals."""
         register_circulation_signals()
         register_files_signals()
+
+
+def before_record_index_hook(
+        sender, json=None, record=None, index=None, **kwargs):
+    """Hook to transform record before indexing in ES.
+
+    :param sender: The entity sending the signal.
+    :param json: The dumped Record dict which will be indexed.
+    :param record: The correspondng Record object.
+    :param index: The index in which the json will be indexed.
+    :param kwargs: Any other parameters.
+    """
+    add_es_metadata_extensions(json)  # mutates json

--- a/invenio_app_ils/records/loaders/schemas/json/series.py
+++ b/invenio_app_ils/records/loaders/schemas/json/series.py
@@ -7,6 +7,7 @@
 
 """Series schema for marshmallow loader."""
 
+from flask import current_app
 from invenio_records_rest.schemas import RecordMetadataSchemaJSONV1
 from invenio_records_rest.schemas.fields import PersistentIdentifier
 from marshmallow import EXCLUDE, Schema, fields, pre_load
@@ -49,6 +50,7 @@ class SeriesSchemaV1(RecordMetadataSchemaJSONV1):
     cover_metadata = fields.Dict()
     created_by = fields.Nested(ChangedBySchema)
     edition = fields.Str()
+    extensions = fields.Method('dump_extensions', 'load_extensions')
     identifiers = fields.Nested(IdentifierSchema, many=True)
     internal_notes = fields.Nested(InternalNoteSchema, many=True)
     isbn = fields.List(fields.Str())
@@ -62,6 +64,22 @@ class SeriesSchemaV1(RecordMetadataSchemaJSONV1):
     title = fields.Str(required=True)
     updated_by = fields.Nested(ChangedBySchema)
     urls = fields.Nested(UrlSchema, many=True)
+
+    def dump_extensions(self, obj):
+        """Dumps the extensions value.
+
+        :params obj: content of the object's 'extensions' field
+        """
+        ExtensionSchema = current_app.series_metadata_extensions.to_schema()
+        return ExtensionSchema().dump(obj)
+
+    def load_extensions(self, value):
+        """Loads the 'extensions' field.
+
+        :params value: content of the input's 'extensions' field
+        """
+        ExtensionSchema = current_app.series_metadata_extensions.to_schema()
+        return ExtensionSchema().load(value)
 
     @pre_load
     def preload_fields(self, data, **kwargs):

--- a/invenio_app_ils/records/metadata_extensions.py
+++ b/invenio_app_ils/records/metadata_extensions.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2018-2020 CERN.
+#
+# invenio-app-ils is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Metadata Extensions."""
+
+from copy import deepcopy
+
+from flask import current_app
+from invenio_records_rest.schemas.fields import DateString, SanitizedUnicode
+from marshmallow import Schema
+from marshmallow.fields import Bool, Integer, List
+
+
+class MetadataExtensions(object):
+    """Custom metadata extensions helper class."""
+
+    def __init__(self, namespaces, extensions):
+        """Constructor."""
+        self.namespaces = deepcopy(namespaces) or {}
+        self.extensions = deepcopy(extensions) or {}
+        self._validate()
+
+    def _validate_marshmallow_type(self, field_cfg):
+        """Make sure the Marshmallow type is one we support."""
+        def validate_basic_marshmallow_type(_type):
+            allowed_types = [
+                Bool, DateString, Integer, SanitizedUnicode
+            ]
+            assert any([
+                isinstance(_type, allowed_type) for allowed_type
+                in allowed_types
+            ])
+
+        marshmallow_type = field_cfg["marshmallow"]
+        if isinstance(marshmallow_type, List):
+            validate_basic_marshmallow_type(marshmallow_type.inner)
+        else:
+            validate_basic_marshmallow_type(marshmallow_type)
+
+    def _validate_elasticsearch_type(self, field_cfg):
+        """Make sure the Elasticsearch type is one we support."""
+        allowed_types = [
+            "boolean", "date", "long", "keyword", "text"
+        ]
+        assert field_cfg["elasticsearch"] in allowed_types
+
+    def _validate(self):
+        """Validates extension configuration.
+
+        We only allow certain types, so this private method flags divergence
+        from what is allowed early.
+        """
+        # Validate namespaces
+        contexts = set()
+        for settings in self.namespaces.values():
+            assert settings["@context"] not in contexts
+            contexts.add(settings["@context"])
+
+        # Validate extensions
+        prefixes = self.namespaces.keys()
+        for field_key, field_cfg in self.extensions.items():
+            prefix = field_key.split(":", 1)[0]
+            assert prefix in prefixes
+            self._validate_marshmallow_type(field_cfg)
+            self._validate_elasticsearch_type(field_cfg)
+
+    def to_schema(self):
+        """Dynamically creates and returns the extensions Schema."""
+        schema_dict = {
+            field_key: field_cfg["marshmallow"]
+            for field_key, field_cfg in self.extensions.items()
+        }
+        return Schema.from_dict(schema_dict)
+
+    def get_field_type(self, field_key, _type):
+        """Returns type value for given field_key and _type.
+
+        :params field_key: str formatted as <prefix>:<field_id>
+        :params _type: str "elasticsearch" or "marshmallow"
+        """
+        return (
+            self.extensions
+                .get(field_key, {})
+                .get(_type)
+        )
+
+
+def add_es_metadata_extensions(record_dict, record_type):
+    """Add "extensions_X" fields to record_dict prior to Elasticsearch index.
+
+    :param record_dict: dumped Record dict
+    :param record_type: Record type
+    """
+    metadata_extensions = current_app.get(
+        "{}_metadata_extensions".format(record_type)
+    )
+
+    for key, value in record_dict.get("extensions", {}).items():
+        field_type = metadata_extensions.get_field_type(key, "elasticsearch")
+        if not field_type:
+            continue
+
+        es_field = "extensions_{}s".format(field_type)
+
+        if es_field not in record_dict:
+            record_dict[es_field] = []
+
+        record_dict[es_field].append({"key": key, "value": value})

--- a/invenio_app_ils/records/metadata_extensions.py
+++ b/invenio_app_ils/records/metadata_extensions.py
@@ -89,14 +89,15 @@ class MetadataExtensions(object):
         )
 
 
-def add_es_metadata_extensions(record_dict, record_type):
+def add_es_metadata_extensions(record_dict):
     """Add "extensions_X" fields to record_dict prior to Elasticsearch index.
 
     :param record_dict: dumped Record dict
-    :param record_type: Record type
     """
-    metadata_extensions = current_app.get(
-        "{}_metadata_extensions".format(record_type)
+    rec_type = record_dict["$schema"].split("/")[-1].split("-")[0]
+    metadata_extensions = getattr(
+        current_app.extensions["invenio-app-ils"],
+        "{}_metadata_extensions".format(rec_type)
     )
 
     for key, value in record_dict.get("extensions", {}).items():

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ invenio_search_version = "1.3.0,<1.4.0"
 
 tests_require = [
     "check-manifest>=0.35",
-    "coverage>=4.4.1",
+    "coverage>=4.4.1,<5.0.0",
     "isort>=4.3.11",
     "mock>=2.0.0",
     "pydocstyle>=2.0.0",

--- a/tests/api/ils/test_metadata_extensions.py
+++ b/tests/api/ils/test_metadata_extensions.py
@@ -1,0 +1,215 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2018-2020 CERN.
+#
+# invenio-app-ils is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Test metadata extensions."""
+
+import pytest
+from invenio_indexer.api import RecordIndexer
+from invenio_records_rest.schemas.fields import DateString, SanitizedUnicode
+from marshmallow import ValidationError
+from marshmallow.fields import Bool, Integer, List
+
+from invenio_app_ils.records.metadata_extensions import MetadataExtensions
+
+
+@pytest.fixture(scope='module')
+def app_config(app_config):
+    """Override conftest.py's app_config
+    """
+    app_config['ILS_RECORDS_METADATA_NAMESPACES'] = {
+        "document": {
+            "accelerator_experiments": {
+                "@context": "https://example.com/accelerator_experiments/terms"
+            },
+            "standard_status": {
+                "@context": "https://example.com/standard_status/terms"
+            },
+        }
+    }
+
+    app_config['ILS_RECORDS_METADATA_EXTENSIONS'] = {
+        "document": {
+            "accelerator_experiments:accelerator": {
+                "elasticsearch": "keyword",
+                "marshmallow": SanitizedUnicode(required=True)
+            },
+            'accelerator_experiments:project': {
+                'elasticsearch': 'text',
+                'marshmallow': SanitizedUnicode()
+            },
+            'accelerator_experiments:number_in_sequence': {
+                'elasticsearch': 'long',
+                'marshmallow': Integer()
+            },
+            'accelerator_experiments:scientific_sequence': {
+                'elasticsearch': 'long',
+                'marshmallow': List(Integer())
+            },
+            'standard_status:original_presentation_date': {
+                'elasticsearch': 'date',
+                'marshmallow': DateString()
+            },
+            'standard_status:right_or_wrong': {
+                'elasticsearch': 'boolean',
+                'marshmallow': Bool()
+            }
+        }
+    }
+
+    return app_config
+
+
+def assert_unordered_equality(array_dict1, array_dict2):
+    array1 = sorted(array_dict1, key=lambda d: d['key'])
+    array2 = sorted(array_dict2, key=lambda d: d['key'])
+    assert array1 == array2
+
+
+def test_metadata_extensions(db, es, testdata):
+    """Tests that a Record is indexed into Elasticsearch properly.
+    - Tests that the before_record_index_hook is registered properly.
+    - Tests add_es_metadata_extensions.
+    - Tests jsonschema validates correctly
+    - Tests that retrieved record document is fine.
+    NOTE:
+        - es fixture depends on appctx fixture, so we are in app context
+        - this test requires a running ES instance
+    """
+    document = testdata["documents"][0]
+    data = {
+        'extensions': {
+            'accelerator_experiments:accelerator': 'LHCb',
+            'accelerator_experiments:project': 'A project for experiment.',
+            'accelerator_experiments:number_in_sequence': 3,
+            'accelerator_experiments:scientific_sequence': [1, 1, 2, 3, 5, 8],
+            'standard_status:original_presentation_date': '2019-02-14',
+            'standard_status:right_or_wrong': True,
+        }
+    }
+    document.update(data)
+    document.validate()
+    db.session.commit()
+    indexer = RecordIndexer()
+    index_result = indexer.index(document)
+
+    _index = index_result['_index']
+    _doc = index_result['_type']
+    _id = index_result['_id']
+    es_doc = es.get(index=_index, doc_type=_doc, id=_id)
+    source = es_doc['_source']
+    expected_keywords = [
+        {'key': 'accelerator_experiments:accelerator', 'value': 'LHCb'},
+    ]
+    expected_texts = [
+        {
+            'key': 'accelerator_experiments:project',
+            'value': 'A project for experiment.'
+        },
+    ]
+    expected_longs = [
+        {
+            'key': 'accelerator_experiments:number_in_sequence',
+            'value': 3
+        },
+        {
+            'key': 'accelerator_experiments:scientific_sequence',
+            'value': [1, 1, 2, 3, 5, 8]
+        },
+    ]
+    expected_dates = [
+        {
+            'key': 'standard_status:original_presentation_date',
+            'value': '2019-02-14'
+        },
+    ]
+    expected_booleans = [
+        {
+            'key': 'standard_status:right_or_wrong',
+            'value': True
+        },
+    ]
+    assert_unordered_equality(source['extensions_keywords'], expected_keywords)
+    assert_unordered_equality(source['extensions_texts'], expected_texts)
+    assert_unordered_equality(source['extensions_longs'], expected_longs)
+    assert_unordered_equality(source['extensions_dates'], expected_dates)
+    assert_unordered_equality(source['extensions_booleans'], expected_booleans)
+
+
+def test_extensions():
+    """Test metadata extensions schema."""
+    ILS_RECORDS_METADATA_NAMESPACES = {
+        'accelerator_experiments': {
+            '@context': 'https://example.com/accelerator_experiments/terms'
+        },
+        'standard_status': {
+            '@context': 'https://example.com/standard_status/terms'
+        }
+    }
+
+    ILS_RECORDS_METADATA_EXTENSIONS = {
+        'accelerator_experiments:accelerator': {
+            'elasticsearch': 'keyword',
+            'marshmallow': SanitizedUnicode(required=True)
+        },
+        'accelerator_experiments:project': {
+            'elasticsearch': 'text',
+            'marshmallow': SanitizedUnicode()
+        },
+        'accelerator_experiments:number_in_sequence': {
+            'elasticsearch': 'long',
+            'marshmallow': Integer()
+        },
+        'accelerator_experiments:scientific_sequence': {
+            'elasticsearch': 'long',
+            'marshmallow': List(Integer())
+        },
+        'standard_status:original_presentation_date': {
+            'elasticsearch': 'date',
+            'marshmallow': DateString()
+        },
+        'standard_status:right_or_wrong': {
+            'elasticsearch': 'boolean',
+            'marshmallow': Bool()
+        }
+    }
+
+    extensions = MetadataExtensions(
+        ILS_RECORDS_METADATA_NAMESPACES,
+        ILS_RECORDS_METADATA_EXTENSIONS
+    )
+    ExtensionsSchema = extensions.to_schema()
+
+    # Minimal if not absent
+    valid_minimal = {
+        'accelerator_experiments:accelerator': 'LHCb'
+    }
+
+    data = ExtensionsSchema().load(valid_minimal)
+
+    assert data == valid_minimal
+
+    # Full
+    valid_full = {
+        'accelerator_experiments:accelerator': 'LHCb',
+        'accelerator_experiments:project': 'A project for experiment.',
+        'accelerator_experiments:number_in_sequence': 3,
+        'accelerator_experiments:scientific_sequence': [1, 1, 2, 3, 5, 8],
+        'standard_status:original_presentation_date': '2019-02-14',
+        'standard_status:right_or_wrong': True,
+    }
+
+    data = ExtensionsSchema().load(valid_full)
+
+    assert data == valid_full
+
+    # Invalid
+    invalid_number_in_sequence = {
+        'accelerator_experiments:accelerator': 'LHCb',
+        'accelerator_experiments:scientific_sequence': [1, 'l', 2, 3, 5, 8],
+    }
+    with pytest.raises(ValidationError):
+        data = ExtensionsSchema().load(invalid_number_in_sequence)


### PR DESCRIPTION
Our `document` is formed as follows
```
         ...
          "extensions": {
            "accelerator_experiments:accelerator": "LHCb",
            "accelerator_experiments:institution": "CERN",
            "accelerator_experiments:project": "Myon energy detection",
            "standard_status:CERN_applicability": "applicable",
            "standard_status:standard_validity": "published"
          }, 
         ...
```

closes #878 