### PR TITLE
permissions: add backoffice readonly action and permission

### DIFF
--- a/invenio_app_ils/acquisition/config.py
+++ b/invenio_app_ils/acquisition/config.py
@@ -10,7 +10,11 @@ from invenio_indexer.api import RecordIndexer
 from invenio_records_rest.facets import terms_filter
 
 from invenio_app_ils.config import RECORDS_REST_MAX_RESULT_WINDOW
-from invenio_app_ils.permissions import backoffice_permission, superuser_permission
+from invenio_app_ils.permissions import (
+    backoffice_permission,
+    backoffice_read_permission,
+    superuser_permission,
+)
 
 from .api import ORDER_PID_FETCHER, ORDER_PID_MINTER, ORDER_PID_TYPE, Order
 from .search import OrderSearch
@@ -44,8 +48,8 @@ RECORDS_REST_ENDPOINTS = dict(
         default_media_type="application/json",
         max_result_window=RECORDS_REST_MAX_RESULT_WINDOW,
         error_handlers=dict(),
-        read_permission_factory_imp=backoffice_permission,
-        list_permission_factory_imp=backoffice_permission,
+        read_permission_factory_imp=backoffice_read_permission,
+        list_permission_factory_imp=backoffice_read_permission,
         create_permission_factory_imp=backoffice_permission,
         update_permission_factory_imp=backoffice_permission,
         delete_permission_factory_imp=superuser_permission,

--- a/invenio_app_ils/circulation/config.py
+++ b/invenio_app_ils/circulation/config.py
@@ -41,7 +41,7 @@ from invenio_app_ils.items.api import (
 )
 from invenio_app_ils.patrons.api import patron_exists
 from invenio_app_ils.permissions import (
-    PatronOwnerPermission,
+    PatronOwnerReadPermission,
     authenticated_user_permission,
     backoffice_permission,
     loan_extend_circulation_permission,
@@ -254,7 +254,7 @@ ILS_CIRCULATION_RECORDS_REST_ENDPOINTS = dict(
         links_factory_imp="invenio_circulation.links:loan_links_factory",
         max_result_window=RECORDS_REST_MAX_RESULT_WINDOW,
         error_handlers=dict(),
-        read_permission_factory_imp=PatronOwnerPermission,
+        read_permission_factory_imp=PatronOwnerReadPermission,
         # auth via search_factory
         list_permission_factory_imp=authenticated_user_permission,
         create_permission_factory_imp=superuser_permission,

--- a/invenio_app_ils/cli.py
+++ b/invenio_app_ils/cli.py
@@ -1308,6 +1308,7 @@ def data(
     # Create roles to restrict access
     _run_command("roles create admin", verbose)
     _run_command("roles create librarian", verbose)
+    _run_command("roles create librarian-readonly", verbose)
 
     # Create users
     patron1_profile = {"full_name": "Yannic Vilma"}
@@ -1325,6 +1326,12 @@ def data(
     librarian_profile = {"full_name": "Hector Nabu"}
     _run_command(
         f"users create librarian@test.ch -a --password=123456 --profile '{json.dumps(librarian_profile)}'",
+        verbose,
+    )
+
+    readonly_profile = {"full_name": "Ro Only"}
+    _run_command(
+        f"users create readonly@test.ch -a --password=123456 --profile '{json.dumps(readonly_profile)}'",
         verbose,
     )
 
@@ -1350,6 +1357,7 @@ def data(
 
     # assign roles
     _run_command("roles add librarian@test.ch librarian", verbose)
+    _run_command("roles add readonly@test.ch librarian-readonly", verbose)
 
     # Index vocabularies
     vocabularies_dir = os.path.join(CURRENT_DIR, "vocabularies", "data")
@@ -1368,6 +1376,9 @@ def data(
     # Assign actions
     _run_command("access allow superuser-access role admin", verbose)
     _run_command("access allow ils-backoffice-access role librarian", verbose)
+    _run_command(
+        "access allow ils-backoffice-readonly-access role librarian-readonly", verbose
+    )
 
     # Create demo locations
     click.echo("Creating locations and internal locations...")

--- a/invenio_app_ils/closures/views.py
+++ b/invenio_app_ils/closures/views.py
@@ -16,7 +16,7 @@ from invenio_rest import ContentNegotiatedMethodView
 from invenio_app_ils.locations.api import LOCATION_PID_TYPE
 from invenio_app_ils.closures.serializers import closure_periods_response
 from invenio_app_ils.closures.api import get_closure_periods
-from invenio_app_ils.permissions import backoffice_permission
+from invenio_app_ils.permissions import backoffice_read_permission
 from invenio_app_ils.records.permissions import RecordPermission
 
 
@@ -53,7 +53,7 @@ class LocationClosurePeriodsResource(ContentNegotiatedMethodView):
         """Get the date ranges for which a location is closure based in the specified year"""
 
         factory = RecordPermission(record, "read")
-        if not factory.is_public() and not backoffice_permission().can():
+        if not factory.is_public() and not backoffice_read_permission().can():
             if not current_user.is_authenticated:
                 abort(401)
             abort(403)

--- a/invenio_app_ils/config.py
+++ b/invenio_app_ils/config.py
@@ -91,9 +91,10 @@ from .patrons.api import (
 )
 from .patrons.search import PatronsSearch
 from .permissions import (
-    PatronOwnerPermission,
+    PatronOwnerReadPermission,
     authenticated_user_permission,
     backoffice_permission,
+    backoffice_read_permission,
     views_permissions_factory,
 )
 from .records.permissions import record_read_permission_factory
@@ -395,8 +396,8 @@ RECORDS_REST_ENDPOINTS = dict(
         default_media_type="application/json",
         max_result_window=RECORDS_REST_MAX_RESULT_WINDOW,
         error_handlers=dict(),
-        read_permission_factory_imp=backoffice_permission,
-        list_permission_factory_imp=backoffice_permission,
+        read_permission_factory_imp=backoffice_read_permission,
+        list_permission_factory_imp=backoffice_read_permission,
         create_permission_factory_imp=backoffice_permission,
         update_permission_factory_imp=backoffice_permission,
         delete_permission_factory_imp=backoffice_permission,
@@ -427,8 +428,8 @@ RECORDS_REST_ENDPOINTS = dict(
         default_media_type="application/json",
         max_result_window=RECORDS_REST_MAX_RESULT_WINDOW,
         error_handlers=dict(),
-        read_permission_factory_imp=backoffice_permission,
-        list_permission_factory_imp=backoffice_permission,
+        read_permission_factory_imp=backoffice_read_permission,
+        list_permission_factory_imp=backoffice_read_permission,
         create_permission_factory_imp=backoffice_permission,
         update_permission_factory_imp=backoffice_permission,
         delete_permission_factory_imp=backoffice_permission,
@@ -522,8 +523,8 @@ RECORDS_REST_ENDPOINTS = dict(
         default_media_type="application/json",
         max_result_window=RECORDS_REST_MAX_RESULT_WINDOW,
         error_handlers=dict(),
-        read_permission_factory_imp=backoffice_permission,
-        list_permission_factory_imp=backoffice_permission,
+        read_permission_factory_imp=backoffice_read_permission,
+        list_permission_factory_imp=backoffice_read_permission,
         create_permission_factory_imp=backoffice_permission,
         update_permission_factory_imp=backoffice_permission,
         delete_permission_factory_imp=backoffice_permission,
@@ -552,7 +553,7 @@ RECORDS_REST_ENDPOINTS = dict(
         max_result_window=RECORDS_REST_MAX_RESULT_WINDOW,
         error_handlers=dict(),
         read_permission_factory_imp=deny_all,
-        list_permission_factory_imp=backoffice_permission,
+        list_permission_factory_imp=backoffice_read_permission,
         create_permission_factory_imp=deny_all,
         update_permission_factory_imp=deny_all,
         delete_permission_factory_imp=deny_all,
@@ -584,7 +585,7 @@ RECORDS_REST_ENDPOINTS = dict(
         default_media_type="application/json",
         max_result_window=RECORDS_REST_MAX_RESULT_WINDOW,
         error_handlers=dict(),
-        read_permission_factory_imp=PatronOwnerPermission,
+        read_permission_factory_imp=PatronOwnerReadPermission,
         # auth via search_factory
         list_permission_factory_imp=authenticated_user_permission,
         create_permission_factory_imp=authenticated_user_permission,

--- a/invenio_app_ils/ill/config.py
+++ b/invenio_app_ils/ill/config.py
@@ -11,7 +11,7 @@ from invenio_records_rest.facets import terms_filter
 
 from invenio_app_ils.config import RECORDS_REST_MAX_RESULT_WINDOW
 from invenio_app_ils.permissions import (
-    PatronOwnerPermission,
+    PatronOwnerReadPermission,
     authenticated_user_permission,
     backoffice_permission,
     superuser_permission,
@@ -76,7 +76,7 @@ RECORDS_REST_ENDPOINTS = dict(
         default_media_type="application/json",
         max_result_window=RECORDS_REST_MAX_RESULT_WINDOW,
         error_handlers=dict(),
-        read_permission_factory_imp=PatronOwnerPermission,
+        read_permission_factory_imp=PatronOwnerReadPermission,
         # auth via search_factory
         list_permission_factory_imp=authenticated_user_permission,
         create_permission_factory_imp=backoffice_permission,

--- a/invenio_app_ils/notifications/views.py
+++ b/invenio_app_ils/notifications/views.py
@@ -38,7 +38,7 @@ def get_notifications_blueprint(_):
             "size": fields.Int(validate=[validate.Range(min=1, max=100)]),
         }
     )
-    @need_permissions("send-notification-to-patron")
+    @need_permissions("get-notifications-sent-to-patron")
     def get_notifications(
         recipient_user_id=None,
         pid_type=None,
@@ -69,7 +69,7 @@ def get_notifications_blueprint(_):
         return {"hits": notifications, "total": len(notifications)}
 
     @blueprint.route("/notifications/<int:id>")
-    @need_permissions("send-notification-to-patron")
+    @need_permissions("get-notifications-sent-to-patron")
     def get_notification(id):
         try:
             notification = NotificationsLogs.query.filter_by(id=id).one()

--- a/invenio_app_ils/patrons/anonymization.py
+++ b/invenio_app_ils/patrons/anonymization.py
@@ -170,7 +170,9 @@ def anonymize_patron_data(patron_pid, force=False):
         borrowing_request["patron"] = anonymous_patron_fields
         borrowing_request["patron_pid"] = anonymous_patron_fields["pid"]
         borrowing_request.commit()
-        anonymized_records[BORROWING_REQUEST_PID_TYPE]["records"].append(borrowing_request)
+        anonymized_records[BORROWING_REQUEST_PID_TYPE]["records"].append(
+            borrowing_request
+        )
         indices += 1
 
     DocumentRequestSearch = current_app_ils.document_request_search_cls

--- a/invenio_app_ils/permissions.py
+++ b/invenio_app_ils/permissions.py
@@ -205,7 +205,7 @@ _is_backoffice_permission = [
 ]
 _is_backoffice_read_permission = [
     "stats-most-loaned",
-    "send-notification-to-patron",
+    "get-notifications-sent-to-patron",
 ]
 _is_patron_owner_permission = [
     "document-request-decline",

--- a/invenio_app_ils/providers/config.py
+++ b/invenio_app_ils/providers/config.py
@@ -10,7 +10,10 @@
 from invenio_records_rest.facets import terms_filter
 
 from invenio_app_ils.config import RECORDS_REST_MAX_RESULT_WINDOW
-from invenio_app_ils.permissions import backoffice_permission
+from invenio_app_ils.permissions import (
+    backoffice_permission,
+    backoffice_read_permission,
+)
 
 from .api import PROVIDER_PID_FETCHER, PROVIDER_PID_MINTER, PROVIDER_PID_TYPE, Provider
 from .indexer import ProviderIndexer
@@ -47,8 +50,8 @@ RECORDS_REST_ENDPOINTS = dict(
         default_media_type="application/json",
         max_result_window=RECORDS_REST_MAX_RESULT_WINDOW,
         error_handlers=dict(),
-        read_permission_factory_imp=backoffice_permission,
-        list_permission_factory_imp=backoffice_permission,
+        read_permission_factory_imp=backoffice_read_permission,
+        list_permission_factory_imp=backoffice_read_permission,
         create_permission_factory_imp=backoffice_permission,
         update_permission_factory_imp=backoffice_permission,
         delete_permission_factory_imp=backoffice_permission,

--- a/invenio_app_ils/records/permissions.py
+++ b/invenio_app_ils/records/permissions.py
@@ -12,7 +12,10 @@ from flask_principal import ActionNeed, RoleNeed, UserNeed
 from invenio_access import Permission, any_user
 from six import string_types
 
-from invenio_app_ils.permissions import backoffice_access_action
+from invenio_app_ils.permissions import (
+    backoffice_access_action,
+    backoffice_readonly_access_action,
+)
 
 create_records_action = ActionNeed("create-records")
 
@@ -68,7 +71,10 @@ class RecordPermission(Permission):
         if self.is_public():
             return [any_user]
         else:
-            return self.record_needs() + [backoffice_access_action]
+            return self.record_needs() + [
+                backoffice_readonly_access_action,
+                backoffice_access_action,
+            ]
 
     def record_explicit_restrictions(self):
         """Return the list of user ids/roles allowed for the given action."""

--- a/invenio_app_ils/records/views.py
+++ b/invenio_app_ils/records/views.py
@@ -17,7 +17,7 @@ from invenio_rest import ContentNegotiatedMethodView
 from invenio_app_ils.documents.api import DOCUMENT_PID_TYPE
 from invenio_app_ils.eitems.api import EITEM_PID_TYPE
 from invenio_app_ils.errors import StatsError
-from invenio_app_ils.permissions import backoffice_permission
+from invenio_app_ils.permissions import backoffice_read_permission
 from invenio_app_ils.records.permissions import RecordPermission
 from invenio_app_ils.series.api import SERIES_PID_TYPE
 from invenio_app_ils.signals import file_downloaded, record_viewed
@@ -62,7 +62,7 @@ class DocumentStatsResource(ContentNegotiatedMethodView):
     def post(self, pid, record, **kwargs):
         """Send a signal to count record view for the record stats."""
         factory = RecordPermission(record, "read")
-        if not factory.is_public() and not backoffice_permission().can():
+        if not factory.is_public() and not backoffice_read_permission().can():
             if not current_user.is_authenticated:
                 abort(401)
             abort(403)

--- a/invenio_app_ils/search_permissions.py
+++ b/invenio_app_ils/search_permissions.py
@@ -13,7 +13,7 @@ from flask import current_app, g, has_request_context, request
 from invenio_search.engine import dsl
 
 from invenio_app_ils.errors import SearchQueryError, UnauthorizedSearchError
-from invenio_app_ils.permissions import backoffice_permission
+from invenio_app_ils.permissions import backoffice_read_permission
 
 
 def _get_user_provides():
@@ -30,7 +30,7 @@ def _get_user_provides():
 
 def search_filter_record_permissions():
     """Filter list of results by `_access` and `restricted` fields."""
-    if not has_request_context() or backoffice_permission().allows(g.identity):
+    if not has_request_context() or backoffice_read_permission().allows(g.identity):
         return dsl.Q()
 
     # A record is public if `restricted` field False or missing
@@ -120,7 +120,7 @@ def _filter_by_patron(patron_id, search, query_string=None):
 def _filter_by_current_patron(search, query_string=None):
     """Filter search results by patron_pid."""
     # if the logged in user is not librarian or admin, validate the query
-    if has_request_context() and not backoffice_permission().allows(g.identity):
+    if has_request_context() and not backoffice_read_permission().allows(g.identity):
         return _filter_by_patron(g.identity.id, search, query_string)
     return search, query_string
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -184,6 +184,7 @@ invenio_pidstore.minters =
     vocid = invenio_app_ils.vocabularies.api:vocabulary_pid_minter
 invenio_access.actions =
     backoffice_access_action = invenio_app_ils.permissions:backoffice_access_action
+    backoffice_readonly_access_action = invenio_app_ils.permissions:backoffice_readonly_access_action
 invenio_records.jsonresolver =
     ill_brw_req = invenio_app_ils.ill.jsonresolvers.borrowing_request_document
     ill_provider = invenio_app_ils.ill.jsonresolvers.borrowing_request_provider

--- a/tests/api/acquisition/test_acq_orders_permissions.py
+++ b/tests/api/acquisition/test_acq_orders_permissions.py
@@ -80,6 +80,7 @@ def test_acq_orders_permissions(client, testdata, json_headers, users):
         res = client.delete(url, headers=json_headers)
         assert res.status_code in expected_status
 
+    # test permission for list, create, update and read
     tests = [
         ("admin", _HTTP_OK, dummy_acquisition_order),
         ("librarian", _HTTP_OK, dummy_acquisition_order),
@@ -93,6 +94,15 @@ def test_acq_orders_permissions(client, testdata, json_headers, users):
         _test_update(expected_status, data, pid, user)
         _test_read(expected_status, pid)
 
+    # Specific test for readonly account
+    user = user_login(client, "readonly", users)
+    _test_list([200])
+    _test_create([403], dummy_acquisition_order, user)
+    _test_update([403], dummy_acquisition_order, ORDER_PID, user)
+    _test_read([200], ORDER_PID)
+    _test_delete([403], ORDER_PID)
+
+    # test permission for delete
     tests = [
         ("patron1", [403]),
         ("anonymous", [401]),

--- a/tests/api/acquisition/test_acq_providers_permissions.py
+++ b/tests/api/acquisition/test_acq_providers_permissions.py
@@ -81,3 +81,11 @@ def test_acq_providers_permissions(client, testdata, json_headers, users):
         _test_update(expected_status, data, pid)
         _test_read(expected_status, pid)
         _test_delete(expected_status, pid)
+
+    # Specific test for readonly account
+    user_login(client, "readonly", users)
+    _test_list([200])
+    _test_create([403], dummy_acquisition_provider)
+    _test_update([403], dummy_acquisition_provider, PROVIDER_PID)
+    _test_read([200], PROVIDER_PID)
+    _test_delete([403], PROVIDER_PID)

--- a/tests/api/circulation/test_loan_bulk_extend.py
+++ b/tests/api/circulation/test_loan_bulk_extend.py
@@ -153,14 +153,21 @@ def test_loan_extend_permissions(
 
         _run_asserts(extended_loans, patron_1_ongoing_loans)
 
+    def test_readonly_cannot_extend_loans():
+        patron_1_ongoing_loans = _prepare_data(db, repeated_run_number=2)["loans"]
+
+        user_login(client, "readonly", users)
+
+        extended_loans, _ = bulk_extend_loans(patron_pid=1)
+
+        assert len(extended_loans) == 0
+
     def test_patron2_cannot_extend_patron1_loans():
-        _prepare_data(db, repeated_run_number=2)
+        _prepare_data(db, repeated_run_number=3)
 
         user_login(client, "patron2", users)
 
-        patron1_pid = "1"
-
-        extended_loans, _ = bulk_extend_loans(patron1_pid)
+        extended_loans, _ = bulk_extend_loans(1)
 
         assert len(extended_loans) == 0
 

--- a/tests/api/circulation/test_loan_extend.py
+++ b/tests/api/circulation/test_loan_extend.py
@@ -53,6 +53,7 @@ def test_loan_extend_permissions(client, json_headers, users, testdata, loan_par
     tests = [
         ("admin", 202),
         ("librarian", 202),
+        ("readonly", 403),
         ("patron1", 202),
         ("patron3", 403),
     ]

--- a/tests/api/circulation/test_loan_list_permissions.py
+++ b/tests/api/circulation/test_loan_list_permissions.py
@@ -88,6 +88,7 @@ def test_most_loaned_permissions(client, json_headers, users, testdata):
     tests = [
         ("admin", 200),
         ("librarian", 200),
+        ("readonly", 200),
         ("patron1", 403),
         ("anonymous", 401),
     ]

--- a/tests/api/circulation/test_notifications.py
+++ b/tests/api/circulation/test_notifications.py
@@ -83,7 +83,7 @@ def test_notification_on_overdue_permissions(client, testdata, json_headers, use
     """Test that only the backoffice can send a reminder."""
     pid = testdata["loans"][0]["pid"]
     url = url_for("invenio_app_ils_circulation.loanid_notification", pid_value=pid)
-    tests = [("patron1", 403), ("anonymous", 401)]
+    tests = [("patron1", 403), ("anonymous", 401), ("readonly", 403)]
     for username, expected_status in tests:
         user_login(client, username, users)
         res = client.post(url, headers=json_headers)

--- a/tests/api/document_requests/test_document_requests.py
+++ b/tests/api/document_requests/test_document_requests.py
@@ -46,7 +46,11 @@ def test_request_list_permissions(client, testdata, json_headers, users):
         res = client.get(url, headers=json_headers)
         assert res.status_code == 200
         data = json.loads(res.data.decode("utf-8"))
-        is_admin = "librarian" in user.email or "admin" in user.email
+        is_admin = (
+            "librarian" in user.email
+            or "readonly" in user.email
+            or "admin" in user.email
+        )
         _compare_list_data(requests_by_patron, data, user.id, is_admin)
 
 

--- a/tests/api/document_requests/test_document_requests_permissions.py
+++ b/tests/api/document_requests/test_document_requests_permissions.py
@@ -18,11 +18,13 @@ def test_get_document_request_endpoint(client, json_headers, testdata, users):
     tests = [
         ("patron1", "dreq-1", 200),
         ("librarian", "dreq-1", 200),
+        ("readonly", "dreq-1", 200),
         ("admin", "dreq-1", 200),
         ("patron2", "dreq-1", 403),
         ("anonymous", "dreq-1", 401),
         ("patron2", "dreq-2", 200),
         ("librarian", "dreq-2", 200),
+        ("readonly", "dreq-2", 200),
         ("admin", "dreq-2", 200),
         ("patron1", "dreq-2", 403),
         ("anonymous", "dreq-2", 401),
@@ -40,6 +42,7 @@ def test_document_request_add_document(client, json_headers, testdata, users):
     tests = [
         ("patron1", "dreq-1", 403),
         ("librarian", "dreq-1", 202),
+        ("readonly", "dreq-1", 403),
         ("admin", "dreq-1", 202),
         ("anonymous", "dreq-1", 401),
     ]
@@ -60,6 +63,7 @@ def test_document_request_remove_document(client, json_headers, testdata, users)
     tests = [
         ("patron1", "dreq-1", 403),
         ("librarian", "dreq-1", 202),
+        ("readonly", "dreq-1", 403),
         ("admin", "dreq-1", 202),
         ("anonymous", "dreq-1", 401),
     ]
@@ -80,6 +84,7 @@ def test_document_request_add_provider(client, json_headers, testdata, users):
     tests = [
         ("patron1", "dreq-1", 403),
         ("librarian", "dreq-1", 202),
+        ("readonly", "dreq-1", 403),
         ("admin", "dreq-1", 202),
         ("anonymous", "dreq-1", 401),
     ]
@@ -105,6 +110,7 @@ def test_document_request_remove_provider(client, json_headers, testdata, users)
     tests = [
         ("patron1", "dreq-1", 403),
         ("librarian", "dreq-1", 202),
+        ("readonly", "dreq-1", 403),
         ("admin", "dreq-1", 202),
         ("anonymous", "dreq-1", 401),
     ]
@@ -124,6 +130,7 @@ def test_document_request_accept(client, json_headers, testdata, users):
     tests = [
         ("patron1", "dreq-1", 403),
         ("librarian", "dreq-5", 202),
+        ("readonly", "dreq-6", 403),
         ("admin", "dreq-6", 202),
         ("anonymous", "dreq-1", 401),
         ("admin", "dreq-2", 400),
@@ -144,6 +151,7 @@ def test_document_request_decline(client, json_headers, testdata, users):
     tests = [
         ("patron1", "dreq-1", 202),
         ("librarian", "dreq-5", 202),
+        ("readonly", "dreq-5", 403),
         ("admin", "dreq-6", 202),
         ("anonymous", "dreq-1", 401),
         ("admin", "dreq-2", 400),

--- a/tests/api/ill/test_ill_brw_reqs_permissions.py
+++ b/tests/api/ill/test_ill_brw_reqs_permissions.py
@@ -61,6 +61,7 @@ def test_ill_brwreqs_list_permissions(client, testdata, json_headers, users):
     tests = [
         ("admin", _HTTP_OK, all_pids),
         ("librarian", _HTTP_OK, all_pids),
+        ("readonly", _HTTP_OK, all_pids),
         ("patron1", _HTTP_OK, [patron1_brwreq_pid]),
         ("patron2", _HTTP_OK, [patron2_brwreq_pid]),
     ]
@@ -131,6 +132,7 @@ def test_ill_brwreq_details_permissions(client, testdata, json_headers, users):
         ("patron2", [403], dummy_borrowing_request),
         ("patron1", [403], dummy_borrowing_request),
         ("librarian", _HTTP_OK, dummy_borrowing_request),
+        ("readonly", [403], dummy_borrowing_request),
         ("admin", _HTTP_OK, dummy_borrowing_request),
     ]
     for username, expected_status, data in tests:
@@ -144,6 +146,7 @@ def test_ill_brwreq_details_permissions(client, testdata, json_headers, users):
         ("patron2", [403]),
         ("patron1", _HTTP_OK),
         ("librarian", _HTTP_OK),
+        ("readonly", _HTTP_OK),
         ("admin", _HTTP_OK),
     ]
     for username, expected_status in tests:
@@ -156,6 +159,7 @@ def test_ill_brwreq_details_permissions(client, testdata, json_headers, users):
         ("patron2", [403]),
         ("patron1", [403]),
         ("librarian", [403]),
+        ("readonly", [403]),
         ("admin", _HTTP_OK),
     ]
     for username, expected_status in tests:

--- a/tests/api/ill/test_ill_providers_permissions.py
+++ b/tests/api/ill/test_ill_providers_permissions.py
@@ -80,3 +80,11 @@ def test_ill_providers_permissions(client, testdata, json_headers, users):
         _test_update(expected_status, data, pid)
         _test_read(expected_status, pid)
         _test_delete(expected_status, pid)
+
+    # Specific test for readonly account
+    user_login(client, "readonly", users)
+    _test_list([200])
+    _test_create([403], dummy_provider)
+    _test_update([403], dummy_provider, PROVIDER_PID)
+    _test_read([200], PROVIDER_PID)
+    _test_delete([403], PROVIDER_PID)

--- a/tests/api/ils/documents/test_document_permissions.py
+++ b/tests/api/ils/documents/test_document_permissions.py
@@ -37,11 +37,13 @@ def test_open_access_permissions(client, json_headers, testdata, users):
         ("patron1", "docid-open-access", 200, 1),
         ("patron2", "docid-open-access", 200, 1),
         ("librarian", "docid-open-access", 200, 1),
+        ("readonly", "docid-open-access", 200, 1),
         ("admin", "docid-open-access", 200, 1),
         ("anonymous", "docid-closed-access", 401, 0),
         ("patron1", "docid-closed-access", 403, 0),
         ("patron2", "docid-closed-access", 403, 0),
         ("librarian", "docid-closed-access", 200, 1),
+        ("readonly", "docid-closed-access", 200, 1),
         ("admin", "docid-closed-access", 200, 1),
     ]
     for user, pid, status_code, n_hits in test_data:
@@ -78,11 +80,13 @@ def test_access_permissions(client, json_headers, testdata, users, with_access):
         ("patron1", "docid-open-access", 403, 0),
         ("patron2", "docid-open-access", 200, 1),  # should have access
         ("librarian", "docid-open-access", 200, 1),
+        ("readonly", "docid-open-access", 200, 1),
         ("admin", "docid-open-access", 200, 1),
         ("anonymous", "docid-closed-access", 401, 0),
         ("patron1", "docid-closed-access", 403, 0),
         ("patron2", "docid-closed-access", 200, 1),  # should have access
         ("librarian", "docid-closed-access", 200, 1),
+        ("readonly", "docid-closed-access", 200, 1),
         ("admin", "docid-closed-access", 200, 1),
     ]
     for user, pid, status_code, n_hits in test_data:

--- a/tests/api/ils/eitems/test_eitems_permissions.py
+++ b/tests/api/ils/eitems/test_eitems_permissions.py
@@ -83,3 +83,11 @@ def test_eitems_permissions(client, testdata, json_headers, users):
         _test_update(expected_status, data, pid)
         _test_read(expected_status, pid)
         _test_delete(expected_status, pid)
+
+    # Specific test for readonly account
+    user_login(client, "readonly", users)
+    _test_list([200])
+    _test_create([403], dummy_eitem)
+    _test_update([403], dummy_eitem, EITEM_PID)
+    _test_read([200], EITEM_PID)
+    _test_delete([403], EITEM_PID)

--- a/tests/api/ils/eitems/test_files.py
+++ b/tests/api/ils/eitems/test_files.py
@@ -72,6 +72,7 @@ def test_create_bucket_permissions(client, json_headers, location, testdata, use
     test_data = [
         ("admin", "eitemid-1", 201),
         ("librarian", "eitemid-2", 201),
+        ("readonly", "eitemid-2", 403),
         ("patron1", "eitemid-2", 403),
     ]
     for user, pid, status_code in test_data:
@@ -92,6 +93,7 @@ def test_upload_files_permissions(client, json_headers, bucket, testdata, users)
         ("anonymous", 404),
         ("admin", 200),
         ("librarian", 200),
+        ("readonly", 404),
         ("patron1", 404),
     ]
     for user, status_code in test_data:
@@ -117,6 +119,7 @@ def test_download_files_permissions(client, json_headers, location, testdata, us
                 ("anonymous", 200),
                 ("admin", 200),
                 ("librarian", 200),
+                ("readonly", 200),
                 ("patron1", 200),
             ],
         ),
@@ -126,6 +129,7 @@ def test_download_files_permissions(client, json_headers, location, testdata, us
                 ("anonymous", 404),
                 ("admin", 200),
                 ("librarian", 200),
+                ("readonly", 200),
                 ("patron1", 200),
             ],
         ),

--- a/tests/api/ils/items/test_items_permissions.py
+++ b/tests/api/ils/items/test_items_permissions.py
@@ -77,6 +77,14 @@ def test_items_permissions(client, testdata, item_record, json_headers, users):
         _test_read(expected_status, pid)
         _test_delete(expected_status, pid)
 
+    # Specific test for readonly account
+    user_login(client, "readonly", users)
+    _test_list([200])
+    _test_create([403], dummy_item)
+    _test_update([403], dummy_item, ITEM_PID)
+    _test_read([200], ITEM_PID)
+    _test_delete([403], ITEM_PID)
+
 
 def test_item_circulation(client, json_headers, testdata, users):
     """Test item circulation filtering."""

--- a/tests/api/ils/series/test_series_permissions.py
+++ b/tests/api/ils/series/test_series_permissions.py
@@ -24,6 +24,7 @@ def test_series_read_permissions(client, testdata, json_headers, users):
     tests = [
         ("admin", _HTTP_OK),
         ("librarian", _HTTP_OK),
+        ("readonly", _HTTP_OK),
         ("patron1", _HTTP_OK),
         ("anonymous", _HTTP_OK),
     ]
@@ -56,6 +57,7 @@ def test_series_edit_permissions(client, testdata, json_headers, users):
     tests = [
         ("admin", _HTTP_OK, dummy_series),
         ("librarian", _HTTP_OK, dummy_series),
+        ("readonly", [403], dummy_series),
         ("patron1", [403], dummy_series),
         ("anonymous", [401], dummy_series),
     ]

--- a/tests/api/ils/test_closures.py
+++ b/tests/api/ils/test_closures.py
@@ -134,6 +134,14 @@ def test_location_permissions(client, testdata, json_headers, users):
         _test_read(read_statuses, pid)
         _test_delete(expected_status, pid)
 
+    # Specific test for readonly account
+    user_login(client, "readonly", users)
+    _test_list([200])
+    _test_create([403], dummy_location)
+    _test_update([403], dummy_location, _LOCATION_PID)
+    _test_read([200], _LOCATION_PID)
+    _test_delete([403], _LOCATION_PID)
+
 
 def test_location_validation(client, json_headers, users, testdata):
     def _test_update_location_closures(data, expected_code):

--- a/tests/api/ils/test_internal_locations.py
+++ b/tests/api/ils/test_internal_locations.py
@@ -94,3 +94,11 @@ def test_internal_locations_permissions(client, testdata, json_headers, users):
         _test_update(expected_status, data, pid)
         _test_read(expected_status, pid)
         _test_delete(expected_status, pid)
+
+    # Specific test for readonly account
+    user_login(client, "readonly", users)
+    _test_list([200])
+    _test_create([403], dummy_internal_location)
+    _test_update([403], dummy_internal_location, _INTERNAL_LOCATION_PID)
+    _test_read([200], _INTERNAL_LOCATION_PID)
+    _test_delete([403], _INTERNAL_LOCATION_PID)

--- a/tests/api/ils/test_notifications_permissions.py
+++ b/tests/api/ils/test_notifications_permissions.py
@@ -23,6 +23,7 @@ def test_notifications_read_permissions(client, json_headers, users):
     list_tests = [
         ("admin", _HTTP_OK),
         ("librarian", _HTTP_OK),
+        ("readonly", _HTTP_OK),
         ("patron1", _HTTP_FORBIDDEN),
         ("anonymous", _HTTP_UNAUTHORIZED),
     ]
@@ -30,6 +31,7 @@ def test_notifications_read_permissions(client, json_headers, users):
     item_tests = [
         ("admin", _HTTP_NOT_FOUND),
         ("librarian", _HTTP_NOT_FOUND),
+        ("readonly", _HTTP_NOT_FOUND),
         ("patron1", _HTTP_FORBIDDEN),
         ("anonymous", _HTTP_UNAUTHORIZED),
     ]

--- a/tests/api/ils/test_patrons.py
+++ b/tests/api/ils/test_patrons.py
@@ -45,6 +45,7 @@ def test_patrons_permissions(client, testdata, json_headers, users):
     tests = [
         ("admin", [200]),
         ("librarian", [200]),
+        ("readonly", [200]),
         ("patron1", [403]),
         ("anonymous", [401]),
     ]

--- a/tests/api/ils/test_stats.py
+++ b/tests/api/ils/test_stats.py
@@ -113,26 +113,24 @@ def test_stats_downloads_views_permissions(
     params = {}
     params["event"] = "record-view"
 
-    # permission for librarian
-    user_login(client, "librarian", users)
-    res = client.post(url_open_access, headers=json_headers, data=json.dumps(params))
-    assert res.status_code == 202
+    tests = [
+        ("librarian", 202, 202),
+        ("readonly", 202, 202),
+        ("patron1", 202, 403),
+    ]
 
-    res = client.post(url_closed_access, headers=json_headers, data=json.dumps(params))
-    assert res.status_code == 202
+    for username, expected_status_open_access, expected_status_closed_access in tests:
+        user_login(client, username, users)
+        res = client.post(
+            url_open_access, headers=json_headers, data=json.dumps(params)
+        )
+        assert res.status_code == expected_status_open_access
 
-    user_logout(client)
-
-    # permission for patron
-    user_login(client, "patron1", users)
-
-    res = client.post(url_open_access, headers=json_headers, data=json.dumps(params))
-    assert res.status_code == 202
-
-    res = client.post(url_closed_access, headers=json_headers, data=json.dumps(params))
-    assert res.status_code == 403
-
-    user_logout(client)
+        res = client.post(
+            url_closed_access, headers=json_headers, data=json.dumps(params)
+        )
+        assert res.status_code == expected_status_closed_access
+        user_logout(client)
 
     # permission for unauthenticated user
     res = client.post(url_open_access, headers=json_headers, data=json.dumps(params))

--- a/tests/api/ils/test_vocabularies.py
+++ b/tests/api/ils/test_vocabularies.py
@@ -20,6 +20,7 @@ def test_vocabularies_permissions(client, testdata, json_headers, users):
     tests = [
         ("admin", [200]),
         ("librarian", [200]),
+        ("readonly", [200]),
         ("patron1", [200]),
         ("anonymous", [200]),
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,13 +17,16 @@ from flask_webpackext.manifest import (
     JinjaManifestEntry,
     JinjaManifestLoader,
 )
-from sqlalchemy import text
 from invenio_access.models import ActionRoles
 from invenio_access.permissions import superuser_access
 from invenio_accounts.models import Role
 from invenio_app.factory import create_app as _create_app
+from sqlalchemy import text
 
-from invenio_app_ils.permissions import backoffice_access_action
+from invenio_app_ils.permissions import (
+    backoffice_access_action,
+    backoffice_readonly_access_action,
+)
 
 
 #
@@ -87,6 +90,11 @@ def users(app, db):
         librarian2 = datastore.create_user(
             email="librarian2@test.com", password="123456", active=True
         )
+        librarian_readonly = datastore.create_user(
+            email="readonly@test.com",
+            password="123456",
+            active=True,
+        )
         admin = datastore.create_user(
             email="admin@test.com", password="123456", active=True
         )
@@ -105,12 +113,22 @@ def users(app, db):
             ActionRoles(action=backoffice_access_action.value, role=librarian_role)
         )
         datastore.add_role_to_user(librarian2, librarian_role)
+        # Give role to readonly user
+        librarian_readonly_role = Role(name="librarian-readonly")
+        db.session.add(
+            ActionRoles(
+                action=backoffice_readonly_access_action.value,
+                role=librarian_readonly_role,
+            )
+        )
+        datastore.add_role_to_user(librarian_readonly, librarian_readonly_role)
     db.session.commit()
 
     return {
         "admin": admin,
         "librarian": librarian,
         "librarian2": librarian2,
+        "readonly": librarian_readonly,
         "patron1": patron1,
         "patron2": patron2,
         "patron3": patron3,


### PR DESCRIPTION
Update the permission system to allow for readonly-librarians.

* add `backoffice_readonly_access_action` and have it replace `backoffice_access_action` in read operations
   * Users with the `backoffice_readonly_access_action` can read everything that users with the`backoffice_access_action` could read before
* create `PatronOwnerReadPermission` and `backoffice_read_permission` that make use of `backoffice_readonly_access_action`
* renamed `send-notification-to-patron` into `get-notifications-sent-to-patron`, as it is only used for reading notifications


closes: https://github.com/CERNDocumentServer/cds-ils/issues/969