### PR TITLE
stats: Track all loan transitions

### DIFF
--- a/invenio_app_ils/stats/event_builders.py
+++ b/invenio_app_ils/stats/event_builders.py
@@ -113,10 +113,5 @@ def loan_transition_event_builder(
                 },
             }
         )
-    elif trigger == "extend":
-        # Extensions are aggregated by invenio-stats and no extra information is required
-        pass
-    else:
-        return None
 
     return event

--- a/invenio_app_ils/stats/processors.py
+++ b/invenio_app_ils/stats/processors.py
@@ -44,12 +44,6 @@ def add_loan_transition_unique_id(doc):
     return doc
 
 
-def filter_extend_transitions(query):
-    """Filter for extend transitions only"""
-
-    return query.filter("term", trigger="extend")
-
-
 class LoansEventsIndexer(EventsIndexer):
     """Events indexer for events related to loans.
 


### PR DESCRIPTION
In the loan transition events introduced [here](https://github.com/inveniosoftware/invenio-app-ils/pull/1256) we previously only tracked extension events. 
This PR removes this filter and starts tracking events for all loan transitions.