### PR TITLE
[BLOCKED]config: set max_results_window to 10000 again, fix demo data author roles

### DIFF
--- a/invenio_app_ils/cli.py
+++ b/invenio_app_ils/cli.py
@@ -385,11 +385,11 @@ class DocumentGenerator(Generator):
                 }
             ],
             "identifiers": [{"scheme": "ORCID", "value": "1234AAA"}],
-            "roles": ["editor"],
+            "roles": ["EDITOR"],
         },
         {
             "full_name": "Doe, John",
-            "roles": ["AUTHOR"],
+            "roles": ["RESEARCHER"],
             "affiliations": [{"name": "CERN"}],
         },
     ]

--- a/invenio_app_ils/config.py
+++ b/invenio_app_ils/config.py
@@ -327,7 +327,7 @@ _SERID_CONVERTER = (
     'pid(serid, record_class="invenio_app_ils.series.api:Series")'
 )
 
-RECORDS_REST_MAX_RESULT_WINDOW = 5000
+RECORDS_REST_MAX_RESULT_WINDOW = 10000
 RECORDS_REST_VOCAB_MAX_RESULT_WINDOW = 500
 PIDSTORE_RECID_FIELD = "pid"
 # name of the URL arg to choose response serializer

--- a/invenio_app_ils/demo_data/documents.json
+++ b/invenio_app_ils/demo_data/documents.json
@@ -4,7 +4,7 @@
     "authors": [
       {
         "full_name": "Delbourgo, Robert",
-        "roles": ["Author"]
+        "roles": ["DATA_CURATOR"]
       }
     ],
     "edition": "2",
@@ -40,7 +40,7 @@
     "authors": [
       {
         "full_name": "Knebl, Helmut",
-        "roles": ["Author"]
+        "roles": ["RESEARCHER"]
       }
     ],
     "imprint": {
@@ -67,7 +67,7 @@
     "authors": [
       {
         "full_name": "Einstein, Albert",
-        "roles": ["Author"]
+        "roles": ["RESEARCHER"]
       }
     ],
     "imprint": {
@@ -103,7 +103,7 @@
     "authors": [
       {
         "full_name": "Jacob, Irene",
-        "roles": ["Author"]
+        "roles": ["DATA_CURATOR"]
       }
     ],
     "imprint": {
@@ -138,7 +138,7 @@
     "authors": [
       {
         "full_name": "Grozin, A G",
-        "roles": ["Author"]
+        "roles": ["DATA_CURATOR"]
       }
     ],
     "imprint": {
@@ -173,7 +173,7 @@
     "authors": [
       {
         "full_name": "Schaa, Volker R W",
-        "roles": ["editor"]
+        "roles": ["EDITOR"]
       }
     ],
     "imprint": {


### PR DESCRIPTION
- in the end the max_results_window can remain 10000 and the changes can be only in the frontend
- changed role `Author` in demo data because it doesn't exist in the vocabulary

DEPENDS ON https://github.com/inveniosoftware/react-invenio-app-ils/pull/349