### PR TITLE
self-checkout: use dedicated endpoints

### DIFF
--- a/invenio_app_ils/circulation/config.py
+++ b/invenio_app_ils/circulation/config.py
@@ -44,7 +44,6 @@ from invenio_app_ils.permissions import (
     PatronOwnerPermission,
     authenticated_user_permission,
     backoffice_permission,
-    loan_checkout_permission,
     loan_extend_circulation_permission,
     patron_owner_permission,
     superuser_permission,
@@ -84,6 +83,7 @@ ILS_CIRCULATION_LOAN_WILL_EXPIRE_DAYS = 7
 ILS_CIRCULATION_DELIVERY_METHODS = {
     "PICKUP": "Pick it up at the library desk",
     "DELIVERY": "Have it delivered to my office",
+    "SELF-CHECKOUT": "Self-checkout",
 }
 
 # Notification message creator for loan notifications
@@ -162,7 +162,13 @@ CIRCULATION_LOAN_TRANSITIONS = {
             dest="ITEM_ON_LOAN",
             trigger="checkout",
             transition=ILSToItemOnLoan,
-            permission_factory=loan_checkout_permission,
+            permission_factory=backoffice_permission,
+        ),
+        dict(
+            dest="ITEM_ON_LOAN",
+            trigger="self_checkout",
+            transition=ILSToItemOnLoan,
+            permission_factory=authenticated_user_permission,
         ),
     ],
     "PENDING": [
@@ -171,6 +177,12 @@ CIRCULATION_LOAN_TRANSITIONS = {
             trigger="checkout",
             transition=ILSToItemOnLoan,
             permission_factory=backoffice_permission,
+        ),
+        dict(
+            dest="ITEM_ON_LOAN",
+            trigger="self_checkout",
+            transition=ILSToItemOnLoan,
+            permission_factory=authenticated_user_permission,
         ),
         dict(
             dest="CANCELLED",

--- a/invenio_app_ils/circulation/loaders/__init__.py
+++ b/invenio_app_ils/circulation/loaders/__init__.py
@@ -12,9 +12,11 @@ from invenio_app_ils.records.loaders import ils_marshmallow_loader
 from .schemas.json.bulk_extend import BulkExtendLoansSchemaV1
 from .schemas.json.loan_checkout import LoanCheckoutSchemaV1
 from .schemas.json.loan_request import LoanRequestSchemaV1
+from .schemas.json.loan_self_checkout import LoanSelfCheckoutSchemaV1
 from .schemas.json.loan_update_dates import LoanUpdateDatesSchemaV1
 
 loan_request_loader = ils_marshmallow_loader(LoanRequestSchemaV1)
 loan_checkout_loader = ils_marshmallow_loader(LoanCheckoutSchemaV1)
+loan_self_checkout_loader = ils_marshmallow_loader(LoanSelfCheckoutSchemaV1)
 loan_update_dates_loader = ils_marshmallow_loader(LoanUpdateDatesSchemaV1)
 loans_bulk_update_loader = ils_marshmallow_loader(BulkExtendLoansSchemaV1)

--- a/invenio_app_ils/circulation/loaders/schemas/json/loan_self_checkout.py
+++ b/invenio_app_ils/circulation/loaders/schemas/json/loan_self_checkout.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CERN.
+#
+# invenio-app-ils is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Invenio App ILS circulation Loan Checkout loader JSON schema."""
+
+from invenio_circulation.records.loaders.schemas.json import LoanItemPIDSchemaV1
+from marshmallow import fields
+
+from .base import LoanBaseSchemaV1
+
+
+class LoanSelfCheckoutSchemaV1(LoanBaseSchemaV1):
+    """Loan self-checkout schema."""
+
+    item_pid = fields.Nested(LoanItemPIDSchemaV1, required=True)

--- a/invenio_app_ils/circulation/notifications/messages.py
+++ b/invenio_app_ils/circulation/notifications/messages.py
@@ -25,6 +25,7 @@ class NotificationLoanMsg(NotificationMsg):
         request="request.html",
         request_no_items="request_no_items.html",
         checkout="checkout.html",
+        self_checkout="self_checkout.html",
         checkin="checkin.html",
         extend="extend.html",
         cancel="cancel.html",

--- a/invenio_app_ils/circulation/serializers/__init__.py
+++ b/invenio_app_ils/circulation/serializers/__init__.py
@@ -6,6 +6,7 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Loan serializers."""
+
 from invenio_records_rest.serializers.response import search_responsify
 
 from invenio_app_ils.records.schemas.json import ILSRecordSchemaJSONV1

--- a/invenio_app_ils/circulation/serializers/response.py
+++ b/invenio_app_ils/circulation/serializers/response.py
@@ -6,6 +6,7 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Response serializers for circulation module."""
+
 import json
 
 from flask import current_app

--- a/invenio_app_ils/circulation/templates/invenio_app_ils_circulation/notifications/self_checkout.html
+++ b/invenio_app_ils/circulation/templates/invenio_app_ils_circulation/notifications/self_checkout.html
@@ -1,0 +1,19 @@
+{% block title %}
+InvenioILS: loan started for "{{ document.title|safe }}"
+{% endblock %}
+
+{% block body_plain %}
+Dear {{ patron.name }},
+
+your self-checkout loan for "{{ document.full_title }}" <{{ spa_routes.HOST }}{{ spa_routes.PATHS['literature']|format(pid=document.pid) }}> has started.
+
+The due date is {{ loan.end_date }}.
+{% endblock %}
+
+{% block body_html %}
+Dear {{ patron.name }}, <br/><br/>
+
+your self-checkout loan for <a href="{{ spa_routes.HOST }}{{ spa_routes.PATHS['literature']|format(pid=document.pid) }}">"{{ document.full_title }}"</a> has <b>started</b>. <br/><br/>
+
+<b>The due date is {{ loan.end_date }}</b>.<br/>
+{% endblock %}

--- a/invenio_app_ils/items/search.py
+++ b/invenio_app_ils/items/search.py
@@ -41,6 +41,19 @@ class ItemSearch(RecordsSearch):
 
         return search
 
+    def search_by_barcode(self, barcode, filter_states=None, exclude_states=None):
+        """Retrieve items matching the given barcode."""
+        search = self
+
+        search = search.filter("term", barcode=barcode)
+
+        if filter_states:
+            search = search.filter("terms", status=filter_states)
+        elif exclude_states:
+            search = search.exclude("terms", status=exclude_states)
+
+        return search
+
     def search_by_internal_location_pid(
         self,
         internal_location_pid=None,

--- a/invenio_app_ils/permissions.py
+++ b/invenio_app_ils/permissions.py
@@ -132,7 +132,10 @@ def patron_owner_permission(record):
 
 
 def loan_checkout_permission(*args, **kwargs):
-    """Return permission to allow admins and librarians to checkout and patrons to self-checkout if enabled."""
+    """Loan checkout permissions checks.
+
+    Allow admins and librarians to checkout, patrons to self-checkout when enabled.
+    """
     if not has_request_context():
         # CLI or Celery task
         return backoffice_permission()
@@ -199,8 +202,10 @@ def views_permissions_factory(action):
     elif action in _is_patron_owner_permission:
         return PatronOwnerPermission
     elif action == "circulation-loan-checkout":
-        if current_app.config["ILS_SELF_CHECKOUT_ENABLED"]:
-            return authenticated_user_permission()
-        else:
-            return backoffice_permission()
+        return backoffice_permission()
+    elif (
+        action == "circulation-loan-self-checkout"
+        and current_app.config["ILS_SELF_CHECKOUT_ENABLED"]
+    ):
+        return authenticated_user_permission()
     return deny_all()

--- a/tests/data/items.json
+++ b/tests/data/items.json
@@ -1,7 +1,7 @@
 [
   {
     "pid": "itemid-1",
-    "created_by": {"type": "script", "value": "demo"},
+    "created_by": { "type": "script", "value": "demo" },
     "barcode": "123456789-1",
     "document_pid": "docid-1",
     "internal_location_pid": "ilocid-1",
@@ -12,7 +12,7 @@
   },
   {
     "pid": "itemid-2",
-    "created_by": {"type": "script", "value": "demo"},
+    "created_by": { "type": "script", "value": "demo" },
     "barcode": "123456789-2",
     "document_pid": "docid-1",
     "internal_location_pid": "ilocid-2",
@@ -23,7 +23,7 @@
   },
   {
     "pid": "itemid-3",
-    "created_by": {"type": "script", "value": "demo"},
+    "created_by": { "type": "script", "value": "demo" },
     "barcode": "123456789-3",
     "document_pid": "docid-2",
     "internal_location_pid": "ilocid-1",
@@ -34,7 +34,7 @@
   },
   {
     "pid": "itemid-4",
-    "created_by": {"type": "script", "value": "demo"},
+    "created_by": { "type": "script", "value": "demo" },
     "barcode": "123456789-4",
     "document_pid": "docid-3",
     "internal_location_pid": "ilocid-2",
@@ -45,7 +45,7 @@
   },
   {
     "pid": "itemid-5",
-    "created_by": {"type": "script", "value": "demo"},
+    "created_by": { "type": "script", "value": "demo" },
     "barcode": "123456789-5",
     "document_pid": "docid-3",
     "internal_location_pid": "ilocid-1",
@@ -56,7 +56,7 @@
   },
   {
     "pid": "itemid-6",
-    "created_by": {"type": "script", "value": "demo"},
+    "created_by": { "type": "script", "value": "demo" },
     "barcode": "123456789-6",
     "document_pid": "docid-3",
     "internal_location_pid": "ilocid-1",
@@ -67,7 +67,7 @@
   },
   {
     "pid": "itemid-7",
-    "created_by": {"type": "script", "value": "demo"},
+    "created_by": { "type": "script", "value": "demo" },
     "barcode": "123456789-7",
     "document_pid": "docid-5",
     "internal_location_pid": "ilocid-2",
@@ -78,7 +78,7 @@
   },
   {
     "pid": "itemid-8",
-    "created_by": {"type": "script", "value": "demo"},
+    "created_by": { "type": "script", "value": "demo" },
     "barcode": "123456789-8",
     "document_pid": "docid-5",
     "internal_location_pid": "ilocid-1",
@@ -89,7 +89,7 @@
   },
   {
     "pid": "itemid-9",
-    "created_by": {"type": "script", "value": "demo"},
+    "created_by": { "type": "script", "value": "demo" },
     "barcode": "123456789-9",
     "document_pid": "docid-5",
     "internal_location_pid": "ilocid-1",
@@ -100,7 +100,7 @@
   },
   {
     "pid": "itemid-10",
-    "created_by": {"type": "script", "value": "demo"},
+    "created_by": { "type": "script", "value": "demo" },
     "barcode": "123456789-10",
     "document_pid": "docid-5",
     "internal_location_pid": "ilocid-1",
@@ -111,7 +111,7 @@
   },
   {
     "pid": "itemid-50",
-    "created_by": {"type": "script", "value": "demo"},
+    "created_by": { "type": "script", "value": "demo" },
     "barcode": "123456789-50",
     "document_pid": "docid-5",
     "internal_location_pid": "ilocid-1",
@@ -123,7 +123,7 @@
   },
   {
     "pid": "itemid-51",
-    "created_by": {"type": "script", "value": "demo"},
+    "created_by": { "type": "script", "value": "demo" },
     "barcode": "123456789-51",
     "document_pid": "docid-5",
     "internal_location_pid": "ilocid-2",
@@ -135,7 +135,7 @@
   },
   {
     "pid": "itemid-52",
-    "created_by": {"type": "script", "value": "demo"},
+    "created_by": { "type": "script", "value": "demo" },
     "barcode": "123456789-52",
     "document_pid": "docid-5",
     "internal_location_pid": "ilocid-1",
@@ -147,7 +147,7 @@
   },
   {
     "pid": "itemid-53",
-    "created_by": {"type": "script", "value": "demo"},
+    "created_by": { "type": "script", "value": "demo" },
     "barcode": "123456789-53",
     "document_pid": "docid-5",
     "internal_location_pid": "ilocid-1",
@@ -159,7 +159,7 @@
   },
   {
     "pid": "itemid-54",
-    "created_by": {"type": "script", "value": "demo"},
+    "created_by": { "type": "script", "value": "demo" },
     "barcode": "123456789-54",
     "document_pid": "docid-5",
     "internal_location_pid": "ilocid-1",
@@ -171,7 +171,7 @@
   },
   {
     "pid": "itemid-55",
-    "created_by": {"type": "script", "value": "demo"},
+    "created_by": { "type": "script", "value": "demo" },
     "barcode": "123456789-55",
     "document_pid": "docid-1",
     "internal_location_pid": "ilocid-1",
@@ -182,7 +182,7 @@
   },
   {
     "pid": "itemid-56",
-    "created_by": {"type": "script", "value": "demo"},
+    "created_by": { "type": "script", "value": "demo" },
     "barcode": "123456789-54",
     "document_pid": "docid-5",
     "internal_location_pid": "ilocid-1",
@@ -193,7 +193,7 @@
   },
   {
     "pid": "itemid-57",
-    "created_by": {"type": "script", "value": "demo"},
+    "created_by": { "type": "script", "value": "demo" },
     "barcode": "123456789-55",
     "document_pid": "docid-1",
     "internal_location_pid": "ilocid-1",
@@ -204,7 +204,7 @@
   },
   {
     "pid": "itemid-MISSING",
-    "created_by": {"type": "script", "value": "demo"},
+    "created_by": { "type": "script", "value": "demo" },
     "barcode": "123456789-55",
     "document_pid": "docid-1",
     "internal_location_pid": "ilocid-1",
@@ -215,8 +215,8 @@
   },
   {
     "pid": "itemid-60",
-    "created_by": {"type": "script", "value": "demo"},
-    "barcode": "123456789-55",
+    "created_by": { "type": "script", "value": "demo" },
+    "barcode": "123456789-60",
     "document_pid": "docid-1",
     "internal_location_pid": "ilocid-1",
     "circulation_restriction": "NO_RESTRICTION",
@@ -226,8 +226,8 @@
   },
   {
     "pid": "itemid-61",
-    "created_by": {"type": "script", "value": "demo"},
-    "barcode": "123456789-55",
+    "created_by": { "type": "script", "value": "demo" },
+    "barcode": "123456789-61",
     "document_pid": "docid-1",
     "internal_location_pid": "ilocid-1",
     "circulation_restriction": "NO_RESTRICTION",
@@ -237,7 +237,7 @@
   },
   {
     "pid": "itemid-62",
-    "created_by": {"type": "script", "value": "demo"},
+    "created_by": { "type": "script", "value": "demo" },
     "barcode": "123456789-55",
     "document_pid": "docid-1",
     "internal_location_pid": "ilocid-1",
@@ -248,7 +248,7 @@
   },
   {
     "pid": "itemid-63",
-    "created_by": {"type": "script", "value": "demo"},
+    "created_by": { "type": "script", "value": "demo" },
     "barcode": "123456789-55",
     "document_pid": "docid-1",
     "internal_location_pid": "ilocid-1",
@@ -259,10 +259,32 @@
   },
   {
     "pid": "itemid-71",
-    "created_by": {"type": "script", "value": "demo"},
+    "created_by": { "type": "script", "value": "demo" },
     "barcode": "123456789-55",
-    "document_pid": "docid-17",
+    "document_pid": "docid-15",
     "internal_location_pid": "ilocid-4",
+    "circulation_restriction": "NO_RESTRICTION",
+    "medium": "NOT_SPECIFIED",
+    "status": "CAN_CIRCULATE",
+    "document": {}
+  },
+  {
+    "pid": "itemid-72",
+    "created_by": { "type": "script", "value": "demo" },
+    "barcode": "123456789-72",
+    "document_pid": "docid-16",
+    "internal_location_pid": "ilocid-1",
+    "circulation_restriction": "NO_RESTRICTION",
+    "medium": "NOT_SPECIFIED",
+    "status": "CAN_CIRCULATE",
+    "document": {}
+  },
+  {
+    "pid": "itemid-73",
+    "created_by": { "type": "script", "value": "demo" },
+    "barcode": "123456789-73",
+    "document_pid": "docid-17",
+    "internal_location_pid": "ilocid-1",
     "circulation_restriction": "NO_RESTRICTION",
     "medium": "NOT_SPECIFIED",
     "status": "CAN_CIRCULATE",


### PR DESCRIPTION
* define new ad-hoc search and checkout endpoints, to be able to have
  better control on contraints and input and output payloads
* use delivery methods to store when the checkout is a self-checkout
* closes https://github.com/CERNDocumentServer/cds-ils/issues/927
