### PR TITLE
global: remove ETag/Last-Modified headers

### DIFF
--- a/invenio_app_ils/circulation/api.py
+++ b/invenio_app_ils/circulation/api.py
@@ -127,7 +127,7 @@ def request_loan(
         transaction_location_pid=transaction_location_pid,
         transaction_user_pid=transaction_user_pid,
     )
-    pid = loan_pid_minter(record_uuid, data=new_loan)
+    pid = ils_circulation_loan_pid_minter(record_uuid, data=new_loan)
     loan = Loan.create(data=new_loan, id_=record_uuid)
 
     params = deepcopy(loan)
@@ -197,7 +197,7 @@ def checkout_loan(
         transaction_location_pid=transaction_location_pid,
         transaction_user_pid=transaction_user_pid,
     )
-    pid = loan_pid_minter(record_uuid, data=new_loan)
+    pid = ils_circulation_loan_pid_minter(record_uuid, data=new_loan)
     loan = Loan.create(data=new_loan, id_=record_uuid)
 
     params = deepcopy(loan)

--- a/invenio_app_ils/circulation/serializers/__init__.py
+++ b/invenio_app_ils/circulation/serializers/__init__.py
@@ -7,28 +7,18 @@
 
 """Loan serializers."""
 
-from invenio_records_rest.serializers.response import (record_responsify,
-                                                       search_responsify)
+from invenio_records_rest.serializers.response import search_responsify
 
 from invenio_app_ils.records.schemas.json import ILSRecordSchemaJSONV1
+from invenio_app_ils.records.serializers import record_responsify_no_etag
 
 from .csv import LoanCSVSerializer
 from .json import LoanJSONSerializer
 
 csv_v1 = LoanCSVSerializer(ILSRecordSchemaJSONV1)
-"""CSV serializer"""
-
-csv_v1_response = record_responsify(csv_v1, "text/csv")
-"""CSV response builder that uses the CSV serializer"""
-
+csv_v1_response = record_responsify_no_etag(csv_v1, "text/csv")
 csv_v1_search = search_responsify(csv_v1, "text/csv")
-"""CSV search response builder that uses the CSV serializer"""
 
 json_v1 = LoanJSONSerializer(ILSRecordSchemaJSONV1, replace_refs=True)
-"""JSON serializer."""
-
-json_v1_response = record_responsify(json_v1, "application/json")
-"""JSON response builder decorates loan."""
-
+json_v1_response = record_responsify_no_etag(json_v1, "application/json")
 json_v1_search = search_responsify(json_v1, "application/json")
-"""JSON response builder decorates loan."""

--- a/invenio_app_ils/ill/serializers/__init__.py
+++ b/invenio_app_ils/ill/serializers/__init__.py
@@ -7,28 +7,18 @@
 
 """Loan serializers."""
 
-from invenio_records_rest.serializers.response import (record_responsify,
-                                                       search_responsify)
+from invenio_records_rest.serializers.response import search_responsify
 
 from invenio_app_ils.records.schemas.json import ILSRecordSchemaJSONV1
+from invenio_app_ils.records.serializers import record_responsify_no_etag
 
 from .csv import BorrowingRequestCSVSerializer
 from .json import BorrowingRequestJSONSerializer
 
 csv_v1 = BorrowingRequestCSVSerializer(ILSRecordSchemaJSONV1)
-"""CSV serializer"""
-
-csv_v1_response = record_responsify(csv_v1, "text/csv")
-"""CSV response builder that uses the CSV serializer"""
-
+csv_v1_response = record_responsify_no_etag(csv_v1, "text/csv")
 csv_v1_search = search_responsify(csv_v1, "text/csv")
-"""CSV search response builder that uses the CSV serializer"""
 
 json_v1 = BorrowingRequestJSONSerializer(ILSRecordSchemaJSONV1, replace_refs=True)
-"""JSON serializer."""
-
-json_v1_response = record_responsify(json_v1, "application/json")
-"""JSON response builder decorates loan."""
-
+json_v1_response = record_responsify_no_etag(json_v1, "application/json")
 json_v1_search = search_responsify(json_v1, "application/json")
-"""JSON response builder decorates loan."""

--- a/invenio_app_ils/items/serializers/__init__.py
+++ b/invenio_app_ils/items/serializers/__init__.py
@@ -7,17 +7,17 @@
 
 """ILS Items serializers."""
 
-from invenio_records_rest.serializers.response import (record_responsify,
-                                                       search_responsify)
+from invenio_records_rest.serializers.response import search_responsify
 
 from invenio_app_ils.records.schemas.json import ILSRecordSchemaJSONV1
+from invenio_app_ils.records.serializers import record_responsify_no_etag
 
 from .item import ItemCSVSerializer, ItemJSONSerializer
 
 csv_v1 = ItemCSVSerializer(ILSRecordSchemaJSONV1, csv_excluded_fields=[])
-csv_v1_response = record_responsify(csv_v1, "text/csv")
+csv_v1_response = record_responsify_no_etag(csv_v1, "text/csv")
 csv_v1_search = search_responsify(csv_v1, "text/csv")
 
 json_v1 = ItemJSONSerializer(ILSRecordSchemaJSONV1, replace_refs=True)
-json_v1_response = record_responsify(json_v1, "application/json")
+json_v1_response = record_responsify_no_etag(json_v1, "application/json")
 json_v1_search = search_responsify(json_v1, "application/json")

--- a/invenio_app_ils/literature/serializers/__init__.py
+++ b/invenio_app_ils/literature/serializers/__init__.py
@@ -7,28 +7,18 @@
 
 """Literature serializers."""
 
-from invenio_records_rest.serializers.response import (record_responsify,
-                                                       search_responsify)
+from invenio_records_rest.serializers.response import search_responsify
 
 from invenio_app_ils.records.schemas.json import ILSRecordSchemaJSONV1
+from invenio_app_ils.records.serializers import record_responsify_no_etag
 
 from .csv import LiteratureCSVSerializer
 from .json import LiteratureJSONSerializer
 
 csv_v1 = LiteratureCSVSerializer(ILSRecordSchemaJSONV1)
-"""CSV serializer"""
-
-csv_v1_response = record_responsify(csv_v1, "text/csv")
-"""CSV response builder that uses the CSV serializer"""
-
+csv_v1_response = record_responsify_no_etag(csv_v1, "text/csv")
 csv_v1_search = search_responsify(csv_v1, "text/csv")
-"""CSV search response builder that uses the CSV serializer"""
 
 json_v1 = LiteratureJSONSerializer(ILSRecordSchemaJSONV1, replace_refs=True)
-"""JSON serializer."""
-
-json_v1_response = record_responsify(json_v1, "application/json")
-"""JSON response builder decorates literature."""
-
+json_v1_response = record_responsify_no_etag(json_v1, "application/json")
 json_v1_search = search_responsify(json_v1, "application/json")
-"""JSON response builder decorates literature."""

--- a/invenio_app_ils/records/serializers/__init__.py
+++ b/invenio_app_ils/records/serializers/__init__.py
@@ -7,27 +7,53 @@
 
 """ILS serializers."""
 
+from flask import current_app
 from invenio_records_rest.serializers.csv import CSVSerializer
 from invenio_records_rest.serializers.json import JSONSerializer
-from invenio_records_rest.serializers.response import (record_responsify,
+from invenio_records_rest.serializers.response import (add_link_header,
                                                        search_responsify)
 
 from invenio_app_ils.records.schemas.json import ILSRecordSchemaJSONV1
 
+
+def record_responsify_no_etag(serializer, mimetype):
+    """Create a Records-REST response serializer, without ETag/Last-Modified.
+
+    Since, in Invenio, the ETag is calculated by default simply on the record
+    revision ID, it does not take into account the extra fields added
+    when serializing.
+    As result, the client will never fetch and get the changes of these extra
+    fields until the record revision will change.
+
+    Removing the ETag could lead to the "lost update problem", where a resource
+    could be updated via a PUT request even if it was previously updated.
+    However, it looks like that browsers are not sending the If-Match/ETag
+    headers on PUT requests.
+    """
+
+    def view(pid, record, code=200, headers=None, links_factory=None):
+        response = current_app.response_class(
+            serializer.serialize(pid, record, links_factory=links_factory),
+            mimetype=mimetype)
+        response.status_code = code
+        response.cache_control.no_cache = True
+        # etag/last-modified headers removed
+
+        if headers is not None:
+            response.headers.extend(headers)
+
+        if links_factory is not None:
+            add_link_header(response, links_factory(pid))
+
+        return response
+
+    return view
+
+
 csv_v1 = CSVSerializer(ILSRecordSchemaJSONV1, csv_excluded_fields=[])
-"""CSV serializer"""
-
-csv_v1_response = record_responsify(csv_v1, "text/csv")
-"""CSV response builder that uses the CSV serializer"""
-
+csv_v1_response = record_responsify_no_etag(csv_v1, "text/csv")
 csv_v1_search = search_responsify(csv_v1, "text/csv")
-"""CSV search response builder that uses the CSV serializer"""
 
 json_v1 = JSONSerializer(ILSRecordSchemaJSONV1, replace_refs=True)
-"""JSON v1 serializer."""
-
-json_v1_response = record_responsify(json_v1, "application/json")
-"""JSON response builder that uses the JSON v1 serializer."""
-
+json_v1_response = record_responsify_no_etag(json_v1, "application/json")
 json_v1_search = search_responsify(json_v1, "application/json")
-"""JSON response builder that uses the JSON v1 serializer."""


### PR DESCRIPTION
* removes the ETag/Last-Modifies headers when returning the records
  REST responses to prevent caching of extra fields added at
  serialization time.
* closes #851
* closes #852
* closes #857
* closes #861