### PR TITLE
items: allow multiple ISBNs

### DIFF
--- a/invenio_app_ils/cli.py
+++ b/invenio_app_ils/cli.py
@@ -230,6 +230,7 @@ class ItemGenerator(Generator):
                 "pid": self.create_pid(),
                 "document_pid": random.choice(doc_pids),
                 "internal_location_pid": random.choice(iloc_pids),
+                "isbns": [{'value': '978-1-891830-85-3'}],
                 "legacy_id": "{}".format(randint(100000, 999999)),
                 "legacy_library_id": "{}".format(randint(5, 50)),
                 "barcode": "{}".format(randint(10000000, 99999999)),

--- a/invenio_app_ils/items/loaders/jsonschemas/items.py
+++ b/invenio_app_ils/items/loaders/jsonschemas/items.py
@@ -43,7 +43,7 @@ class ItemSchemaV1(RecordMetadataSchemaJSONV1):
     document_pid = fields.Str(required=True)  # TODO: validate
     internal_location_pid = fields.Str(required=True)  # TODO: validate
     internal_notes = fields.Str()
-    isbn = fields.Nested(ISBNSchema)
+    isbns = fields.List(fields.Nested(ISBNSchema))
     legacy_id = fields.Str()
     legacy_library_id = fields.Str()
     medium = fields.Str(required=True)

--- a/invenio_app_ils/items/mappings/v6/items/item-v1.0.0.json
+++ b/invenio_app_ils/items/mappings/v6/items/item-v1.0.0.json
@@ -252,7 +252,7 @@
         "internal_notes": {
           "type": "text"
         },
-        "isbn": {
+        "isbns": {
           "properties": {
             "description": {
               "type": "keyword"

--- a/invenio_app_ils/items/mappings/v7/items/item-v1.0.0.json
+++ b/invenio_app_ils/items/mappings/v7/items/item-v1.0.0.json
@@ -251,7 +251,7 @@
       "internal_notes": {
         "type": "text"
       },
-      "isbn": {
+      "isbns": {
         "properties": {
           "description": {
             "type": "keyword"

--- a/invenio_app_ils/items/schemas/items/item-v1.0.0.json
+++ b/invenio_app_ils/items/schemas/items/item-v1.0.0.json
@@ -70,20 +70,26 @@
       "type": "string",
       "title": "Any extra description for this Item reserved for library usage"
     },
-    "isbn": {
-      "properties": {
-        "description": {
-          "title": "Free text, used to describe the document to ISBN refers to.",
-          "type": "string"
+    "isbns": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "title": "Free text, used to describe the document to ISBN refers to.",
+            "type": "string"
+          },
+          "value": {
+            "minLength": 1,
+            "type": "string"
+          }
         },
-        "value": {
-          "minLength": 1,
-          "type": "string"
-        }
+        "required": ["value"],
+        "title": "ISBN",
+        "type": "object"
       },
-      "required": ["value"],
-      "title": "ISBN",
-      "type": "object"
+      "title": "List of ISBNs",
+      "type": "array",
+      "uniqueItems": true
     },
     "legacy_id": {
       "type": "string",


### PR DESCRIPTION
As requested by @kprzerwa, and to match the library requirement of having multiple ISBNs (although there is technically only one such identifier per physical item, with two different representations; see #991). Renaming `isbn` to `isbns` to avoid confusion.