### PR TITLE
circulation: self-checkout of MISSING items marks them as CAN_CIRCULATE

### DIFF
--- a/tests/data/items.json
+++ b/tests/data/items.json
@@ -289,5 +289,16 @@
     "medium": "NOT_SPECIFIED",
     "status": "CAN_CIRCULATE",
     "document": {}
+  },
+  {
+    "pid": "itemid-74",
+    "created_by": { "type": "script", "value": "demo" },
+    "barcode": "123456789-74",
+    "document_pid": "docid-17",
+    "internal_location_pid": "ilocid-1",
+    "circulation_restriction": "NO_RESTRICTION",
+    "medium": "NOT_SPECIFIED",
+    "status": "IN_BINDING",
+    "document": {}
   }
 ]


### PR DESCRIPTION
Closes: https://github.com/CERNDocumentServer/cds-ils/issues/978

As I changed the parameters of the function `_set_item_to_can_circulate` I checked, that there are no uses of it in https://github.com/CERNDocumentServer/cds-ils (even though it is marked as private)