### PR TITLE
Cli: add user anonymization command

### DIFF
--- a/invenio_app_ils/anonymization.py
+++ b/invenio_app_ils/anonymization.py
@@ -1,0 +1,201 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2018-2020 CERN.
+#
+# invenio-app-ils is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Functions to anonymize user data and activity."""
+
+
+from copy import deepcopy
+
+from elasticsearch.exceptions import NotFoundError
+from flask import current_app
+from invenio_accounts.models import SessionActivity, User, userrole
+from invenio_circulation.api import Loan
+from invenio_circulation.proxies import current_circulation
+from invenio_db import db
+from invenio_oauthclient.models import RemoteAccount, UserIdentity
+from invenio_userprofiles.models import UserProfile
+
+from invenio_app_ils.acquisition.api import Order
+from invenio_app_ils.acquisition.proxies import current_ils_acq
+from invenio_app_ils.document_requests.api import DocumentRequest
+from invenio_app_ils.errors import PatronNotFoundError
+from invenio_app_ils.ill.api import BorrowingRequest
+from invenio_app_ils.ill.proxies import current_ils_ill
+from invenio_app_ils.patrons.api import (Patron, SystemAgent,
+                                         get_anonymous_patron_dict,
+                                         get_patron_or_unknown)
+
+from .acquisition.search import OrderSearch
+from .circulation.search import get_loans_by_patron_pid
+from .document_requests.search import DocumentRequestSearch
+from .ill.search import BorrowingRequestsSearch
+from .patrons.indexer import PatronIndexer
+from .proxies import current_app_ils
+
+
+def get_patron_activity(patron_pid):
+    """Get activity related to the given patron pid."""
+    if patron_pid is None:
+        raise ValueError("No patron pid was provided.")
+
+    patron = get_patron_or_unknown(patron_pid)
+    if not patron:
+        return None
+
+    def dump(search):
+        return [hit.to_dict() for hit in search.scan()]
+
+    patron_document_requests = dump(
+        DocumentRequestSearch().search_by_patron_pid(patron_pid)
+    )
+
+    patron_borrowing_requests = dump(
+        BorrowingRequestsSearch().search_by_patron_pid(patron_pid)
+    )
+
+    patron_acquisitions = dump(OrderSearch().search_by_patron_pid(patron_pid))
+
+    patron_loans = dump(get_loans_by_patron_pid(patron_pid))
+
+    patron_profile = UserProfile.get_by_userid(patron_pid).__dict__
+    del patron_profile["_sa_instance_state"]
+
+    patron_data = {
+        "patron": patron,
+        "profile": patron_profile,
+        "document_requests": patron_document_requests,
+        "borrowing_requests": patron_borrowing_requests,
+        "acquisitions": patron_acquisitions,
+        "loans": patron_loans,
+    }
+
+    return patron_data
+
+
+def anonymize_patron_data(patron_pid, force=False):
+    """Anonymize all the data/activity related to the given patron pid."""
+    if patron_pid is None:
+        raise ValueError("No patron pid was provided.")
+
+    patron = get_patron_or_unknown(patron_pid)
+    if not patron and not force:
+        return None
+
+    patron_object = None
+    try:
+        patron_object = current_app_ils.patron_cls.get_patron(patron_pid)
+    except PatronNotFoundError:
+        if not force:
+            raise PatronNotFoundError(patron_pid)
+
+    if (
+        get_loans_by_patron_pid(patron_pid)
+        .filter("term", state="ITEM_ON_LOAN")
+        .count()
+    ):
+        raise AssertionError(
+            "Cannot delete user %s: they have ongoing loans." % (patron_pid)
+        )
+
+    # Serialize empty patron values
+    anonymous_patron_fields = get_anonymous_patron_dict(patron_pid)
+
+    patron_loans = get_loans_by_patron_pid(patron_pid).execute()
+
+    indices = 0
+
+    for hit in patron_loans:
+        loan = Loan.get_record_by_pid(hit.pid)
+        if loan["state"] == current_app.config["CIRCULATION_STATES_LOAN_REQUEST"]:
+            params = deepcopy(loan)
+            params.update(
+                dict(
+                    cancel_reason="Loan request cancelled to anonymize user.",
+                    transaction_user_pid=str(SystemAgent.id),
+                )
+            )
+            current_circulation.circulation.trigger(
+                loan, **dict(params, trigger="cancel")
+            )
+        loan["patron"] = anonymous_patron_fields
+        loan.commit()
+        current_circulation.loan_indexer().index(loan)
+        indices += 1
+
+    patron_borrowing_requests = (
+        BorrowingRequestsSearch().search_by_patron_pid(patron_pid).scan()
+    )
+
+    for hit in patron_borrowing_requests:
+        borrowing_request = BorrowingRequest.get_record_by_pid(hit.pid)
+        borrowing_request["patron"] = anonymous_patron_fields
+        borrowing_request.commit()
+        current_ils_ill.borrowing_request_indexer_cls().index(
+            borrowing_request
+        )
+        indices += 1
+
+    patron_document_requests = (
+        DocumentRequestSearch().search_by_patron_pid(patron_pid).scan()
+    )
+
+    for hit in patron_document_requests:
+        document_request = DocumentRequest.get_record_by_pid(hit.pid)
+        if document_request["state"] == "PENDING":
+            document_request["state"] = "REJECTED"
+            document_request["reject_reason"] = "USER_CANCEL"
+        document_request["patron"] = anonymous_patron_fields
+        document_request.commit()
+        current_app_ils.document_request_indexer.index(document_request)
+        indices += 1
+
+    patron_acquisitions = OrderSearch().search_by_patron_pid(patron_pid).scan()
+
+    for hit in patron_acquisitions:
+        acquisition = Order.get_record_by_pid(hit.pid)
+        acquisition.commit()
+        current_ils_acq.order_indexer.index(acquisition)
+        indices += 1
+
+    # Delete rows from db
+    dropped = delete_user_account(patron_pid)
+
+    db.session.commit()
+    if patron_object:
+        try:
+            PatronIndexer().delete(patron_object)
+        except NotFoundError:
+            pass
+
+    return dropped, indices
+
+
+def delete_user_account(patron_pid):
+    """Deletes a user account from the database, without updating the index."""
+    dropped = 0
+
+    with db.session.begin_nested():
+        d = db.session.query(userrole).filter(userrole.c.user_id == patron_pid)
+        dropped += d.delete(synchronize_session=False)
+
+        dropped += SessionActivity.query.filter(
+            SessionActivity.user_id == patron_pid
+        ).delete()
+
+        dropped += UserIdentity.query.filter(
+            UserIdentity.id_user == patron_pid
+        ).delete()
+        dropped += RemoteAccount.query.filter(
+            RemoteAccount.user_id == patron_pid
+        ).delete()
+
+        dropped += UserProfile.query.filter(
+            UserProfile.user_id == patron_pid
+        ).delete()
+        dropped += User.query.filter(User.id == patron_pid).delete()
+
+    return dropped

--- a/invenio_app_ils/circulation/config.py
+++ b/invenio_app_ils/circulation/config.py
@@ -33,6 +33,7 @@ from invenio_app_ils.permissions import (PatronOwnerPermission,
                                          authenticated_user_permission,
                                          backoffice_permission,
                                          loan_extend_circulation_permission,
+                                         patron_owner_permission,
                                          superuser_permission)
 
 from .api import ILS_CIRCULATION_LOAN_FETCHER, ILS_CIRCULATION_LOAN_MINTER
@@ -158,7 +159,7 @@ CIRCULATION_LOAN_TRANSITIONS = {
             dest="CANCELLED",
             trigger="cancel",
             transition=ToCancelled,
-            permission_factory=PatronOwnerPermission,
+            permission_factory=patron_owner_permission,
         ),
     ],
     "ITEM_ON_LOAN": [

--- a/invenio_app_ils/circulation/jsonresolvers/loan.py
+++ b/invenio_app_ils/circulation/jsonresolvers/loan.py
@@ -11,7 +11,7 @@ from invenio_circulation.proxies import current_circulation
 from invenio_pidstore.errors import PIDDeletedError
 
 from invenio_app_ils.circulation.utils import resolve_item_from_loan
-from invenio_app_ils.patrons.api import get_patron_or_empty_dict
+from invenio_app_ils.patrons.api import get_patron_or_unknown
 from invenio_app_ils.proxies import current_app_ils
 from invenio_app_ils.records.jsonresolvers.api import \
     get_field_value_for_record as get_field_value
@@ -34,12 +34,7 @@ def item_resolver(loan_pid):
         # if it the item is a BorrowingRequest, then some of these
         # fields might not be there
         item = pick(
-            item,
-            "barcode",
-            "description",
-            "document_pid",
-            "medium",
-            "pid",
+            item, "barcode", "description", "document_pid", "medium", "pid",
         )
 
     return item
@@ -54,7 +49,7 @@ def loan_patron_resolver(loan_pid):
     except KeyError:
         return {}
 
-    return get_patron_or_empty_dict(patron_pid)
+    return get_patron_or_unknown(patron_pid)
 
 
 @get_pid_or_default(default_value=dict())

--- a/invenio_app_ils/circulation/search.py
+++ b/invenio_app_ils/circulation/search.py
@@ -118,11 +118,23 @@ def get_most_loaned_documents(from_date, to_date, bucket_size):
 def get_loans_aggregated_by_states(document_pid, states, patron_pid=None):
     """Returns loans aggregated by states for a given document."""
     search_cls = current_circulation.loan_search_cls
-    search = search_cls().filter("terms", state=states).filter("term", document_pid=document_pid)
+    search = (
+        search_cls()
+        .filter("terms", state=states)
+        .filter("term", document_pid=document_pid)
+    )
     if patron_pid:
         search = search.filter("term", patron_pid=patron_pid)
     # Aggregation
     aggs = A("terms", field="state")
     search.aggs.bucket("states", aggs)
 
+    return search
+
+
+def get_loans_by_patron_pid(patron_pid):
+    """Returns all the loans (past and current) for a given patron."""
+    search = current_circulation.loan_search_cls().filter(
+        "term", patron_pid=patron_pid
+    )
     return search

--- a/invenio_app_ils/document_requests/jsonresolvers/document_request_patron.py
+++ b/invenio_app_ils/document_requests/jsonresolvers/document_request_patron.py
@@ -10,7 +10,7 @@
 import jsonresolver
 from werkzeug.routing import Rule
 
-from invenio_app_ils.patrons.api import get_patron_or_empty_dict
+from invenio_app_ils.patrons.api import get_patron_or_unknown
 from invenio_app_ils.records.jsonresolvers.api import \
     get_field_value_for_record as get_field_value
 
@@ -34,7 +34,7 @@ def jsonresolver_loader(url_map):
         except KeyError:
             return {}
 
-        return get_patron_or_empty_dict(patron_pid)
+        return get_patron_or_unknown(patron_pid)
 
     url_map.add(
         Rule(

--- a/invenio_app_ils/ext.py
+++ b/invenio_app_ils/ext.py
@@ -207,6 +207,13 @@ class InvenioAppIls(object):
                 template_folder="templates",
             )
         )
+        app.register_blueprint(
+            Blueprint(
+                "invenio_app_ils_circulation_ mail",
+                __name__,
+                template_folder="circulation/templates",
+            )
+        )
         # disable warnings being logged to Sentry
         logging.getLogger("py.warnings").propagate = False
 

--- a/invenio_app_ils/patrons/api.py
+++ b/invenio_app_ils/patrons/api.py
@@ -123,12 +123,23 @@ def patron_exists(patron_pid):
     return User.query.filter_by(id=patron_pid).first() is not None
 
 
-def get_patron_or_empty_dict(patron_pid):
+def get_anonymous_patron_dict(patron_pid):
+    """Return dict with Unknown values for patron."""
+    return {
+        "id": "anonymous",
+        "pid": patron_pid,
+        "name": "anonymous",
+        "email": "anonymous",
+        "location_pid": "anonymous",
+    }
+
+
+def get_patron_or_unknown(patron_pid):
     """Resolve a Patron for a given field."""
     if not patron_pid:
-        return {}
+        raise PatronNotFoundError
     try:
         cls = current_app_ils.patron_cls
         return cls.get_patron(patron_pid).dumps_loader()
     except PatronNotFoundError:
-        return {}
+        return get_anonymous_patron_dict(patron_pid)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/setup.py
+++ b/setup.py
@@ -35,15 +35,9 @@ extras_require = {
     "postgresql": [
         "invenio-db[postgresql,versioning]{}".format(invenio_db_version),
     ],
-    "mysql": [
-        "invenio-db[mysql,versioning]{}".format(invenio_db_version),
-    ],
-    "sqlite": [
-        "invenio-db[versioning]{}".format(invenio_db_version),
-    ],
-    "vocabulary": [
-        "pycountry>=19.8.18",
-    ],
+    "mysql": ["invenio-db[mysql,versioning]{}".format(invenio_db_version),],
+    "sqlite": ["invenio-db[versioning]{}".format(invenio_db_version),],
+    "vocabulary": ["pycountry>=19.8.18",],
 }
 
 extras_require["all"] = []
@@ -67,7 +61,7 @@ install_requires = [
     "Flask-Debugtoolbar>=0.10.1",
     "invenio[base,auth]>=3.3.0,<3.4",
     # --- translations -----------------------------------------------------
-    'invenio-i18n>=1.2.0,<1.3.0',
+    "invenio-i18n>=1.2.0,<1.3.0",
     # --- `metadata` bundle without records UI -----------------------------
     "invenio-indexer>=1.1.0,<1.2.0",
     "invenio-jsonschemas>=1.1.0,<1.2.0",
@@ -116,9 +110,11 @@ setup(
             "demo = invenio_app_ils.cli:demo",
             "patrons = invenio_app_ils.cli:patrons",
             "setup = invenio_app_ils.cli:setup",
-            'stats = invenio_stats.cli:stats',
+            "stats = invenio_stats.cli:stats",
             "vocabulary = invenio_app_ils.vocabularies.cli:vocabulary",
             "fixtures = invenio_app_ils.cli:fixtures",
+            "list_patron_activity = invenio_app_ils.cli:list_patron_activity",
+            "anonymize_patron = invenio_app_ils.cli:anonymize_patron",
         ],
         "invenio_base.apps": [
             "ils_ui = invenio_app_ils.ext:InvenioAppIlsUI",
@@ -142,7 +138,7 @@ setup(
         ],
         "invenio_config.module": [
             "00_invenio_app_ils = invenio_app_ils.config",
-            "00_invenio_app_ils_circulation = invenio_app_ils.circulation.config"
+            "00_invenio_app_ils_circulation = invenio_app_ils.circulation.config",
         ],
         "invenio_i18n.translations": ["messages = invenio_app_ils"],
         "invenio_jsonschemas.schemas": [

--- a/tests/api/document_requests/test_document_requests.py
+++ b/tests/api/document_requests/test_document_requests.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2019 CERN.
+# Copyright (C) 2020 CERN.
 #
 # invenio-app-ils is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/tests/api/ils/test_anonymization.py
+++ b/tests/api/ils/test_anonymization.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# invenio-app-ils is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Test anonymization of users."""
+
+import json
+from copy import deepcopy
+
+from invenio_accounts.models import User
+from invenio_circulation.api import Loan
+from invenio_circulation.proxies import current_circulation
+from invenio_db import db
+from invenio_oauthclient.models import RemoteAccount, UserIdentity
+from invenio_search import current_search
+from invenio_userprofiles.models import UserProfile
+
+from invenio_app_ils.acquisition.api import Order
+from invenio_app_ils.acquisition.search import OrderSearch
+from invenio_app_ils.anonymization import anonymize_patron_data
+from invenio_app_ils.circulation.search import get_loans_by_patron_pid
+from invenio_app_ils.document_requests.api import DocumentRequest
+from invenio_app_ils.document_requests.search import DocumentRequestSearch
+from invenio_app_ils.ill.api import BorrowingRequest
+from invenio_app_ils.ill.search import BorrowingRequestsSearch
+from invenio_app_ils.patrons.api import (get_anonymous_patron_dict,
+                                         patron_exists)
+from tests.helpers import user_login, user_logout
+
+
+def check_user_deleted(user_pid):
+    """ Check if user was deleted from database. """
+    with db.session.begin_nested():
+        user_identity = UserIdentity.query.filter(
+            UserIdentity.id_user == user_pid
+        ).first()
+
+        assert user_identity is None
+
+        remote_account = RemoteAccount.query.filter(
+            RemoteAccount.user_id == user_pid
+        ).first()
+        assert remote_account is None
+
+        user_profile = UserProfile.query.filter(
+            UserProfile.user_id == user_pid
+        ).first()
+        assert user_profile is None
+
+        user = User.query.filter(User.id == user_pid).first()
+        assert user is None
+
+
+def check_user_exists(user_pid):
+    """ Check if user exists in database. """
+    with db.session.begin_nested():
+        assert patron_exists(user_pid)
+
+
+def check_user_activity(user_pid):
+    """ Check if there are records related to the user. """
+    anonymous_patron = get_anonymous_patron_dict(user_pid)
+
+    loans = get_loans_by_patron_pid(user_pid).scan()
+    for hit in loans:
+        loan = Loan.get_record_by_pid(hit.pid)
+        assert loan["patron"] == anonymous_patron
+
+    borrowing_requests = (
+        BorrowingRequestsSearch().search_by_patron_pid(user_pid).scan()
+    )
+    for hit in borrowing_requests:
+        borrowing_request = BorrowingRequest.get_record_by_pid(hit.pid)
+        assert borrowing_request["patron"] == anonymous_patron
+
+    document_requests = (
+        DocumentRequestSearch().search_by_patron_pid(user_pid).scan()
+    )
+    for hit in document_requests:
+        document_request = DocumentRequest.get_record_by_pid(hit.pid)
+        assert document_request["patron"] == anonymous_patron
+
+    acquisitions = OrderSearch().search_by_patron_pid(user_pid).scan()
+    for hit in acquisitions:
+        acquisition = Order.get_record_by_pid(hit.pid)
+        assert acquisition["patron"] == anonymous_patron
+
+
+def cancel_ongoing_loans(patron_pid, client, users):
+    """ Cancel ongoing loans of a patron. """
+    user = user_login(client, "admin", users)
+
+    ongoing_loans = (
+        get_loans_by_patron_pid(patron_pid)
+        .filter("term", state="ITEM_ON_LOAN")
+        .scan()
+    )
+
+    for hit in ongoing_loans:
+        loan = Loan.get_record_by_pid(hit.pid)
+        params = deepcopy(loan)
+        params.update(
+            dict(
+                cancel_reason="Loan cancelled to anonymize user.",
+                transaction_user_pid=str(user.id),
+            )
+        )
+        current_circulation.circulation.trigger(
+            loan, **dict(params, trigger="cancel")
+        )
+
+        loan.commit()
+        db.session.commit()
+        current_circulation.loan_indexer().index(loan)
+        current_search.flush_and_refresh(index="*")
+
+    user_logout(client)
+
+
+def test_anonymization(client, json_headers, users, testdata):
+    """Test anonymization of a user."""
+
+    # Anonymize patron
+    patron_pid = users["patron1"].id
+
+    check_user_exists(patron_pid)
+    cancel_ongoing_loans(patron_pid, client, users)
+    anonymize_patron_data(patron_pid)
+    check_user_deleted(patron_pid)
+    check_user_activity(patron_pid)
+
+    # Anonymize librarian
+    librarian_pid = users["librarian"].id
+
+    check_user_exists(librarian_pid)
+    cancel_ongoing_loans(librarian_pid, client, users)
+    anonymize_patron_data(librarian_pid)
+    check_user_deleted(librarian_pid)
+
+    # Anonymize patron while logged in
+    patron_pid = users["patron2"].id
+
+    user_login(client, "patron2", users)
+
+    check_user_exists(patron_pid)
+    cancel_ongoing_loans(patron_pid, client, users)
+    anonymize_patron_data(patron_pid)
+    check_user_deleted(patron_pid)
+
+    # Anonymize patron with ongoing loans
+    patron_pid = users["patron3"].id
+
+    check_user_exists(patron_pid)
+    anonymize_patron_data(patron_pid)
+    check_user_deleted(patron_pid)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2018 CERN.
+# Copyright (C) 2020 CERN.
 #
 # invenio-app-ils is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2018 CERN.
+# Copyright (C) 2020 CERN.
 #
 # invenio-app-ils is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -13,4 +13,5 @@ from __future__ import absolute_import, print_function
 def test_version():
     """Test version import."""
     from invenio_app_ils import __version__
+
     assert __version__


### PR DESCRIPTION
Closes #925

- Command to list patron's activity 
   - Display patron related data and activity with a pretty printed dict
- Command to anonymize patron with force option in case of interrupted call
   - Delete user profile and all relations to the user 
   - Re-index all records and replace patron info with dict with `Unknown` values
   - Display number of rows deleted from db and records re-indexed