### PR TITLE
put back db.session.commit after transactions

### DIFF
--- a/invenio_app_ils/config.py
+++ b/invenio_app_ils/config.py
@@ -113,8 +113,6 @@ BABEL_DEFAULT_TIMEZONE = "Europe/Zurich"
 ###############################################################################
 #: Email address for support.
 SUPPORT_EMAIL = "info@inveniosoftware.org"
-#: Management email for internal notifications.
-MANAGEMENT_EMAIL = "internal@inveniosoftware.org"
 #: Disable email sending by default.
 MAIL_SUPPRESS_SEND = True
 #: Email address for email notification sender.

--- a/invenio_app_ils/files/views.py
+++ b/invenio_app_ils/files/views.py
@@ -60,5 +60,6 @@ class RecordBucketResource(ContentNegotiatedMethodView):
             bucket = Bucket.create()
             record["bucket_id"] = str(bucket.id)
             record.commit()
+        db.session.commit()
         current_app_ils.eitem_indexer.index(record)
         return self.make_response(record.pid, record, 201)


### PR DESCRIPTION
Put back the missing db.session.commit after a transaction. This is the only place that should be missing.