### PR TITLE
location: relax constraint on opening hours

### DIFF
--- a/invenio_app_ils/locations/loaders/jsonschemas/location.py
+++ b/invenio_app_ils/locations/loaders/jsonschemas/location.py
@@ -89,11 +89,15 @@ class OpeningWeekdaySchema(Schema):
                     "Time periods must be defined on an opened weekday.",
                     "times",
                 )
-            if len(data["times"]) != 2:
-                raise ValidationError(
-                    "There must be exactly two time periods.", "times"
-                )
             times = data["times"]
+            if len(times) == 0:
+                raise ValidationError(
+                    "At least one time period must be defined.", "times"
+                )
+            if len(times) > 2:
+                raise ValidationError(
+                    "At most two time periods can be defined.", "times"
+                )
             times.sort(key=lambda period: period["start_time"])
             previous = None
             for current in times:

--- a/tests/api/ils/test_closures.py
+++ b/tests/api/ils/test_closures.py
@@ -107,7 +107,8 @@ def test_location_validation(client, json_headers, users, testdata):
 
     _test_update_times([["08:00", "12:00"], ["13:00", "18:00"]], 200)
     _test_update_times([["13:00", "18:00"], ["08:00", "12:00"]], 200)
-    _test_update_times([["08:00", "12:00"]], 400)
+    _test_update_times([["08:00", "18:00"]], 200)
+    _test_update_times([], 400)
     _test_update_times(
         [["08:00", "10:00"], ["11:00", "12:00"], ["13:00", "18:00"]], 400)
     _test_update_times([["8:00", "12:00"], ["13:00", "18:00"]], 400)


### PR DESCRIPTION
* addresses #980

**Before**: exactly two opening hours period had to be defined
**After**: there can be either one or two opening hours periods

This is just to set a frame for the backoffice form. The validation works for any number of time periods (though there should be a least one because it wouldn't make sense otherwise).