### PR TITLE
docker: pin setuptools version

### DIFF
--- a/docker-services.yml
+++ b/docker-services.yml
@@ -88,7 +88,7 @@ services:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     ports: ["5601:5601"]
   flower:
-    image: mher/flower
+    image: mher/flower:0.9.7
     command: --broker=amqp://guest:guest@mq:5672/ --broker_api=http://guest:guest@mq:15672/api/
     ports:
       - "5555:5555"

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -10,7 +10,10 @@ FROM python:3.6
 RUN apt-get update && apt-get upgrade -y && apt-get install apt-file -y && apt-file update
 RUN cd /tmp && curl -sL https://deb.nodesource.com/setup_12.x -o nodesource_setup.sh && bash nodesource_setup.sh
 RUN apt-get install -y nodejs git curl vim
-RUN pip install --upgrade setuptools wheel pip uwsgi uwsgitop uwsgi-tools
+
+# setuptools<58: https://setuptools.pypa.io/en/latest/history.html#v58-0-0
+# the `fs` package relies on `2to3`
+RUN pip install --upgrade "setuptools<58" wheel pip uwsgi uwsgitop uwsgi-tools
 
 RUN python -m site
 RUN python -m site --user-site


### PR DESCRIPTION
* the release of setuptools v58 dropped support for 2to3
* the `fs` packages used by Invenio still needs 2to3
* closes #1113
* closes inveniosoftware#1105