### PR TITLE
DocumentRequest: validate accepted requests

### DIFF
--- a/invenio_app_ils/cli.py
+++ b/invenio_app_ils/cli.py
@@ -102,6 +102,7 @@ class Holder(object):
             "objs": [],
             "total": total_borrowing_requests,
         }
+        self.pending_borrowing_requests = {"objs": []}
         self.libraries = {"objs": [], "total": total_libraries}
 
     def pids(self, collection, pid_field):
@@ -480,7 +481,7 @@ class DocumentGenerator(Generator):
                 lang["key"]
                 for lang in random.sample(self.holder.languages, randint(1, 3))
             ],
-                        "table_of_content": ["{}".format(lorem.sentence())],
+            "table_of_content": ["{}".format(lorem.sentence())],
             "note": "{}".format(lorem.text()),
             "tags": [
                 tag["key"]
@@ -906,6 +907,12 @@ class DocumentRequestGenerator(Generator):
         """Get a random document PID."""
         return random.choice(self.holder.pids("documents", "pid"))
 
+    def random_pending_borrowing_request(self):
+        """Get a random document PID."""
+        return random.choice(
+            self.holder.pids("pending_borrowing_requests", "pid")
+        )
+
     def generate(self):
         """Generate."""
         size = self.holder.document_requests["total"]
@@ -930,6 +937,10 @@ class DocumentRequestGenerator(Generator):
                     obj["document_pid"] = self.random_document_pid()
             elif state == "ACCEPTED":
                 obj["document_pid"] = self.random_document_pid()
+                obj["physical_item_provider"] = {
+                    "pid": self.random_pending_borrowing_request(),
+                    "pid_type": BORROWING_REQUEST_PID_TYPE,
+                }
             objs.append(obj)
 
         self.holder.document_requests["objs"] = objs
@@ -1011,9 +1022,10 @@ class BorrowingRequestGenerator(Generator):
         objs = []
         now = datetime.now()
         for pid in range(1, size + 1):
+            status = random.choice(BorrowingRequest.STATUSES)
             obj = {
                 "pid": self.create_pid(),
-                "status": random.choice(BorrowingRequest.STATUSES),
+                "status": status,
                 "library_pid": self.random_library_pid(),
                 "document_pid": self.random_document_pid(),
                 "patron_pid": random.choice(self.holder.patrons_pids),
@@ -1047,6 +1059,9 @@ class BorrowingRequestGenerator(Generator):
                 obj["cancel_reason"] = lorem.sentence()
 
             objs.append(obj)
+
+            if status == "PENDING":
+                self.holder.pending_borrowing_requests["objs"] = objs
 
         self.holder.borrowing_requests["objs"] = objs
 
@@ -1302,6 +1317,18 @@ def data(
     related_generator.generate(rec_docs, rec_series)
     related_generator.persist()
 
+    # Libraries
+    click.echo("Creating ILL external libraries...")
+    library_generator = LibraryGenerator(holder, minter)
+    library_generator.generate()
+    rec_libraries = library_generator.persist()
+
+    # Borrowing requests
+    click.echo("Creating ILL borrowing requests...")
+    borrowing_requests_generator = BorrowingRequestGenerator(holder, minter)
+    borrowing_requests_generator.generate()
+    rec_borrowing_requests = borrowing_requests_generator.persist()
+
     # Document requests
     click.echo("Creating document requests...")
     document_requests_generator = DocumentRequestGenerator(holder, minter)
@@ -1319,18 +1346,6 @@ def data(
     order_generator = OrderGenerator(holder, minter)
     order_generator.generate()
     rec_orders = order_generator.persist()
-
-    # Libraries
-    click.echo("Creating ILL external libraries...")
-    library_generator = LibraryGenerator(holder, minter)
-    library_generator.generate()
-    rec_libraries = library_generator.persist()
-
-    # Borrowing requests
-    click.echo("Creating ILL borrowing requests...")
-    borrowing_requests_generator = BorrowingRequestGenerator(holder, minter)
-    borrowing_requests_generator.generate()
-    rec_borrowing_requests = borrowing_requests_generator.persist()
 
     # index internal locations
     indexer.bulk_index([str(r.id) for r in rec_intlocs])

--- a/invenio_app_ils/document_requests/api.py
+++ b/invenio_app_ils/document_requests/api.py
@@ -74,6 +74,16 @@ class DocumentRequestValidator(RecordValidator):
                 "without providing a document_pid."
             )
 
+    def validate_acceptance(self, document_pid, physical_item_provider, state):
+        """Validate rejection is correct."""
+        if state == "ACCEPTED" and (
+            not document_pid or not physical_item_provider
+        ):
+            raise DocumentRequestError(
+                "Need to provide a document_pid and a physical_item_provider "
+                "when accepting a request"
+            )
+
     def validate(self, record, **kwargs):
         """Validate record before create and commit."""
         super().validate(record, **kwargs)
@@ -83,10 +93,12 @@ class DocumentRequestValidator(RecordValidator):
         document_pid = record.get("document_pid", None)
         state = record.get("state", None)
         reject_reason = record.get("reject_reason", None)
+        physical_item_provider = record.get("physical_item_provider", None)
 
         self.validate_state(state, valid_states)
         self.validate_document_pid(document_pid, state, reject_reason)
         self.validate_rejection(document_pid, state, reject_reason)
+        self.validate_acceptance(document_pid, physical_item_provider, state)
 
 
 class DocumentRequest(IlsRecord):

--- a/tests/data/document_requests.json
+++ b/tests/data/document_requests.json
@@ -28,8 +28,13 @@
     "request_type": "LOAN",
     "medium": "PAPER",
     "document_pid": "docid-1",
-    "title": "Test title 3"
+    "title": "Test title 3",
+    "physical_item_provider": {
+      "pid": "acq-order-pid",
+      "pid_type": "acquisition"
+    }
   },
+
   {
     "pid": "dreq-4",
     "state": "ACCEPTED",
@@ -37,7 +42,11 @@
     "request_type": "BUY",
     "medium": "PAPER",
     "document_pid": "docid-2",
-    "title": "Test title 4"
+    "title": "Test title 4",
+    "physical_item_provider": {
+      "pid": "acq-order-pid",
+      "pid_type": "acquisition"
+    }
   },
   {
     "pid": "dreq-5",


### PR DESCRIPTION
Validate if provider and document is given to a request with accepted status. 
The problem that occured before had to do with the demo data from cli: in the frontend the step to add a provider was not disabled (because the accepted requests didn't have a provider) and resulted in a server error when a provider was added.
Closes partially inveniosoftware/react-invenio-app-ils#290