### PR TITLE
fix: use correct search dsl interface  for date range filters

### DIFF
--- a/invenio_app_ils/facets.py
+++ b/invenio_app_ils/facets.py
@@ -140,6 +140,6 @@ def date_range_filter(field, comparator):
             input_date = str(arrow.get(values[0]).date())
         except arrow.parser.ParserError:
             raise ValueError("Input should be a date")
-        return dsl.RangeField(**{field: {comparator: input_date}})
+        return dsl.query.Range(**{field: {comparator: input_date}})
 
     return inner

--- a/tests/api/ils/test_facets.py
+++ b/tests/api/ils/test_facets.py
@@ -78,10 +78,10 @@ def test_date_range_filter(app):
         to_filter = date_range_filter("field", "lte")
 
         try:
-            assert from_filter([input_date]) == dsl.RangeField(
+            assert from_filter([input_date]) == dsl.query.Range(
                 field={"gte": input_date}
             )
-            assert to_filter([input_date]) == dsl.RangeField(field={"lte": input_date})
+            assert to_filter([input_date]) == dsl.query.Range(field={"lte": input_date})
         except (ValueError, AssertionError):
             with pytest.raises(ValueError):
                 from_filter([input_date])


### PR DESCRIPTION
closes: https://github.com/CERNDocumentServer/cds-ils/issues/1038