### PR TITLE
items: serializers: Build cover metadata for resolved doc before index

### DIFF
--- a/invenio_app_ils/items/serializers/item.py
+++ b/invenio_app_ils/items/serializers/item.py
@@ -10,6 +10,7 @@
 from invenio_records_rest.serializers.csv import CSVSerializer
 from invenio_records_rest.serializers.json import JSONSerializer
 
+from invenio_app_ils.literature.serializers.custom_fields import field_cover_metadata
 from invenio_app_ils.permissions import patron_permission
 
 FILTER_KEYS = [
@@ -48,6 +49,7 @@ class ItemCSVSerializer(CSVSerializer):
             pid, record, links_factory=links_factory, **kwargs
         )
         filter_circulation(item)
+        field_cover_metadata(item.get('metadata', {}).get("document", {}))
         return item
 
     def transform_search_hit(self, pid, record_hit, links_factory=None, **kwargs):
@@ -56,6 +58,7 @@ class ItemCSVSerializer(CSVSerializer):
             pid, record_hit, links_factory=links_factory, **kwargs
         )
         filter_circulation(hit)
+        field_cover_metadata(hit.get('metadata', {}).get("document", {}))
         return hit
 
 
@@ -68,6 +71,7 @@ class ItemJSONSerializer(JSONSerializer):
             pid, record, links_factory=links_factory, **kwargs
         )
         filter_circulation(item)
+        field_cover_metadata(item.get('metadata', {}).get("document", {}))
         return item
 
     def transform_search_hit(self, pid, record_hit, links_factory=None, **kwargs):
@@ -76,4 +80,5 @@ class ItemJSONSerializer(JSONSerializer):
             pid, record_hit, links_factory=links_factory, **kwargs
         )
         filter_circulation(hit)
+        field_cover_metadata(hit.get('metadata', {}).get("document", {}))
         return hit


### PR DESCRIPTION
Build cover metadata at creation before indexing in items' resolved document fields