### PR TITLE
update(search): add accent folding to acquisition

### DIFF
--- a/invenio_app_ils/acquisition/mappings/os-v2/acq_orders/order-v1.0.0.json
+++ b/invenio_app_ils/acquisition/mappings/os-v2/acq_orders/order-v1.0.0.json
@@ -5,6 +5,11 @@
         "email": {
           "type": "custom",
           "tokenizer": "uax_url_email"
+        },
+        "accent_folding": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "filter": ["lowercase", "asciifolding"]
         }
       }
     }
@@ -68,7 +73,8 @@
         "type": "keyword"
       },
       "notes": {
-        "type": "text"
+        "type": "text",
+        "analyzer": "accent_folding"
       },
       "order_date": {
         "type": "date"
@@ -87,14 +93,16 @@
           "document": {
             "properties": {
               "authors": {
-                "type": "text"
+                "type": "text",
+                "analyzer": "accent_folding"
               },
               "cover_metadata": {
                 "properties": {},
                 "type": "object"
               },
               "edition": {
-                "type": "text"
+                "type": "text",
+                "analyzer": "accent_folding"
               },
               "pid": {
                 "type": "keyword"
@@ -104,6 +112,7 @@
               },
               "title": {
                 "type": "text",
+                "analyzer": "accent_folding",
                 "fields": {
                   "keyword": {
                     "type": "keyword"
@@ -119,7 +128,8 @@
                     "type": "keyword"
                   },
                   "value": {
-                    "type": "text"
+                    "type": "text",
+                    "analyzer": "accent_folding"
                   }
                 },
                 "type": "object"
@@ -143,7 +153,8 @@
             "type": "keyword"
           },
           "notes": {
-            "type": "text"
+            "type": "text",
+            "analyzer": "accent_folding"
           },
           "patron": {
             "properties": {
@@ -156,6 +167,7 @@
               },
               "name": {
                 "type": "text",
+                "analyzer": "accent_folding",
                 "fields": {
                   "keyword": {
                     "type": "keyword"
@@ -258,6 +270,52 @@
           "copies_received": {
             "type": "integer"
           },
+          "document": {
+            "properties": {
+              "authors": {
+                "type": "text",
+                "analyzer": "accent_folding"
+              },
+              "cover_metadata": {
+                "type": "object"
+              },
+              "edition": {
+                "type": "text",
+                "analyzer": "accent_folding"
+              },
+              "pid": {
+                "type": "keyword"
+              },
+              "publication_year": {
+                "type": "keyword"
+              },
+              "title": {
+                "type": "text",
+                "analyzer": "accent_folding",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword"
+                  }
+                }
+              },
+              "alternative_titles": {
+                "properties": {
+                  "language": {
+                    "type": "keyword"
+                  },
+                  "type": {
+                    "type": "keyword"
+                  },
+                  "value": {
+                    "type": "text",
+                    "analyzer": "accent_folding"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
           "document_pid": {
             "type": "keyword"
           },
@@ -274,7 +332,32 @@
             "type": "keyword"
           },
           "notes": {
-            "type": "text"
+            "type": "text",
+            "analyzer": "accent_folding"
+          },
+          "patron": {
+            "properties": {
+              "email": {
+                "type": "text",
+                "analyzer": "email"
+              },
+              "id": {
+                "type": "keyword"
+              },
+              "location_pid": {
+                "type": "keyword"
+              },
+              "name": {
+                "type": "text",
+                "analyzer": "accent_folding",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword"
+                  }
+                }
+              }
+            },
+            "type": "object"
           },
           "patron_pid": {
             "type": "keyword"
@@ -342,10 +425,12 @@
                 "type": "keyword"
               }
             },
-            "type": "text"
+            "type": "text",
+            "analyzer": "accent_folding"
           },
           "notes": {
-            "type": "text"
+            "type": "text",
+            "analyzer": "accent_folding"
           },
           "phone": {
             "type": "keyword"

--- a/invenio_app_ils/document_requests/mappings/os-v2/document_requests/document_request-v1.0.0.json
+++ b/invenio_app_ils/document_requests/mappings/os-v2/document_requests/document_request-v1.0.0.json
@@ -1,4 +1,15 @@
 {
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "accent_folding": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "filter": ["lowercase", "asciifolding"]
+        }
+      }
+    }
+  },
   "mappings": {
     "date_detection": false,
     "numeric_detection": false,
@@ -13,7 +24,8 @@
         "type": "date"
       },
       "authors": {
-        "type": "text"
+        "type": "text",
+        "analyzer": "accent_folding"
       },
       "document": {
         "properties": {
@@ -97,6 +109,7 @@
           },
           "title": {
             "type": "text",
+            "analyzer": "accent_folding",
             "fields": {
               "keyword": {
                 "type": "keyword"
@@ -113,8 +126,9 @@
         "type": "keyword"
       },
       "internal_note": {
-          "type": "text"
-        },
+        "type": "text",
+        "analyzer": "accent_folding"
+      },
       "isbn": {
         "type": "keyword"
       },
@@ -134,7 +148,8 @@
         "type": "keyword"
       },
       "note": {
-        "type": "text"
+        "type": "text",
+        "analyzer": "accent_folding"
       },
       "page": {
         "type": "keyword"
@@ -179,6 +194,7 @@
       },
       "title": {
         "type": "text",
+        "analyzer": "accent_folding",
         "fields": {
           "keyword": {
             "type": "keyword"
@@ -186,10 +202,12 @@
         }
       },
       "volume": {
-        "type": "text"
+        "type": "text",
+        "analyzer": "accent_folding"
       },
       "publisher": {
-        "type": "text"
+        "type": "text",
+        "analyzer": "accent_folding"
       },
       "stats": {
         "type": "object",

--- a/invenio_app_ils/ill/mappings/os-v2/ill_borrowing_requests/borrowing_request-v1.0.0.json
+++ b/invenio_app_ils/ill/mappings/os-v2/ill_borrowing_requests/borrowing_request-v1.0.0.json
@@ -5,6 +5,11 @@
         "email": {
           "type": "custom",
           "tokenizer": "uax_url_email"
+        },
+        "accent_folding": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "filter": ["lowercase", "asciifolding"]
         }
       }
     }
@@ -23,7 +28,8 @@
         "type": "date"
       },
       "cancel_reason": {
-        "type": "text"
+        "type": "text",
+        "analyzer": "accent_folding"
       },
       "created_by": {
         "properties": {
@@ -39,7 +45,8 @@
       "document": {
         "properties": {
           "authors": {
-            "type": "text"
+            "type": "text",
+            "analyzer": "accent_folding"
           },
           "cover_metadata": {
             "properties": {},
@@ -55,7 +62,8 @@
             "type": "keyword"
           },
           "title": {
-            "type": "text"
+            "type": "text",
+            "analyzer": "accent_folding"
           },
           "alternative_titles": {
             "properties": {
@@ -66,7 +74,8 @@
                 "type": "keyword"
               },
               "value": {
-                "type": "text"
+                "type": "text",
+                "analyzer": "accent_folding"
               }
             },
             "type": "object"
@@ -94,7 +103,8 @@
                 "type": "keyword"
               }
             },
-            "type": "text"
+            "type": "text",
+            "analyzer": "accent_folding"
           },
           "pid": {
             "type": "keyword"
@@ -106,7 +116,8 @@
         "type": "keyword"
       },
       "notes": {
-        "type": "text"
+        "type": "text",
+        "analyzer": "accent_folding"
       },
       "patron": {
         "properties": {
@@ -119,6 +130,7 @@
           },
           "name": {
             "type": "text",
+            "analyzer": "accent_folding",
             "fields": {
               "keyword": {
                 "type": "keyword"
@@ -142,7 +154,8 @@
           "extension": {
             "properties": {
               "notes": {
-                "type": "text"
+                "type": "text",
+                "analyzer": "accent_folding"
               },
               "request_date": {
                 "type": "date"

--- a/invenio_app_ils/patrons/mappings/os-v2/patrons/patron-v1.0.0.json
+++ b/invenio_app_ils/patrons/mappings/os-v2/patrons/patron-v1.0.0.json
@@ -5,6 +5,11 @@
         "email": {
           "type": "custom",
           "tokenizer": "uax_url_email"
+        },
+        "accent_folding": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "filter": ["lowercase", "asciifolding"]
         }
       }
     }
@@ -25,6 +30,7 @@
       },
       "name": {
         "type": "text",
+        "analyzer": "accent_folding",
         "fields": {
           "keyword": {
             "type": "keyword"

--- a/invenio_app_ils/providers/mappings/os-v2/providers/provider-v1.0.0.json
+++ b/invenio_app_ils/providers/mappings/os-v2/providers/provider-v1.0.0.json
@@ -5,6 +5,11 @@
         "email": {
           "type": "custom",
           "tokenizer": "uax_url_email"
+        },
+        "accent_folding": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "filter": ["lowercase", "asciifolding"]
         }
       }
     }
@@ -23,7 +28,8 @@
         "type": "date"
       },
       "address": {
-        "type": "text"
+        "type": "text",
+        "analyzer": "accent_folding"
       },
       "email": {
         "type": "text",
@@ -38,10 +44,12 @@
             "type": "keyword"
           }
         },
-        "type": "text"
+        "type": "text",
+        "analyzer": "accent_folding"
       },
       "notes": {
-        "type": "text"
+        "type": "text",
+        "analyzer": "accent_folding"
       },
       "phone": {
         "type": "keyword"


### PR DESCRIPTION
Improved search in backoffice to better account for different accents on characters, added to search for the following:
- Acquisition: Purchase Orders
- Catalogue: Books/Articles
- InterLibrary Loans: Borrowing Requests
- Providers: Providers
- Patrons: Patrons

Unable to add to Library: Loans in this PR as it requires editing Invenio-Circulation module. 

* closes https://github.com/CERNDocumentServer/cds-ils/issues/1018