### PR TITLE
email: overdue loans

### DIFF
--- a/invenio_app_ils/circulation/search.py
+++ b/invenio_app_ils/circulation/search.py
@@ -72,6 +72,7 @@ def get_all_overdue_loans():
         search_cls()
         .filter("terms", state=states)
         .filter("range", end_date=dict(lt="now/d"))
+        .filter("range", patron_pid=dict(gte=0))
     )
 
 


### PR DESCRIPTION
* Restricts the email sending to loans
  assigned to real patrons (excludes ids < 0)
* https://cds-sentry.web.cern.ch/sentry/cds-ils/issues/27269/?environment=sandbox&referrer=alert_email