### PR TITLE
records: split records db tables

### DIFF
--- a/invenio_app_ils/acquisition/api.py
+++ b/invenio_app_ils/acquisition/api.py
@@ -13,6 +13,7 @@ from flask import current_app
 from invenio_pidstore.models import PIDStatus
 from invenio_pidstore.providers.recordid_v2 import RecordIdProviderV2
 
+from invenio_app_ils.acquisition.models import OrderMetadata, VendorMetadata
 from invenio_app_ils.acquisition.proxies import current_ils_acq
 from invenio_app_ils.errors import RecordHasReferencesError
 from invenio_app_ils.fetchers import pid_fetcher
@@ -35,6 +36,7 @@ vendor_pid_fetcher = partial(pid_fetcher, provider_cls=VendorIdProvider)
 class Vendor(IlsRecord):
     """Acquisition vendor class."""
 
+    model_cls = VendorMetadata
     _pid_type = VENDOR_PID_TYPE
     _schema = "acq_vendors/vendor-v1.0.0.json"
 
@@ -70,6 +72,7 @@ order_pid_fetcher = partial(pid_fetcher, provider_cls=OrderIdProvider)
 class Order(IlsRecord):
     """Acquisition order class."""
 
+    model_cls = OrderMetadata
     _pid_type = ORDER_PID_TYPE
     _schema = "acq_orders/order-v1.0.0.json"
     _vendor_resolver_path = (

--- a/invenio_app_ils/acquisition/models.py
+++ b/invenio_app_ils/acquisition/models.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# invenio-app-ils is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Acquisition models."""
+
+from invenio_db import db
+from invenio_records.models import RecordMetadataBase
+
+
+class VendorMetadata(db.Model, RecordMetadataBase):
+    """Vendor record metadata."""
+
+    __tablename__ = "acq_vendors_metadata"
+
+
+class OrderMetadata(db.Model, RecordMetadataBase):
+    """Order record metadata."""
+
+    __tablename__ = "acq_orders_metadata"

--- a/invenio_app_ils/circulation/config.py
+++ b/invenio_app_ils/circulation/config.py
@@ -7,7 +7,6 @@
 
 """Configuration for Invenio ILS circulation module."""
 
-from invenio_circulation.api import Loan
 from invenio_circulation.pidstore.pids import (_LOANID_CONVERTER,
                                                CIRCULATION_LOAN_PID_TYPE)
 from invenio_circulation.search.api import LoansSearch
@@ -33,7 +32,8 @@ from invenio_app_ils.permissions import (PatronOwnerPermission,
                                          patron_owner_permission,
                                          superuser_permission)
 
-from .api import ILS_CIRCULATION_LOAN_FETCHER, ILS_CIRCULATION_LOAN_MINTER
+from .api import (ILS_CIRCULATION_LOAN_FETCHER, ILS_CIRCULATION_LOAN_MINTER,
+                  Loan)
 from .indexer import LoanIndexer
 from .jsonresolvers.loan import (document_resolver, item_resolver,
                                  loan_patron_resolver)

--- a/invenio_app_ils/circulation/models.py
+++ b/invenio_app_ils/circulation/models.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# invenio-app-ils is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Circulation models."""
+
+from invenio_db import db
+from invenio_records.models import RecordMetadataBase
+
+
+class LoanMetadata(db.Model, RecordMetadataBase):
+    """Loan record metadata."""
+
+    __tablename__ = "loans_metadata"

--- a/invenio_app_ils/circulation/tasks.py
+++ b/invenio_app_ils/circulation/tasks.py
@@ -12,7 +12,6 @@ from copy import deepcopy
 from celery import shared_task
 from celery.utils.log import get_task_logger
 from flask import current_app
-from invenio_circulation.api import Loan
 from invenio_circulation.proxies import current_circulation
 from invenio_db import db
 
@@ -27,6 +26,7 @@ def cancel_expired_loan_requests():
     SystemAgent = current_app.config["ILS_PATRON_SYSTEM_AGENT_CLASS"]
     system_agent_id = str(SystemAgent.id)
 
+    Loan = current_circulation.loan_record_cls
     expired_loans = get_all_expired_loans().execute()
     for hit in expired_loans.hits:
         loan = Loan.get_record_by_pid(hit.pid)

--- a/invenio_app_ils/cli.py
+++ b/invenio_app_ils/cli.py
@@ -21,8 +21,8 @@ import lorem
 from flask import current_app
 from flask.cli import with_appcontext
 from invenio_accounts.models import User
-from invenio_circulation.api import Loan
 from invenio_circulation.pidstore.pids import CIRCULATION_LOAN_PID_TYPE
+from invenio_circulation.proxies import current_circulation
 from invenio_db import db
 from invenio_indexer.api import RecordIndexer
 from invenio_pages import Page
@@ -665,6 +665,7 @@ class LoanGenerator(Generator):
     def persist(self):
         """Persist."""
         recs = []
+        Loan = current_circulation.loan_record_cls
         for obj in self.holder.loans["objs"]:
             rec = self._persist(
                 CIRCULATION_LOAN_PID_TYPE, "pid", Loan.create(obj)

--- a/invenio_app_ils/document_requests/api.py
+++ b/invenio_app_ils/document_requests/api.py
@@ -14,6 +14,7 @@ from invenio_pidstore.errors import PIDDoesNotExistError
 from invenio_pidstore.models import PIDStatus
 from invenio_pidstore.providers.recordid_v2 import RecordIdProviderV2
 
+from invenio_app_ils.document_requests.models import DocumentRequestMetadata
 from invenio_app_ils.document_requests.search import DocumentRequestSearch
 from invenio_app_ils.errors import DocumentRequestError
 from invenio_app_ils.fetchers import pid_fetcher
@@ -95,6 +96,7 @@ class DocumentRequest(IlsRecord):
     STATES = ["ACCEPTED", "PENDING", "REJECTED"]
     REJECT_TYPES = ["USER_CANCEL", "IN_CATALOG", "NOT_FOUND"]
 
+    model_cls = DocumentRequestMetadata
     _pid_type = DOCUMENT_REQUEST_PID_TYPE
     _schema = "document_requests/document_request-v1.0.0.json"
     _validator = DocumentRequestValidator()

--- a/invenio_app_ils/document_requests/models.py
+++ b/invenio_app_ils/document_requests/models.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# invenio-app-ils is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""DocumetRequest models."""
+
+from invenio_db import db
+from invenio_records.models import RecordMetadataBase
+
+
+class DocumentRequestMetadata(db.Model, RecordMetadataBase):
+    """DocumentRequest record metadata."""
+
+    __tablename__ = "document_requests_metadata"

--- a/invenio_app_ils/documents/api.py
+++ b/invenio_app_ils/documents/api.py
@@ -15,6 +15,7 @@ from invenio_pidstore.errors import PersistentIdentifierError
 from invenio_pidstore.models import PIDStatus
 from invenio_pidstore.providers.recordid_v2 import RecordIdProviderV2
 
+from invenio_app_ils.documents.models import DocumentMetadata
 from invenio_app_ils.errors import RecordHasReferencesError
 from invenio_app_ils.fetchers import pid_fetcher
 from invenio_app_ils.minters import pid_minter
@@ -37,13 +38,9 @@ document_pid_fetcher = partial(pid_fetcher, provider_cls=DocumentIdProvider)
 class Document(IlsRecordWithRelations):
     """Document record class."""
 
-    DOCUMENT_TYPES = [
-        "BOOK",
-        "PROCEEDING",
-        "STANDARD",
-        "PERIODICAL_ISSUE",
-    ]
+    DOCUMENT_TYPES = ["BOOK", "PROCEEDING", "STANDARD", "PERIODICAL_ISSUE"]
 
+    model_cls = DocumentMetadata
     _pid_type = DOCUMENT_PID_TYPE
     _schema = "documents/document-v1.0.0.json"
     _circulation_resolver_path = (
@@ -119,7 +116,7 @@ class Document(IlsRecordWithRelations):
         """Delete Document record."""
         loan_search_res = search_by_pid(
             document_pid=self["pid"],
-            filter_states=["PENDING"]
+            filter_states=current_app.config["CIRCULATION_STATES_LOAN_REQUEST"]
             + current_app.config["CIRCULATION_STATES_LOAN_ACTIVE"],
         )
         if loan_search_res.count():

--- a/invenio_app_ils/documents/models.py
+++ b/invenio_app_ils/documents/models.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# invenio-app-ils is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Document models."""
+
+from invenio_db import db
+from invenio_records.models import RecordMetadataBase
+
+
+class DocumentMetadata(db.Model, RecordMetadataBase):
+    """Document record metadata."""
+
+    __tablename__ = "documents_metadata"

--- a/invenio_app_ils/eitems/api.py
+++ b/invenio_app_ils/eitems/api.py
@@ -14,6 +14,7 @@ from invenio_files_rest.models import ObjectVersion
 from invenio_pidstore.models import PIDStatus
 from invenio_pidstore.providers.recordid_v2 import RecordIdProviderV2
 
+from invenio_app_ils.eitems.models import EItemMetadata
 from invenio_app_ils.fetchers import pid_fetcher
 from invenio_app_ils.minters import pid_minter
 from invenio_app_ils.records.api import IlsRecord
@@ -34,6 +35,7 @@ eitem_pid_fetcher = partial(pid_fetcher, provider_cls=EItemIdProvider)
 class EItem(IlsRecord):
     """EItem record class."""
 
+    model_cls = EItemMetadata
     _pid_type = EITEM_PID_TYPE
     _schema = "eitems/eitem-v1.0.0.json"
     _document_resolver_path = (

--- a/invenio_app_ils/eitems/models.py
+++ b/invenio_app_ils/eitems/models.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# invenio-app-ils is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""EItem models."""
+
+from invenio_db import db
+from invenio_records.models import RecordMetadataBase
+
+
+class EItemMetadata(db.Model, RecordMetadataBase):
+    """EItem record metadata."""
+
+    __tablename__ = "eitems_metadata"

--- a/invenio_app_ils/eitems/search.py
+++ b/invenio_app_ils/eitems/search.py
@@ -7,10 +7,13 @@
 
 """ILS EItems search APIs."""
 
+from elasticsearch import VERSION as ES_VERSION
 from flask import current_app
 from invenio_search.api import RecordsSearch
 
 from invenio_app_ils.errors import MissingRequiredParameterError
+
+ES_LT_7 = ES_VERSION[0] < 7
 
 
 class EItemSearch(RecordsSearch):
@@ -53,7 +56,8 @@ class EItemSearch(RecordsSearch):
             )
 
         results = search.execute()
-        if len(results) != 1:
+        total = results.hits.total if ES_LT_7 else results.hits.total.value
+        if total != 1:
             # There should always be one bucket associated with an eitem when
             # downloading a file.
             msg = "found 0 or multiple records with bucket {0}".format(

--- a/invenio_app_ils/ill/models.py
+++ b/invenio_app_ils/ill/models.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# invenio-app-ils is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""ILL models."""
+
+from invenio_db import db
+from invenio_records.models import RecordMetadataBase
+
+
+class LibraryMetadata(db.Model, RecordMetadataBase):
+    """Library record metadata."""
+
+    __tablename__ = "ill_libraries_metadata"
+
+
+class BorrowingRequestMetadata(db.Model, RecordMetadataBase):
+    """BorrowingRequest record metadata."""
+
+    __tablename__ = "ill_brwreqs_metadata"

--- a/invenio_app_ils/internal_locations/api.py
+++ b/invenio_app_ils/internal_locations/api.py
@@ -15,6 +15,7 @@ from invenio_pidstore.providers.recordid_v2 import RecordIdProviderV2
 
 from invenio_app_ils.errors import RecordHasReferencesError
 from invenio_app_ils.fetchers import pid_fetcher
+from invenio_app_ils.internal_locations.models import InternalLocationMetadata
 from invenio_app_ils.minters import pid_minter
 from invenio_app_ils.proxies import current_app_ils
 from invenio_app_ils.records.api import IlsRecord
@@ -35,6 +36,7 @@ internal_location_pid_fetcher = partial(pid_fetcher, provider_cls=InternalLocati
 class InternalLocation(IlsRecord):
     """Internal Location record class."""
 
+    model_cls = InternalLocationMetadata
     _pid_type = INTERNAL_LOCATION_PID_TYPE
     _schema = "internal_locations/internal_location-v1.0.0.json"
     _location_resolver_path = (

--- a/invenio_app_ils/internal_locations/models.py
+++ b/invenio_app_ils/internal_locations/models.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# invenio-app-ils is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Internal Location models."""
+
+from invenio_db import db
+from invenio_records.models import RecordMetadataBase
+
+
+class InternalLocationMetadata(db.Model, RecordMetadataBase):
+    """Internal Location record metadata."""
+
+    __tablename__ = "intlocs_metadata"

--- a/invenio_app_ils/items/api.py
+++ b/invenio_app_ils/items/api.py
@@ -27,6 +27,7 @@ from invenio_app_ils.records.api import IlsRecord, RecordValidator
 from ..circulation.utils import resolve_item_from_loan
 from ..errors import RecordHasReferencesError
 from ..proxies import current_app_ils
+from .models import ItemMetadata
 
 lt_es7 = ES_VERSION[0] < 7
 
@@ -85,6 +86,7 @@ class ItemValidator(RecordValidator):
 class Item(IlsRecord):
     """Item record class."""
 
+    model_cls = ItemMetadata
     _pid_type = ITEM_PID_TYPE
     _schema = "items/item-v1.0.0.json"
     _validator = ItemValidator()

--- a/invenio_app_ils/items/models.py
+++ b/invenio_app_ils/items/models.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# invenio-app-ils is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Item models."""
+
+from invenio_db import db
+from invenio_records.models import RecordMetadataBase
+
+
+class ItemMetadata(db.Model, RecordMetadataBase):
+    """Item record metadata."""
+
+    __tablename__ = "items_metadata"

--- a/invenio_app_ils/locations/api.py
+++ b/invenio_app_ils/locations/api.py
@@ -14,6 +14,7 @@ from invenio_pidstore.providers.recordid_v2 import RecordIdProviderV2
 
 from invenio_app_ils.errors import RecordHasReferencesError
 from invenio_app_ils.fetchers import pid_fetcher
+from invenio_app_ils.locations.models import LocationMetadata
 from invenio_app_ils.minters import pid_minter
 from invenio_app_ils.proxies import current_app_ils
 from invenio_app_ils.records.api import IlsRecord
@@ -34,6 +35,7 @@ location_pid_fetcher = partial(pid_fetcher, provider_cls=LocationIdProvider)
 class Location(IlsRecord):
     """Location record class."""
 
+    model_cls = LocationMetadata
     _pid_type = LOCATION_PID_TYPE
     _schema = "locations/location-v1.0.0.json"
 

--- a/invenio_app_ils/locations/models.py
+++ b/invenio_app_ils/locations/models.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# invenio-app-ils is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Location models."""
+
+from invenio_db import db
+from invenio_records.models import RecordMetadataBase
+
+
+class LocationMetadata(db.Model, RecordMetadataBase):
+    """Location record metadata."""
+
+    __tablename__ = "locations_metadata"

--- a/invenio_app_ils/records/api.py
+++ b/invenio_app_ils/records/api.py
@@ -34,6 +34,8 @@ class RecordValidator(object):
 class IlsRecord(Record):
     """Ils record class."""
 
+    model_cls = None
+
     CURATOR_TYPES = ["user_id", "script",  "import"]
 
     _validator = RecordValidator()

--- a/invenio_app_ils/series/api.py
+++ b/invenio_app_ils/series/api.py
@@ -16,6 +16,7 @@ from invenio_pidstore.providers.recordid_v2 import RecordIdProviderV2
 from invenio_app_ils.fetchers import pid_fetcher
 from invenio_app_ils.minters import pid_minter
 from invenio_app_ils.records_relations.api import IlsRecordWithRelations
+from invenio_app_ils.series.models import SeriesMetadata
 
 SERIES_PID_TYPE = "serid"
 SERIES_PID_MINTER = "serid"
@@ -33,6 +34,7 @@ series_pid_fetcher = partial(pid_fetcher, provider_cls=SeriesIdProvider)
 class Series(IlsRecordWithRelations):
     """Series record class."""
 
+    model_cls = SeriesMetadata
     _pid_type = SERIES_PID_TYPE
     _schema = "series/series-v1.0.0.json"
     _relations_path = (

--- a/invenio_app_ils/series/models.py
+++ b/invenio_app_ils/series/models.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# invenio-app-ils is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Location models."""
+
+from invenio_db import db
+from invenio_records.models import RecordMetadataBase
+
+
+class SeriesMetadata(db.Model, RecordMetadataBase):
+    """Series record metadata."""
+
+    __tablename__ = "series_metadata"

--- a/setup.py
+++ b/setup.py
@@ -137,6 +137,18 @@ setup(
             "00_invenio_app_ils = invenio_app_ils.config",
             "00_invenio_app_ils_circulation = invenio_app_ils.circulation.config",
         ],
+        "invenio_db.models": [
+            "ils_acquisition = invenio_app_ils.acquisition.models",
+            "ils_circulation = invenio_app_ils.circulation.models",
+            "ils_document_requests = invenio_app_ils.document_requests.models",
+            "ils_documents = invenio_app_ils.documents.models",
+            "ils_eitems = invenio_app_ils.eitems.models",
+            "ils_ill = invenio_app_ils.ill.models",
+            "ils_internal_locations = invenio_app_ils.internal_locations.models",
+            "ils_items = invenio_app_ils.items.models",
+            "ils_locations = invenio_app_ils.locations.models",
+            "ils_series = invenio_app_ils.series.models",
+        ],
         "invenio_i18n.translations": ["messages = invenio_app_ils"],
         "invenio_jsonschemas.schemas": [
             "acquisition = invenio_app_ils.acquisition.schemas",


### PR DESCRIPTION
<img width="344" alt="pgAdmin_4" src="https://user-images.githubusercontent.com/2089455/99313599-1fc66800-2860-11eb-9667-22a4fe63ee40.png">

There is still an issue with this to be solved before merging:

```
....lib/python3.6/site-packages/sqlalchemy/ext/declarative/clsregistry.py:129: SAWarning: This declarative base already contains a class with the same class name and module name as sqlalchemy_continuum.m
odel_builder.SeriesMetadataVersion, and will be replaced in the string-lookup table.
  % (item.__module__, item.__name__)

...lib/python3.6/site-packages/sqlalchemy/orm/properties.py:249: SAWarning: On mapper mapped class RecordMetadataVersion->records_metadata_version, primary key column 'records_metadata_version.transacti
on_id' is being combined with distinct primary key column 'records_metadata_version.transaction_id' in attribute 'transaction_id'. Use explicit properties to give each column its own mapped attribute name.
  % (self.parent, self.columns[1], self.columns[0], self.key)
```

Related to https://github.com/inveniosoftware/invenio-db/issues/96