### PR TITLE
Global: change email tokenizer

### DIFF
--- a/invenio_app_ils/acquisition/mappings/v6/acq_orders/order-v1.0.0.json
+++ b/invenio_app_ils/acquisition/mappings/v6/acq_orders/order-v1.0.0.json
@@ -1,4 +1,14 @@
 {
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "email": {
+          "type": "custom",
+          "tokenizer": "uax_url_email"
+        }
+      }
+    }
+  },
   "mappings": {
     "order-v1.0.0": {
       "date_detection": false,
@@ -225,7 +235,8 @@
             "patron": {
               "properties": {
                 "email": {
-                  "type": "text"
+                  "type": "text",
+                  "analyzer": "email"
                 },
                 "id": {
                   "type": "keyword"
@@ -293,7 +304,8 @@
               "type": "text"
             },
             "email": {
-              "type": "text"
+              "type": "text",
+              "analyzer": "email"
             },
             "name": {
               "fields": {

--- a/invenio_app_ils/acquisition/mappings/v6/acq_vendors/vendor-v1.0.0.json
+++ b/invenio_app_ils/acquisition/mappings/v6/acq_vendors/vendor-v1.0.0.json
@@ -1,4 +1,14 @@
 {
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "email": {
+          "type": "custom",
+          "tokenizer": "uax_url_email"
+        }
+      }
+    }
+  },
   "mappings": {
     "vendor-v1.0.0": {
       "date_detection": false,
@@ -17,7 +27,8 @@
           "type": "text"
         },
         "email": {
-          "type": "text"
+          "type": "text",
+          "analyzer": "email"
         },
         "legacy_id": {
           "type": "keyword"

--- a/invenio_app_ils/acquisition/mappings/v7/acq_orders/order-v1.0.0.json
+++ b/invenio_app_ils/acquisition/mappings/v7/acq_orders/order-v1.0.0.json
@@ -1,4 +1,14 @@
 {
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "email": {
+          "type": "custom",
+          "tokenizer": "uax_url_email"
+        }
+      }
+    }
+  },
   "mappings": {
     "date_detection": false,
     "numeric_detection": false,
@@ -113,7 +123,8 @@
           "patron": {
             "properties": {
               "email": {
-                "type": "text"
+                "type": "text",
+                "analyzer": "email"
               },
               "id": {
                 "type": "keyword"
@@ -292,7 +303,8 @@
             "type": "text"
           },
           "email": {
-            "type": "text"
+            "type": "text",
+            "analyzer": "email"
           },
           "name": {
             "fields": {

--- a/invenio_app_ils/acquisition/mappings/v7/acq_vendors/vendor-v1.0.0.json
+++ b/invenio_app_ils/acquisition/mappings/v7/acq_vendors/vendor-v1.0.0.json
@@ -1,4 +1,14 @@
 {
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "email": {
+          "type": "custom",
+          "tokenizer": "uax_url_email"
+        }
+      }
+    }
+  },
   "mappings": {
     "date_detection": false,
     "numeric_detection": false,
@@ -16,7 +26,8 @@
         "type": "text"
       },
       "email": {
-        "type": "text"
+        "type": "text",
+        "analyzer": "email"
       },
       "legacy_id": {
         "type": "keyword"

--- a/invenio_app_ils/ill/mappings/v6/ill_borrowing_requests/borrowing_request-v1.0.0.json
+++ b/invenio_app_ils/ill/mappings/v6/ill_borrowing_requests/borrowing_request-v1.0.0.json
@@ -1,4 +1,14 @@
 {
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "email": {
+          "type": "custom",
+          "tokenizer": "uax_url_email"
+        }
+      }
+    }
+  },
   "mappings": {
     "borrowing_request-v1.0.0": {
       "date_detection": false,
@@ -85,7 +95,8 @@
         "patron": {
           "properties": {
             "email": {
-              "type": "text"
+              "type": "text",
+              "analyzer": "email"
             },
             "id": {
               "type": "keyword"

--- a/invenio_app_ils/ill/mappings/v6/ill_libraries/library-v1.0.0.json
+++ b/invenio_app_ils/ill/mappings/v6/ill_libraries/library-v1.0.0.json
@@ -1,4 +1,14 @@
 {
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "email": {
+          "type": "custom",
+          "tokenizer": "uax_url_email"
+        }
+      }
+    }
+  },
   "mappings": {
     "library-v1.0.0": {
       "date_detection": false,
@@ -17,7 +27,8 @@
           "type": "text"
         },
         "email": {
-          "type": "text"
+          "type": "text",
+          "analyzer": "email"
         },
         "legacy_id": {
           "type": "keyword"

--- a/invenio_app_ils/ill/mappings/v7/ill_borrowing_requests/borrowing_request-v1.0.0.json
+++ b/invenio_app_ils/ill/mappings/v7/ill_borrowing_requests/borrowing_request-v1.0.0.json
@@ -1,4 +1,14 @@
 {
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "email": {
+          "type": "custom",
+          "tokenizer": "uax_url_email"
+        }
+      }
+    }
+  },
   "mappings": {
     "date_detection": false,
     "numeric_detection": false,
@@ -84,7 +94,8 @@
       "patron": {
         "properties": {
           "email": {
-            "type": "text"
+            "type": "text",
+            "analyzer": "email"
           },
           "id": {
             "type": "keyword"

--- a/invenio_app_ils/ill/mappings/v7/ill_libraries/library-v1.0.0.json
+++ b/invenio_app_ils/ill/mappings/v7/ill_libraries/library-v1.0.0.json
@@ -1,4 +1,14 @@
 {
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "email": {
+          "type": "custom",
+          "tokenizer": "uax_url_email"
+        }
+      }
+    }
+  },
   "mappings": {
     "date_detection": false,
     "numeric_detection": false,
@@ -16,7 +26,8 @@
         "type": "text"
       },
       "email": {
-        "type": "text"
+        "type": "text",
+        "analyzer": "email"
       },
       "legacy_id": {
         "type": "keyword"

--- a/invenio_app_ils/internal_locations/jsonresolvers/internal_location.py
+++ b/invenio_app_ils/internal_locations/jsonresolvers/internal_location.py
@@ -12,9 +12,10 @@ from werkzeug.routing import Rule
 
 from invenio_app_ils.internal_locations.api import InternalLocation
 from invenio_app_ils.locations.api import Location
-from invenio_app_ils.records.jsonresolvers.api import \
-    get_field_value_for_record as get_field_value
-from invenio_app_ils.records.jsonresolvers.api import get_pid_or_default
+from invenio_app_ils.records.jsonresolvers.api import (
+    get_field_value_for_record as get_field_value,
+)
+from invenio_app_ils.records.jsonresolvers.api import get_pid_or_default, pick
 
 # Note: there must be only one resolver per file,
 # otherwise only the last one is registered
@@ -28,12 +29,18 @@ def jsonresolver_loader(url_map):
     @get_pid_or_default(default_value=dict())
     def location_resolver(internal_loc_pid):
         """Return the Location record for the given Internal Loc. or raise."""
-        location_pid = get_field_value(InternalLocation, internal_loc_pid,
-                                       "location_pid")
+        location_pid = get_field_value(
+            InternalLocation, internal_loc_pid, "location_pid"
+        )
         location = Location.get_record_by_pid(location_pid)
-        del location["$schema"]
 
-        return location
+        return pick(
+            location,
+            "name",
+            "opening_exceptions",
+            "opening_weekdays",
+            "pid",
+        )
 
     url_map.add(
         Rule(

--- a/invenio_app_ils/internal_locations/mappings/v6/internal_locations/internal_location-v1.0.0.json
+++ b/invenio_app_ils/internal_locations/mappings/v6/internal_locations/internal_location-v1.0.0.json
@@ -1,4 +1,14 @@
 {
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "email": {
+          "type": "custom",
+          "tokenizer": "uax_url_email"
+        }
+      }
+    }
+  },
   "mappings": {
     "internal_location-v1.0.0": {
       "date_detection": false,
@@ -25,18 +35,6 @@
               "type": "keyword"
             },
             "name": {
-              "type": "text"
-            },
-            "address": {
-              "type": "text"
-            },
-            "email": {
-              "type": "text"
-            },
-            "phone": {
-              "type": "keyword"
-            },
-            "notes": {
               "type": "text"
             },
             "opening_weekdays": {

--- a/invenio_app_ils/internal_locations/mappings/v7/internal_locations/internal_location-v1.0.0.json
+++ b/invenio_app_ils/internal_locations/mappings/v7/internal_locations/internal_location-v1.0.0.json
@@ -1,4 +1,14 @@
 {
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "email": {
+          "type": "custom",
+          "tokenizer": "uax_url_email"
+        }
+      }
+    }
+  },
   "mappings": {
     "date_detection": false,
     "numeric_detection": false,
@@ -24,18 +34,6 @@
             "type": "keyword"
           },
           "name": {
-            "type": "text"
-          },
-          "address": {
-            "type": "text"
-          },
-          "email": {
-            "type": "text"
-          },
-          "phone": {
-            "type": "keyword"
-          },
-          "notes": {
             "type": "text"
           },
           "opening_weekdays": {

--- a/invenio_app_ils/items/jsonresolvers/item_internal_location.py
+++ b/invenio_app_ils/items/jsonresolvers/item_internal_location.py
@@ -14,7 +14,7 @@ from invenio_app_ils.internal_locations.api import InternalLocation
 from invenio_app_ils.items.api import Item
 from invenio_app_ils.records.jsonresolvers.api import \
     get_field_value_for_record as get_field_value
-from invenio_app_ils.records.jsonresolvers.api import get_pid_or_default
+from invenio_app_ils.records.jsonresolvers.api import get_pid_or_default, pick
 
 # Note: there must be only one resolver per file,
 # otherwise only the last one is registered
@@ -22,7 +22,7 @@ from invenio_app_ils.records.jsonresolvers.api import get_pid_or_default
 
 @jsonresolver.hookimpl
 def jsonresolver_loader(url_map):
-    """Resolve the referredInternal Location for an Item record."""
+    """Resolve the referred Internal Location for an Item record."""
     from flask import current_app
 
     @get_pid_or_default(default_value=dict())
@@ -32,13 +32,16 @@ def jsonresolver_loader(url_map):
             internal_location_pid
         )
         del internal_location["$schema"]
+        if "notes" in internal_location:
+            del internal_location["notes"]
 
         return internal_location
 
     def internal_location_resolver(item_pid):
         """Return the IntLoc record for the given Item or raise."""
-        internal_loc_pid = get_field_value(Item, item_pid,
-                                           "internal_location_pid")
+        internal_loc_pid = get_field_value(
+            Item, item_pid, "internal_location_pid"
+        )
         return get_internal_location(internal_loc_pid)
 
     url_map.add(

--- a/invenio_app_ils/items/mappings/v6/items/item-v1.0.0.json
+++ b/invenio_app_ils/items/mappings/v6/items/item-v1.0.0.json
@@ -1,4 +1,14 @@
 {
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "email": {
+          "type": "custom",
+          "tokenizer": "uax_url_email"
+        }
+      }
+    }
+  },
   "mappings": {
     "item-v1.0.0": {
       "date_detection": false,
@@ -48,7 +58,8 @@
             "patron": {
               "properties": {
                 "email": {
-                  "type": "text"
+                  "type": "text",
+                  "analyzer": "email"
                 },
                 "id": {
                   "type": "keyword"
@@ -178,18 +189,6 @@
                 "name": {
                   "type": "keyword"
                 },
-                "address": {
-                  "type": "keyword"
-                },
-                "email": {
-                  "type": "keyword"
-                },
-                "phone": {
-                  "type": "keyword"
-                },
-                "notes": {
-                  "type": "keyword"
-                },
                 "opening_weekdays": {
                   "properties": {
                     "weekday": {
@@ -236,9 +235,6 @@
               "type": "keyword"
             },
             "name": {
-              "type": "keyword"
-            },
-            "notes": {
               "type": "keyword"
             },
             "physical_location": {

--- a/invenio_app_ils/items/mappings/v7/items/item-v1.0.0.json
+++ b/invenio_app_ils/items/mappings/v7/items/item-v1.0.0.json
@@ -1,4 +1,14 @@
 {
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "email": {
+          "type": "custom",
+          "tokenizer": "uax_url_email"
+        }
+      }
+    }
+  },
   "mappings": {
     "date_detection": false,
     "numeric_detection": false,
@@ -47,7 +57,8 @@
           "patron": {
             "properties": {
               "email": {
-                "type": "text"
+                "type": "text",
+                "analyzer": "email"
               },
               "id": {
                 "type": "keyword"
@@ -177,18 +188,6 @@
               "name": {
                 "type": "keyword"
               },
-              "address": {
-                "type": "keyword"
-              },
-              "email": {
-                "type": "keyword"
-              },
-              "phone": {
-                "type": "keyword"
-              },
-              "notes": {
-                "type": "keyword"
-              },
               "opening_weekdays": {
                 "properties": {
                   "weekday": {
@@ -235,9 +234,6 @@
             "type": "keyword"
           },
           "name": {
-            "type": "keyword"
-          },
-          "notes": {
             "type": "keyword"
           },
           "physical_location": {

--- a/invenio_app_ils/locations/mappings/v6/locations/location-v1.0.0.json
+++ b/invenio_app_ils/locations/mappings/v6/locations/location-v1.0.0.json
@@ -1,4 +1,14 @@
 {
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "email": {
+          "type": "custom",
+          "tokenizer": "uax_url_email"
+        }
+      }
+    }
+  },
   "mappings": {
     "location-v1.0.0": {
       "date_detection": false,
@@ -17,7 +27,8 @@
           "type": "text"
         },
         "email": {
-          "type": "text"
+          "type": "text",
+          "analyzer": "email"
         },
         "name": {
           "type": "text"

--- a/invenio_app_ils/locations/mappings/v7/locations/location-v1.0.0.json
+++ b/invenio_app_ils/locations/mappings/v7/locations/location-v1.0.0.json
@@ -1,4 +1,14 @@
 {
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "email": {
+          "type": "custom",
+          "tokenizer": "uax_url_email"
+        }
+      }
+    }
+  },
   "mappings": {
     "date_detection": false,
     "numeric_detection": false,
@@ -16,7 +26,8 @@
         "type": "text"
       },
       "email": {
-        "type": "text"
+        "type": "text",
+        "analyzer": "email"
       },
       "name": {
         "type": "text"

--- a/invenio_app_ils/patrons/anonymization.py
+++ b/invenio_app_ils/patrons/anonymization.py
@@ -15,7 +15,7 @@ from flask import current_app
 from invenio_accounts.models import SessionActivity, User, userrole
 from invenio_circulation.proxies import current_circulation
 from invenio_db import db
-from invenio_oauthclient.models import RemoteAccount, UserIdentity, RemoteToken
+from invenio_oauthclient.models import RemoteAccount, RemoteToken, UserIdentity
 from invenio_userprofiles.models import UserProfile
 
 from invenio_app_ils.acquisition.proxies import current_ils_acq

--- a/invenio_app_ils/patrons/mappings/v6/patrons/patron-v1.0.0.json
+++ b/invenio_app_ils/patrons/mappings/v6/patrons/patron-v1.0.0.json
@@ -1,4 +1,14 @@
 {
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "email": {
+          "type": "custom",
+          "tokenizer": "uax_url_email"
+        }
+      }
+    }
+  },
   "mappings": {
     "patron-v1.0.0": {
       "date_detection": false,
@@ -8,6 +18,7 @@
           "type": "keyword"
         },
         "email": {
+          "analyzer": "email",
           "type": "text"
         },
         "id": {

--- a/invenio_app_ils/patrons/mappings/v7/patrons/patron-v1.0.0.json
+++ b/invenio_app_ils/patrons/mappings/v7/patrons/patron-v1.0.0.json
@@ -1,4 +1,14 @@
 {
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "email": {
+          "type": "custom",
+          "tokenizer": "uax_url_email"
+        }
+      }
+    }
+  },
   "mappings": {
     "date_detection": false,
     "numeric_detection": false,
@@ -7,7 +17,8 @@
         "type": "keyword"
       },
       "email": {
-        "type": "text"
+        "type": "text",
+        "analyzer": "email"
       },
       "id": {
         "type": "keyword"


### PR DESCRIPTION
Closes #922  (the wildcard from patronApi email is removed in [this PR)](https://github.com/inveniosoftware/react-invenio-app-ils/pull/275).

[Here](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-uaxurlemail-tokenizer.html) is the difference between the standard tokenizer and the `uax_url_email`.
The `uax_url_email` matches only the exact email address with the results, so for the email "john.doe@mail.com" the search john.doe or mail.com has no results.

Instead of defining settings in each mapping maybe we could use [elasticsearch index templates](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-templates.html).

Searches tested and working with the new tokenizer:
- checkout (search for patron by email)
- patrons search page
- libraries search page (search for library by email)
- vendors search page (search for vendor by email)
- borrowing request search (search by patron email)
- orders search page (search for vendor/patron by email)
- items search page (search by patron email)

Generally when you don't specify `email:` in the search it will tokenize the string and might return results if a field(except the email field) matches a token.
