### PR TITLE
API loan dates update

### DIFF
--- a/invenio_app_ils/circulation/api.py
+++ b/invenio_app_ils/circulation/api.py
@@ -13,6 +13,8 @@ from flask_login import current_user
 from invenio_circulation.config import (
     CIRCULATION_STATES_LOAN_ACTIVE,
     CIRCULATION_STATES_LOAN_COMPLETED,
+    CIRCULATION_STATES_LOAN_REQUEST,
+    CIRCULATION_STATES_LOAN_CANCELLED,
 )
 from invenio_circulation.errors import CirculationException
 from invenio_circulation.pidstore.pids import CIRCULATION_LOAN_PID_TYPE
@@ -374,47 +376,45 @@ def update_dates_loan(
 ):
     """Updates the dates of a loan."""
     state = record["state"]
-    is_active = state in CIRCULATION_STATES_LOAN_ACTIVE
-    is_completed = state in CIRCULATION_STATES_LOAN_COMPLETED
+    requested = {
+        "start_date": start_date,
+        "end_date": end_date,
+        "request_start_date": request_start_date,
+        "request_expire_date": request_expire_date,
+    }
+    requested = {k: v for k, v in requested.items() if v is not None}
+
+    if state in CIRCULATION_STATES_LOAN_ACTIVE:
+        if "request_start_date" in requested or "request_expire_date" in requested:
+            raise IlsException(
+                description="Cannot modify request dates of an active loan."
+            )
+        if "start_date" in requested:
+            raise InvalidParameterError(
+                description="Cannot modify start date for active loans."
+            )
+
+    elif state in CIRCULATION_STATES_LOAN_REQUEST:
+        pass  # all fields editable while pending
+
+    elif state in CIRCULATION_STATES_LOAN_CANCELLED or state in CIRCULATION_STATES_LOAN_COMPLETED:
+        if requested:
+            raise IlsException(
+                description="Cannot modify dates of a returned or cancelled loan."
+            )
 
     data = copy(record)
+    data.update(requested)
 
-    if is_active or is_completed:
-        today = date.today().strftime("%Y-%m-%d")
-        if request_start_date or request_expire_date:
-            raise IlsException(
-                description="Cannot modify request dates of "
-                "an active or completed loan."
-            )
-        if start_date:
-            if start_date > today:
-                raise InvalidParameterError(
-                    description="Start date cannot be in "
-                    "the future for active loans."
-                )
-            data["start_date"] = start_date
-        if end_date:
-            data["end_date"] = end_date
-        if data["end_date"] < data["start_date"]:
-            raise InvalidParameterError(description="Negative date range.")
-    else:  # Pending or cancelled
-        if start_date or end_date:
-            raise IlsException(
-                description="Cannot modify dates of " "a pending or cancelled loan."
-            )
-        if request_start_date:
-            data["request_start_date"] = request_start_date
-        if request_expire_date:
-            data["request_expire_date"] = request_expire_date
-        if data["request_expire_date"] < data["request_start_date"]:
-            raise InvalidParameterError(description="Negative date range.")
+    if data.get("start_date") and data.get("end_date") and data["end_date"] < data["start_date"]:
+        raise InvalidParameterError(description="Negative date range.")
 
     record.update(data)
     record.commit()
     db.session.commit()
     current_circulation.loan_indexer().index(record)
 
-    if is_active:
+    if state in CIRCULATION_STATES_LOAN_ACTIVE:
         send_dates_updated_notification(record)
 
     return record

--- a/tests/api/circulation/test_loan_update.py
+++ b/tests/api/circulation/test_loan_update.py
@@ -8,6 +8,7 @@ from datetime import date, timedelta
 
 from flask import url_for
 from invenio_circulation.api import Loan
+from invenio_db import db
 
 from tests.helpers import user_login, user_logout
 
@@ -67,80 +68,64 @@ def test_loan_access_permission(client, json_headers, users, testdata):
 
 def test_loan_update_date(client, json_headers, users, testdata):
     """Test the edition of the dates on a loan."""
-    pid = testdata["loans"][4]["pid"]  # Item on loan
-
-    res = _post_loan_update(client, json_headers, pid)
-    assert res.status_code == 401
-
-    # Patron cannot update loan
-    user_login(client, "patron1", users)
-    res = _post_loan_update(client, json_headers, pid)
-    assert res.status_code == 403
-    user_logout(client)
-
-    # Librarian can
     user_login(client, "librarian", users)
-    old_loan = _load_result(client.get(_url_loan(pid), headers=json_headers))
-    res = _post_loan_update(client, json_headers, pid)
-    assert res.status_code == 202
-    new_loan = _load_result(res)
-    assert old_loan["updated"] < new_loan["updated"]  # Liveness check
 
-    # Update both values
-    start_date = "2020-01-01"
-    end_date = _today(+1)
+    def _get_or_set_loan(index, state):
+        """Fetch loan by testdata index and ensure it has the required DB state."""
+        pid = testdata["loans"][index]["pid"]
+        loan = Loan.get_record_by_pid(pid)
+        if loan.get("state") != state:
+            loan["state"] = state
+            loan.commit()
+            db.session.commit()
+        return pid
+
+    # 1. Test update cancelled loan dates -> fail
+    pid_cancelled = _get_or_set_loan(0, "CANCELLED")
+    res = _post_loan_update(client, json_headers, pid_cancelled, end_date=_today(+1))
+    assert res.status_code == 400
+
+    # 2. Test update returned loan dates -> fail
+    pid_returned = _get_or_set_loan(1, "ITEM_RETURNED")
+    res = _post_loan_update(client, json_headers, pid_returned, end_date=_today(+1))
+    assert res.status_code == 400
+
+    # 3. Test update request dates on active loan -> fail
+    pid_active = _get_or_set_loan(4, "ITEM_ON_LOAN")
     res = _post_loan_update(
-        client, json_headers, pid, start_date=start_date, end_date=end_date
+        client,
+        json_headers,
+        pid_active,
+        request_start_date=_today(0),
+        request_expire_date=_today(+5),
+    )
+    assert res.status_code == 400
+
+    # 4. Test update start date on active loan -> fail
+    res = _post_loan_update(client, json_headers, pid_active, start_date="2020-01-01")
+    assert res.status_code == 400
+
+    # 5. Test update end date on active loan -> pass
+    new_end_date = _today(+5)
+    res = _post_loan_update(client, json_headers, pid_active, end_date=new_end_date)
+    assert res.status_code == 202
+    new_loan_meta = _load_result(res)["metadata"]
+    assert new_loan_meta["end_date"] == new_end_date
+
+    # 6. Test update all dates on pending loan -> pass
+    pid_pending = _get_or_set_loan(3, "PENDING")
+    req_start = _today(0)
+    req_expire = _today(+5)
+    res = _post_loan_update(
+        client,
+        json_headers,
+        pid_pending,
+        request_start_date=req_start,
+        request_expire_date=req_expire,
+        start_date=_today(+5),
+        end_date=_today(+10)
     )
     assert res.status_code == 202
     new_loan_meta = _load_result(res)["metadata"]
-    assert new_loan_meta["start_date"] == start_date
-    assert new_loan_meta["end_date"] == end_date
-
-    # Start date after today
-    start_date = _today(+2)
-    end_date = _today(+3)
-    res = _post_loan_update(
-        client, json_headers, pid, start_date=start_date, end_date=end_date
-    )
-    assert res.status_code == 400
-
-    # No relative constraints on non-active loans
-    pid = testdata["loans"][3]["pid"]  # Pending
-    res = _post_loan_update(
-        client,
-        json_headers,
-        pid,
-        request_start_date=start_date,
-        request_expire_date=end_date,
-    )
-    assert res.status_code == 202
-    new_loan_meta = _load_result(res)["metadata"]
-    assert new_loan_meta["request_start_date"] == start_date
-    assert new_loan_meta["request_expire_date"] == end_date
-
-    # Negative date range
-    start_date = "2000-02-01"
-    end_date = "2000-01-01"
-    res = _post_loan_update(
-        client,
-        json_headers,
-        pid,
-        request_start_date=start_date,
-        request_expire_date=end_date,
-    )
-    assert res.status_code == 400
-
-    # Illegal combination of parameters
-    start_date = _today(-2)
-    end_date = _today(+2)
-    res = _post_loan_update(
-        client,
-        json_headers,
-        pid,
-        start_date=start_date,
-        end_date=end_date,
-        request_start_date=start_date,
-        request_expire_date=end_date,
-    )
-    assert res.status_code == 400
+    assert new_loan_meta["request_start_date"] == req_start
+    assert new_loan_meta["request_expire_date"] == req_expire


### PR DESCRIPTION
Loan dates are now only editable through the api if the loans are active or pending.

* closes https://github.com/CERNDocumentServer/cds-ils/issues/1004